### PR TITLE
Clean up ruff per-file-ignores on src/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,6 @@ target-version = "py310"
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "UP", "B"]
 
-# src/ は既存コードの長い SQL 文字列と import 順の扱いが現状と異なるため、
-# E501 と I001 のみ緩和。新規ルール適用は別 PR で実施する。
-[tool.ruff.lint.per-file-ignores]
-"src/vault_search/*.py" = ["E501", "I001", "B007"]
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -84,7 +84,7 @@ class TieredCache:
                 best_score = 0.0
                 best_entry: CacheEntry | None = None
 
-                for k, entry in self._store.items():
+                for _k, entry in self._store.items():
                     if now - entry.created_at >= self._ttl:
                         continue
                     score = self._jaccard(query_tokens, entry.tokens)
@@ -321,7 +321,10 @@ class VaultIndex:
 
     def _upsert_note(self, conn: sqlite3.Connection, note: ParsedNote, mtime: float) -> None:
         conn.execute(
-            """INSERT INTO notes (path, title, folder, tags, aliases, created_at, modified_at, file_mtime, content, frontmatter)
+            """INSERT INTO notes (
+                   path, title, folder, tags, aliases,
+                   created_at, modified_at, file_mtime, content, frontmatter
+               )
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(path) DO UPDATE SET
                    title=excluded.title, folder=excluded.folder, tags=excluded.tags,
@@ -502,7 +505,8 @@ class VaultIndex:
         conn = self._connect()
         try:
             row = conn.execute(
-                "SELECT path, title, folder, tags, aliases, created_at, modified_at, content, frontmatter FROM notes WHERE path = ?",
+                "SELECT path, title, folder, tags, aliases, created_at, modified_at, "
+                "content, frontmatter FROM notes WHERE path = ?",
                 (path,),
             ).fetchone()
             if row is None:
@@ -529,12 +533,14 @@ class VaultIndex:
                 folder = folder.replace("\\", "/")
                 escaped = folder.replace("%", "\\%").replace("_", "\\_")
                 rows = conn.execute(
-                    "SELECT path, title, folder, tags, created_at, modified_at FROM notes WHERE folder LIKE ? ESCAPE '\\' ORDER BY file_mtime DESC LIMIT ?",
+                    "SELECT path, title, folder, tags, created_at, modified_at FROM notes "
+                    "WHERE folder LIKE ? ESCAPE '\\' ORDER BY file_mtime DESC LIMIT ?",
                     (escaped + "%", limit),
                 ).fetchall()
             else:
                 rows = conn.execute(
-                    "SELECT path, title, folder, tags, created_at, modified_at FROM notes ORDER BY file_mtime DESC LIMIT ?",
+                    "SELECT path, title, folder, tags, created_at, modified_at FROM notes "
+                    "ORDER BY file_mtime DESC LIMIT ?",
                     (limit,),
                 ).fetchall()
             return [
@@ -617,8 +623,8 @@ class VaultWatcher:
     def start(self) -> bool:
         """監視開始。watchdog が利用可能なら True."""
         try:
+            from watchdog.events import FileSystemEvent, FileSystemEventHandler
             from watchdog.observers import Observer
-            from watchdog.events import FileSystemEventHandler, FileSystemEvent
 
             watcher = self
 

--- a/src/vault_search/schemas.py
+++ b/src/vault_search/schemas.py
@@ -47,7 +47,10 @@ class SearchHit(BaseModel):
     )
     snippet: str = Field(
         default="",
-        description="マッチ位置の抜粋。'>>>' / '<<<' でハイライト箇所を囲む。3文字未満クエリのフォールバック時は空文字",
+        description=(
+            "マッチ位置の抜粋。'>>>' / '<<<' でハイライト箇所を囲む。"
+            "3文字未満クエリのフォールバック時は空文字"
+        ),
     )
     score: float = Field(
         default=0.0,
@@ -69,7 +72,9 @@ class SearchResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     tier: Literal[0, 1, 2] = Field(
-        description="ヒットしたキャッシュ段。0=完全一致キャッシュ, 1=ファジーキャッシュ, 2=FTS5 検索",
+        description=(
+            "ヒットしたキャッシュ段。0=完全一致キャッシュ, 1=ファジーキャッシュ, 2=FTS5 検索"
+        ),
     )
     total: int = Field(
         description="フィルタ後の総件数 (limit/offset 適用前)",


### PR DESCRIPTION
## Summary

- Remove the temporary `[tool.ruff.lint.per-file-ignores]` entry exempting `src/vault_search/*.py` from `E501`/`I001`/`B007` (added in PR #3 as a scope-limit).
- Fix the 8 resulting lint violations in source without changing runtime behavior.
- `ruff check` now passes cleanly across the whole repo with no per-file carve-outs for `src/`.

## Violations fixed

- **E501** (line-too-long) x6: 4 long SQL string literals in `indexer.py` split into concatenated adjacent strings (SQL output unchanged); 2 long Japanese `Field(description=...)` strings in `schemas.py` wrapped with parenthesized string concatenation.
- **I001** (unsorted imports) x1: `watchdog` imports in `indexer.py` reordered by `ruff --fix --select I`.
- **B007** (unused loop var) x1: `for k, entry in ...` renamed to `for _k, entry in ...` in `indexer.py`.

## Test plan

- [x] `uv run ruff check` — clean across whole project
- [x] `uv run ruff format --check` — clean
- [x] `uv run pytest --cov=vault_search --cov-fail-under=60` — 67 passed, total coverage **81.43%** (unchanged from main)
- [x] No logic changes; only formatting/imports/loop-var rename and string splits

🤖 Generated with [Claude Code](https://claude.com/claude-code)