### PR TITLE
Fix #59: unify vault_reindex / vault_stats on dict return

### DIFF
--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -214,7 +214,7 @@ def vault_folders() -> dict[str, Any]:
 
 
 @mcp.tool()
-def vault_reindex(force: bool = False) -> ReindexStats:
+def vault_reindex(force: bool = False) -> dict[str, Any]:
     """インデックスを再構築する。
 
     通常はファイル監視が差分更新するため手動実行は不要。
@@ -224,19 +224,20 @@ def vault_reindex(force: bool = False) -> ReindexStats:
         force: True なら全件リビルド。False なら mtime ベースの差分更新。
 
     Returns:
-        ReindexStats: added / updated / deleted / skipped / errors の件数内訳。
+        dict: ReindexStats に相当する flat JSON (added / updated / deleted / skipped / errors)。
     """
-    return ReindexStats(**_get_index().build_index(force=force))
+    return ReindexStats(**_get_index().build_index(force=force)).model_dump(mode="json")
 
 
 @mcp.tool()
-def vault_stats() -> VaultStats:
+def vault_stats() -> dict[str, Any]:
     """インデックスの統計情報を返す。
 
     Returns:
-        VaultStats: ノート総数, DB サイズ (bytes / MB), Vault ルート絶対パス。
+        dict: VaultStats に相当する flat JSON
+            (total_notes / db_size_bytes / db_size_mb / vault_root)。
     """
-    return VaultStats(**_get_index().stats())
+    return VaultStats(**_get_index().stats()).model_dump(mode="json")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_wrapping.py
+++ b/tests/test_mcp_wrapping.py
@@ -200,6 +200,37 @@ def test_mcp_vault_recent_full_response_validates(vault_index: VaultIndex) -> No
     jsonschema.validate(structured, schema)
 
 
+def test_vault_reindex_structured_content_not_wrapped(vault_index: VaultIndex) -> None:
+    """vault_reindex の structured content が ``result`` でラップされない.
+
+    ReindexStats (Pydantic) 戻り型のままだと FastMCP のバージョン依存で
+    wrap_output の挙動が変わる (silent regression 導線)。dict 統一後は
+    wrap が発生しないことを保証する。
+    """
+    _content, structured = _call_tool("vault_reindex", {})
+    assert isinstance(structured, dict)
+    assert "result" not in structured, (
+        f"vault_reindex wrap drift: keys={list(structured.keys())}"
+    )
+    assert {"added", "updated", "deleted", "skipped", "errors"}.issubset(structured.keys()), (
+        f"vault_reindex missing ReindexStats keys: {structured!r}"
+    )
+    schema = _get_tool_output_schema("vault_reindex")
+    jsonschema.validate(structured, schema)
+
+
+def test_vault_stats_structured_content_not_wrapped(vault_index: VaultIndex) -> None:
+    """vault_stats の structured content が ``result`` でラップされない."""
+    _content, structured = _call_tool("vault_stats", {})
+    assert isinstance(structured, dict)
+    assert "result" not in structured, f"vault_stats wrap drift: keys={list(structured.keys())}"
+    assert {"total_notes", "db_size_bytes", "db_size_mb", "vault_root"}.issubset(
+        structured.keys()
+    ), f"vault_stats missing VaultStats keys: {structured!r}"
+    schema = _get_tool_output_schema("vault_stats")
+    jsonschema.validate(structured, schema)
+
+
 def test_mcp_outputschema_is_rich_matches_resource(vault_index: VaultIndex) -> None:
     """MCP tools/list の outputSchema が schema://tools と同じ rich schema であること.
 

--- a/tests/test_mcp_wrapping.py
+++ b/tests/test_mcp_wrapping.py
@@ -209,9 +209,7 @@ def test_vault_reindex_structured_content_not_wrapped(vault_index: VaultIndex) -
     """
     _content, structured = _call_tool("vault_reindex", {})
     assert isinstance(structured, dict)
-    assert "result" not in structured, (
-        f"vault_reindex wrap drift: keys={list(structured.keys())}"
-    )
+    assert "result" not in structured, f"vault_reindex wrap drift: keys={list(structured.keys())}"
     assert {"added", "updated", "deleted", "skipped", "errors"}.issubset(structured.keys()), (
         f"vault_reindex missing ReindexStats keys: {structured!r}"
     )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,10 +14,8 @@ from vault_search.schemas import (
     NoteDetail,
     NoteNotFoundError,
     RecentNote,
-    ReindexStats,
     SearchResponse,
     TagCount,
-    VaultStats,
 )
 
 
@@ -185,22 +183,19 @@ def test_mcp_tool_vault_folders_root_is_empty_string(vault_index: VaultIndex) ->
 def test_mcp_tool_vault_reindex(vault_index: VaultIndex) -> None:
     fn = _fn(server_mod.vault_reindex)
     res = fn(False)
-    assert isinstance(res, ReindexStats)
-    # ReindexStats は added/updated/deleted/skipped/errors を必須フィールドで持つ
-    assert res.added >= 0
-    assert res.updated >= 0
-    assert res.deleted >= 0
-    assert res.skipped >= 0
-    assert res.errors >= 0
+    assert isinstance(res, dict)
+    # added/updated/deleted/skipped/errors を必須キーで持つ flat JSON
+    for key in ("added", "updated", "deleted", "skipped", "errors"):
+        assert res[key] >= 0
 
 
 def test_mcp_tool_vault_stats(vault_index: VaultIndex) -> None:
     fn = _fn(server_mod.vault_stats)
     res = fn()
-    assert isinstance(res, VaultStats)
-    assert res.total_notes > 0
-    assert res.db_size_bytes >= 0
-    assert res.vault_root  # non-empty path string
+    assert isinstance(res, dict)
+    assert res["total_notes"] > 0
+    assert res["db_size_bytes"] >= 0
+    assert res["vault_root"]  # non-empty path string
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `vault_reindex` / `vault_stats` の戻り型を他 5 ツールに倣い `dict[str, Any]`
  (`model_dump(mode=\"json\")`) に統一。FastMCP の `wrap_output` 挙動が SDK
  バージョン依存で変わる silent regression 導線を排除。
- `tests/test_mcp_wrapping.py` に該当 2 ツールの wrap-regression テストを追加
  (structured content が `{\"result\": ...}` でラップされないこと、および
  `jsonschema.validate(structured, tool.outputSchema)` を通ること)。
- `tests/test_server.py` の `isinstance(res, ReindexStats/VaultStats)` 検査を
  dict キー検査に置換。

## Commits

- \`069c813\` Test: add wrap-regression tests for vault_reindex / vault_stats
- \`2a82bd5\` Refactor: unify vault_reindex / vault_stats on dict return

## Gates

- \`.venv/bin/pytest\` — **194 passed**
- \`.venv/bin/ruff check\` — clean
- \`.venv/bin/ruff format --check\` — clean

Closes #59