### PR TITLE
Fix #60: escape LIKE wildcards and FTS5 quotes in query

### DIFF
--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -510,7 +510,7 @@ class VaultIndex:
 
             if fts_terms:
                 # FTS5 phrase 内の `"` は `""` にダブルして構文エラーを防ぐ
-                fts_query = " AND ".join(f'"{t.replace(chr(34), chr(34) * 2)}"' for t in fts_terms)
+                fts_query = " AND ".join('"' + t.replace('"', '""') + '"' for t in fts_terms)
                 sql_parts: list[str] = [
                     "SELECT n.path, n.title, n.folder, n.tags, n.created_at, n.modified_at,",
                     "       snippet(notes_fts, 1, '>>>', '<<<', '...', 64) AS snippet,",

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -509,7 +509,8 @@ class VaultIndex:
                 return []
 
             if fts_terms:
-                fts_query = " AND ".join(f'"{t}"' for t in fts_terms)
+                # FTS5 phrase 内の `"` は `""` にダブルして構文エラーを防ぐ
+                fts_query = " AND ".join(f'"{t.replace(chr(34), chr(34) * 2)}"' for t in fts_terms)
                 sql_parts: list[str] = [
                     "SELECT n.path, n.title, n.folder, n.tags, n.created_at, n.modified_at,",
                     "       snippet(notes_fts, 1, '>>>', '<<<', '...', 64) AS snippet,",
@@ -530,10 +531,11 @@ class VaultIndex:
                 ]
                 params = []
 
-            # 短い語は LIKE で補完
+            # 短い語は LIKE で補完。'%' '_' '\' はエスケープしてワイルドカード誤ヒットを防ぐ
             for term in short_terms:
-                like_param = "%" + term + "%"
-                sql_parts.append("AND (n.title LIKE ? OR n.content LIKE ?)")
+                escaped = term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                like_param = "%" + escaped + "%"
+                sql_parts.append(r"AND (n.title LIKE ? ESCAPE '\' OR n.content LIKE ? ESCAPE '\')")
                 params.extend([like_param, like_param])
 
             # メタデータフィルタ — folder は同プレフィックス兄弟の誤マッチを避ける

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -522,3 +522,65 @@ def test_metadata_filter_invalid_value_raises(vault_index: VaultIndex) -> None:
     """制御文字を含む値は ValidationError / ValueError."""
     with pytest.raises((ValueError, ValidationError)):
         vault_index.search("obsidian", metadata_filter={"status": "a\x00b"})
+
+
+# ---------------------------------------------------------------------------
+# Issue #60: query の LIKE ワイルドカード / FTS5 特殊文字エスケープ
+# ---------------------------------------------------------------------------
+
+
+def test_search_like_underscore_not_wildcard(tmp_path: Path) -> None:
+    """<3 文字 query の LIKE fallback で '_' がワイルドカード扱いされない.
+
+    `query="_a"` (2 文字) は LIKE フォールバックに落ちる。従来は ``%_a%``
+    として LIKE に差し込まれ、'_' が任意 1 文字扱いで 'Xa' 等も誤ヒットした。
+    """
+    root = tmp_path / "vault"
+    root.mkdir()
+    # 'Xa' を含むが '_a' は含まないノート (LIKE '_' ワイルドカード経由で誤ヒットする危険)
+    (root / "bystander.md").write_text("# bystander\nthe Xa token here.\n", encoding="utf-8")
+    # '_a' を含むノート (正例)
+    (root / "target.md").write_text("# target\nliteral _a marker.\n", encoding="utf-8")
+    idx = VaultIndex(root, db_path=tmp_path / "q.db")
+    idx.build_index()
+
+    res = idx.search("_a")
+    paths = {r["path"] for r in res["results"]}
+    assert "target.md" in paths
+    assert "bystander.md" not in paths, (
+        f"LIKE underscore leaked as wildcard: matched bystander.md (paths={paths})"
+    )
+
+
+def test_search_like_percent_not_wildcard(tmp_path: Path) -> None:
+    """<3 文字 query の LIKE fallback で '%' がワイルドカード扱いされない."""
+    root = tmp_path / "vault"
+    root.mkdir()
+    (root / "bystander.md").write_text("# bystander\nthe aZZZZb token.\n", encoding="utf-8")
+    (root / "target.md").write_text("# target\nliteral %a marker.\n", encoding="utf-8")
+    idx = VaultIndex(root, db_path=tmp_path / "q.db")
+    idx.build_index()
+
+    res = idx.search("%a")
+    paths = {r["path"] for r in res["results"]}
+    assert "target.md" in paths
+    assert "bystander.md" not in paths, (
+        f"LIKE percent leaked as wildcard: matched bystander.md (paths={paths})"
+    )
+
+
+def test_search_query_with_double_quote_does_not_raise(vault_index: VaultIndex) -> None:
+    """query 内に `"` を含んでも sqlite3.OperationalError を漏らさない.
+
+    従来は FTS5 path で ``f'"{t}"'`` に term をそのまま差し込むため、term 内の
+    ``"`` が FTS5 構文エラーを引き起こし sqlite3.OperationalError が上流に漏れた。
+    エスケープされていれば例外を上げず、通常の結果を返す (0 件でも可)。
+    """
+    import sqlite3
+
+    try:
+        res = vault_index.search('abc"def')
+    except sqlite3.OperationalError as exc:  # pragma: no cover — regression
+        raise AssertionError(f"FTS5 quote leaked as syntax error: {exc}") from exc
+    # 結果の形式が壊れていないこと
+    assert isinstance(res["results"], list)


### PR DESCRIPTION
## Summary

- `_fts5_search` の短語 LIKE fallback: `%`, `_`, `\\` を `\\` でエスケープし
  `ESCAPE '\\'` 句を併用。query=\"_a\" / \"%a\" が任意 1 文字/任意文字列として
  誤ヒットする問題を修正。
- FTS5 phrase 内の `\"` を `\"\"` にダブルしてサニタイズ。従来は term に `\"` が
  含まれると `sqlite3.OperationalError: unterminated string` が上流に漏れていた。

## Commits

- \`a3425f0\` Red: detect LIKE wildcard leak and FTS5 quote syntax error in query
- \`aa7fc74\` Green: escape LIKE wildcards and FTS5 quotes in query
- \`d178222\` Refactor: inline chr(34) as literal '\"' in FTS5 escape

## Gates

- \`.venv/bin/pytest\` — **195 passed**
- \`.venv/bin/ruff check\` — clean
- \`.venv/bin/ruff format --check\` — clean

Closes #60