### PR TITLE
Fix #51/#61: validate limit/offset and add vault_recent offset

### DIFF
--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -610,8 +610,13 @@ class VaultIndex:
         finally:
             conn.close()
 
-    def recent_notes(self, limit: int = 20, folder: str | None = None) -> list[dict[str, Any]]:
-        """最近更新されたノート."""
+    def recent_notes(
+        self,
+        limit: int = 20,
+        offset: int = 0,
+        folder: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """最近更新されたノート. offset スキップ後 limit 件を返す."""
         conn = self._connect()
         try:
             if folder:
@@ -619,14 +624,14 @@ class VaultIndex:
                 rows = conn.execute(
                     "SELECT path, title, folder, tags, created_at, modified_at FROM notes "
                     f"WHERE {clause} "
-                    "ORDER BY file_mtime DESC LIMIT ?",
-                    (*folder_params, limit),
+                    "ORDER BY file_mtime DESC LIMIT ? OFFSET ?",
+                    (*folder_params, limit, offset),
                 ).fetchall()
             else:
                 rows = conn.execute(
                     "SELECT path, title, folder, tags, created_at, modified_at FROM notes "
-                    "ORDER BY file_mtime DESC LIMIT ?",
-                    (limit,),
+                    "ORDER BY file_mtime DESC LIMIT ? OFFSET ?",
+                    (limit, offset),
                 ).fetchall()
             return [
                 {

--- a/src/vault_search/schemas.py
+++ b/src/vault_search/schemas.py
@@ -225,6 +225,26 @@ _FOLDER_INPUT_SCHEMA: dict[str, Any] = {
 }
 
 
+# Shared pagination input schemas. ``minimum`` / ``maximum`` are the single
+# source of truth the agent sees via ``schema://tools``; the runtime guard in
+# ``validation.validate_pagination`` enforces the same bounds server-side.
+_LIMIT_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "integer",
+    "minimum": 1,
+    "maximum": 500,
+    "default": 20,
+    "description": "最大返却件数 (1-500)。上限超過は ValidationError。",
+}
+
+
+_OFFSET_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "integer",
+    "minimum": 0,
+    "default": 0,
+    "description": "ページング用の開始位置 (>=0)。負値は ValidationError。",
+}
+
+
 _FIELDS_INPUT_SCHEMA: dict[str, Any] = {
     "type": ["array", "null"],
     "items": {"type": "string"},
@@ -245,8 +265,8 @@ _TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
                 "query": {"type": "string", "description": "検索クエリ"},
                 "tags": {"type": ["array", "null"], "items": {"type": "string"}},
                 "folder": _FOLDER_INPUT_SCHEMA,
-                "limit": {"type": "integer", "default": 20},
-                "offset": {"type": "integer", "default": 0},
+                "limit": _LIMIT_INPUT_SCHEMA,
+                "offset": _OFFSET_INPUT_SCHEMA,
                 "fields": _FIELDS_INPUT_SCHEMA,
                 "metadata_filter": {
                     "type": ["object", "null"],
@@ -307,7 +327,8 @@ _TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
         input_schema={
             "type": "object",
             "properties": {
-                "limit": {"type": "integer", "default": 20},
+                "limit": _LIMIT_INPUT_SCHEMA,
+                "offset": _OFFSET_INPUT_SCHEMA,
                 "folder": _FOLDER_INPUT_SCHEMA,
                 "fields": _FIELDS_INPUT_SCHEMA,
             },

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -39,6 +39,7 @@ from .schemas import (
     build_schema_payload,
     validate_fields,
 )
+from .validation import validate_pagination
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +107,7 @@ def vault_search(
         ツール戻り型を Union にすると FastMCP が structured content を
         ``{"result": ...}`` でラップしてしまうため、dict 統一で回避している。
     """
+    validate_pagination(limit, offset)
     fields_set = validate_fields(SearchHit, fields)
     raw = _get_index().search(
         query,
@@ -157,13 +159,17 @@ def vault_get_note(path: str, fields: list[str] | None = None) -> dict[str, Any]
 @mcp.tool()
 def vault_recent(
     limit: int = 20,
+    offset: int = 0,
     folder: str | None = None,
     fields: list[str] | None = None,
 ) -> dict[str, Any]:
     """最近更新されたノート一覧を取得する。
 
     Args:
-        limit: 最大返却件数（デフォルト 20）
+        limit: 最大返却件数（デフォルト 20, 1-500）。
+        offset: ページング用の開始位置（デフォルト 0, >=0）。vault_search と同じ
+                意味論で、最近更新順 (file_mtime DESC) の先頭から offset 件を
+                スキップして limit 件返す。
         folder: フォルダプレフィックスで絞り込み（例: "Research"）
         fields: 返却フィールドを限定 (例: ["path"])。None で全フィールド。
                 空リストまたは不正名は ValidationError。context window 節約用。
@@ -175,8 +181,9 @@ def vault_recent(
         を参照。list 戻り型だと FastMCP が ``{"result": [...]}`` にラップ
         してしまうため dict envelope に統一している。
     """
+    validate_pagination(limit, offset)
     fields_set = validate_fields(RecentNote, fields)
-    rows = _get_index().recent_notes(limit=limit, folder=folder)
+    rows = _get_index().recent_notes(limit=limit, offset=offset, folder=folder)
     if fields_set is None:
         notes = [RecentNote(**note).model_dump(mode="json") for note in rows]
     else:

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -27,8 +27,14 @@ import re
 __all__ = [
     "ValidationError",
     "validate_identifier",
+    "validate_pagination",
     "validate_value",
 ]
+
+# Hard ceiling on paginated result size. Anchored to the FTS5 cache ceiling
+# (`_MAX_RESULTS` in indexer) so that requested limit never exceeds what the
+# backend actually returns — avoiding silent truncation from the agent's POV.
+_LIMIT_MAX = 500
 
 
 # Allowed character class for identifiers (field names, frontmatter keys).
@@ -107,6 +113,26 @@ def validate_identifier(
             f"{kind} contains disallowed characters (allowed: {_IDENTIFIER_ALLOWED_DESC}): {name!r}"
         )
     return name
+
+
+def validate_pagination(limit: int, offset: int = 0) -> None:
+    """Validate paginated-query bounds, raising on out-of-range values.
+
+    ``limit`` must be a positive integer (zero-result queries waste a round
+    trip and usually indicate a hallucinated bound). ``offset`` must be
+    non-negative. ``limit`` is capped at :data:`_LIMIT_MAX` to keep requests
+    aligned with the internal FTS5 cache ceiling.
+    """
+    if not isinstance(limit, int) or isinstance(limit, bool):
+        raise ValidationError(f"limit must be an integer, got {type(limit).__name__}")
+    if not isinstance(offset, int) or isinstance(offset, bool):
+        raise ValidationError(f"offset must be an integer, got {type(offset).__name__}")
+    if limit < 1:
+        raise ValidationError(f"limit must be >= 1 (got {limit})")
+    if limit > _LIMIT_MAX:
+        raise ValidationError(f"limit must be <= {_LIMIT_MAX} (got {limit})")
+    if offset < 0:
+        raise ValidationError(f"offset must be >= 0 (got {offset})")
 
 
 def validate_value(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -447,3 +447,65 @@ def test_vault_search_fields_none_mcp_returns_all(vault_index: VaultIndex) -> No
         "created_at",
         "modified_at",
     }
+
+
+# ---------------------------------------------------------------------------
+# Issue #51 R3.4 + Issue #61 R9.1: limit / offset 境界値 validation と
+# vault_recent の offset ページング対応
+# ---------------------------------------------------------------------------
+
+
+def test_vault_search_rejects_negative_limit(vault_index: VaultIndex) -> None:
+    """limit が負値のとき ValidationError (ValueError 派生) を投げる."""
+    from vault_search.validation import ValidationError
+
+    fn = _fn(server_mod.vault_search)
+    with pytest.raises((ValueError, ValidationError)):
+        fn("obsidian", limit=-1)
+
+
+def test_vault_search_rejects_zero_limit(vault_index: VaultIndex) -> None:
+    """limit=0 は ValidationError。意味のない呼び出しを早期に弾く."""
+    from vault_search.validation import ValidationError
+
+    fn = _fn(server_mod.vault_search)
+    with pytest.raises((ValueError, ValidationError)):
+        fn("obsidian", limit=0)
+
+
+def test_vault_search_rejects_negative_offset(vault_index: VaultIndex) -> None:
+    """offset が負値のとき ValidationError."""
+    from vault_search.validation import ValidationError
+
+    fn = _fn(server_mod.vault_search)
+    with pytest.raises((ValueError, ValidationError)):
+        fn("obsidian", offset=-1)
+
+
+def test_vault_search_rejects_limit_above_max(vault_index: VaultIndex) -> None:
+    """limit > 500 は ValidationError。内部 _MAX_RESULTS 超えは silent truncate を避ける."""
+    from vault_search.validation import ValidationError
+
+    fn = _fn(server_mod.vault_search)
+    with pytest.raises((ValueError, ValidationError)):
+        fn("obsidian", limit=501)
+
+
+def test_vault_recent_accepts_offset_parameter(vault_index: VaultIndex) -> None:
+    """vault_recent に offset 引数があり、指定分スキップする."""
+    fn = _fn(server_mod.vault_recent)
+    full = fn(5, None)
+    assert len(full["notes"]) >= 2, "テスト前提: 最低 2 件の recent notes が必要"
+    skipped = fn(limit=5, offset=1)
+    assert skipped["notes"] == full["notes"][1:], (
+        "offset=1 は先頭 1 件を省いた結果を返すこと"
+    )
+
+
+def test_vault_recent_rejects_negative_offset(vault_index: VaultIndex) -> None:
+    """vault_recent も offset 負値を拒否."""
+    from vault_search.validation import ValidationError
+
+    fn = _fn(server_mod.vault_recent)
+    with pytest.raises((ValueError, ValidationError)):
+        fn(limit=5, offset=-1)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -139,7 +139,7 @@ def test_mcp_tool_vault_get_note_found(vault_index: VaultIndex) -> None:
 
 def test_mcp_tool_vault_recent(vault_index: VaultIndex) -> None:
     fn = _fn(server_mod.vault_recent)
-    res = fn(5, None)
+    res = fn(limit=5)
     # envelope dict `{"notes": [...]}` を返す (FastMCP の list wrap 回避のため)
     assert isinstance(res, dict)
     assert set(res.keys()) == {"notes"}
@@ -290,7 +290,7 @@ def test_vault_get_note_fields_nonexistent_raises(vault_index: VaultIndex) -> No
 def test_vault_recent_fields_subset(vault_index: VaultIndex) -> None:
     """fields=["path"] で subset 返却 (envelope dict `{"notes": [...]}`)."""
     fn = _fn(server_mod.vault_recent)
-    res = fn(5, None, ["path"])
+    res = fn(limit=5, fields=["path"])
     assert isinstance(res, dict)
     assert set(res.keys()) == {"notes"}
     notes = res["notes"]
@@ -306,14 +306,14 @@ def test_vault_recent_fields_empty_raises(vault_index: VaultIndex) -> None:
     """fields=[] は ValueError."""
     fn = _fn(server_mod.vault_recent)
     with pytest.raises(ValueError):
-        fn(5, None, [])
+        fn(limit=5, fields=[])
 
 
 def test_vault_recent_fields_nonexistent_raises(vault_index: VaultIndex) -> None:
     """fields=["nope"] は ValueError."""
     fn = _fn(server_mod.vault_recent)
     with pytest.raises(ValueError):
-        fn(5, None, ["nope"])
+        fn(limit=5, fields=["nope"])
 
 
 # ---------------------------------------------------------------------------
@@ -494,12 +494,10 @@ def test_vault_search_rejects_limit_above_max(vault_index: VaultIndex) -> None:
 def test_vault_recent_accepts_offset_parameter(vault_index: VaultIndex) -> None:
     """vault_recent に offset 引数があり、指定分スキップする."""
     fn = _fn(server_mod.vault_recent)
-    full = fn(5, None)
+    full = fn(limit=5)
     assert len(full["notes"]) >= 2, "テスト前提: 最低 2 件の recent notes が必要"
     skipped = fn(limit=5, offset=1)
-    assert skipped["notes"] == full["notes"][1:], (
-        "offset=1 は先頭 1 件を省いた結果を返すこと"
-    )
+    assert skipped["notes"] == full["notes"][1:], "offset=1 は先頭 1 件を省いた結果を返すこと"
 
 
 def test_vault_recent_rejects_negative_offset(vault_index: VaultIndex) -> None:


### PR DESCRIPTION
## Summary

- \`validate_pagination(limit, offset)\` を validation.py に新設。
  limit は 1-500、offset は >=0 の範囲外を ValidationError で拒否。
  従来 \`limit=-1\` は \`total=1, results=[]\` のような奇妙な挙動で silent fail
  していた。
- schemas.py に共有 \`_LIMIT_INPUT_SCHEMA\` / \`_OFFSET_INPUT_SCHEMA\` を追加し、
  \`schema://tools\` の input_schema に minimum/maximum を公開。エージェントが
  hallucinated 値を投げても schema 層で拒否される。
- server.vault_recent に \`offset\` 引数を追加 (indexer.recent_notes も同様)。
  vault_search と同じページング意味論に統一 (#61)。
- 既存の vault_recent 呼び出しを positional から keyword へ更新して
  signature 変更の互換性を保つ。

## Commits

- \`67be778\` Red: detect missing pagination validation and vault_recent offset
- \`3fd49ad\` Green: validate limit/offset bounds and add vault_recent offset

## Gates

- \`.venv/bin/pytest\` — **203 passed**
- \`.venv/bin/ruff check\` — clean
- \`.venv/bin/ruff format --check\` — clean

Closes #51
Closes #61