### PR TITLE
Fix #55: unify vault_get_note shape and drop vault_search dead $defs

### DIFF
--- a/src/vault_search/schemas.py
+++ b/src/vault_search/schemas.py
@@ -397,7 +397,8 @@ def _build_tool_entry(spec: _ToolSchemaSpec, tool_name: str) -> dict[str, Any]:
         # 外枠 (tier/total/results) の required は維持、
         # results.items (SearchHit) のみ subset 許容。
         # Pydantic 生成スキーマは results.items を {"$ref": "#/$defs/SearchHit"}
-        # と参照するため、$defs から SearchHit 本体を取り出して anyOf を組む。
+        # と参照するため、$defs から SearchHit 本体を取り出して inline anyOf に
+        # 差し替え、もはや参照先がない $defs は削除する (dead schema を残さない)。
         output_schema = dict(item_schema)
         hit_schema = output_schema["$defs"]["SearchHit"]
         results_prop = dict(output_schema["properties"]["results"])
@@ -406,9 +407,13 @@ def _build_tool_entry(spec: _ToolSchemaSpec, tool_name: str) -> dict[str, Any]:
             **output_schema["properties"],
             "results": results_prop,
         }
+        output_schema.pop("$defs", None)
     elif supports_fields:
-        # vault_get_note: NoteDetail 全体が subset 可能
-        output_schema = _allow_subset(item_schema)
+        # vault_get_note: トップレベルは {"type": "object", "properties": ...} の
+        # 対称 shape を維持し、required のみ外して subset を許容する。
+        # fields=None 時の全フィールド存在は server 側 Pydantic が保証するため、
+        # schema 層で required を緩めても runtime 契約は崩れない。
+        output_schema = _without_required(item_schema)
     else:
         output_schema = item_schema
     return {

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -106,21 +106,39 @@ def _call_vault_search_via_mcp(arguments: dict[str, Any]) -> dict[str, Any]:
 def _search_hit_properties(output_schema: dict[str, Any]) -> dict[str, Any]:
     """vault_search の output_schema から SearchHit 相当の properties を取り出す.
 
-    SearchResponse の JSON Schema は ``$defs`` に SearchHit を抱えるので、
-    path + title + snippet を全て持つ properties dict を探して返す。
+    path + title + snippet を全て持つ properties dict を、$defs / items /
+    anyOf ブランチのいずれに格納されていても再帰探索して返す。
     """
-    defs = output_schema.get("$defs") or output_schema.get("definitions") or {}
-    for d in defs.values():
-        if isinstance(d, dict) and "properties" in d:
-            props = d["properties"]
-            if {"path", "title", "snippet"}.issubset(props.keys()):
-                return props
-    # fallback: ルート直下 (list wrap 等) に SearchHit があった場合
-    if "properties" in output_schema:
-        props = output_schema["properties"]
-        if {"path", "title", "snippet"}.issubset(props.keys()):
+    target_keys = {"path", "title", "snippet"}
+
+    def _walk(node: Any) -> dict[str, Any]:
+        if not isinstance(node, dict):
+            return {}
+        props = node.get("properties")
+        if isinstance(props, dict) and target_keys.issubset(props.keys()):
             return props
-    return {}
+        for key in ("anyOf", "oneOf", "allOf"):
+            branches = node.get(key)
+            if isinstance(branches, list):
+                for branch in branches:
+                    hit = _walk(branch)
+                    if hit:
+                        return hit
+        for key in ("items", "$defs", "definitions", "properties"):
+            sub = node.get(key)
+            if isinstance(sub, dict):
+                if key in {"$defs", "definitions", "properties"}:
+                    for v in sub.values():
+                        hit = _walk(v)
+                        if hit:
+                            return hit
+                else:
+                    hit = _walk(sub)
+                    if hit:
+                        return hit
+        return {}
+
+    return _walk(output_schema)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_schema_resource.py
+++ b/tests/test_schema_resource.py
@@ -282,3 +282,52 @@ def test_metadata_filter_grammar_structured_in_schema(vault_index: VaultIndex) -
     ops = [set(v.get("properties", {}).keys()) for v in obj_variants]
     assert {"in"} in ops, f"'in' operator variant missing: {ops!r}"
     assert {"ne"} in ops, f"'ne' operator variant missing: {ops!r}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #55 R6.1: vault_get_note output_schema の shape 非対称と
+# vault_search の dead $defs/SearchHit を検出する。
+# ---------------------------------------------------------------------------
+
+
+def test_vault_get_note_output_schema_has_top_level_object_shape(vault_index: VaultIndex) -> None:
+    """vault_get_note の output_schema がトップレベルで ``type: object`` を持つこと.
+
+    他 6 ツールは ``{"type": "object", "properties": {...}}`` 形だが、
+    vault_get_note は Round 5 で ``_allow_subset`` 適用によりトップレベルが
+    ``{"anyOf": [...]}`` の包含構造になり、``type`` フィールドを失った。
+    エージェントの schema クローラが ``type == 'object'`` 前提だと silent skip。
+    """
+    from vault_search.schemas import build_schema_payload
+
+    payload = build_schema_payload(vault_index)
+    schema = payload["tools"]["vault_get_note"]["output_schema"]
+
+    assert schema.get("type") == "object", (
+        f"vault_get_note top-level must be object shape; got keys={list(schema.keys())}"
+    )
+    assert "properties" in schema, (
+        f"vault_get_note top-level must expose properties; got keys={list(schema.keys())}"
+    )
+    # path は NoteDetail の必須キー相当で、subset 許容でも properties には残るべき
+    assert "path" in schema["properties"], (
+        f"vault_get_note properties must include 'path'; got {list(schema['properties'].keys())}"
+    )
+
+
+def test_vault_search_output_schema_has_no_dead_defs(vault_index: VaultIndex) -> None:
+    """vault_search の output_schema に参照ゼロの ``$defs`` が残存しないこと.
+
+    Round 5 で ``results.items`` は完全インライン anyOf に差し替わったが、
+    元の ``$defs/SearchHit`` が残ったままで、そちらは subset 未許容の
+    古い required を保持しており schema クローラに古い情報を返す dead schema。
+    """
+    from vault_search.schemas import build_schema_payload
+
+    payload = build_schema_payload(vault_index)
+    schema = payload["tools"]["vault_search"]["output_schema"]
+
+    assert "$defs" not in schema, (
+        f"vault_search output_schema still contains dead $defs: "
+        f"{list(schema.get('$defs', {}).keys())}"
+    )

--- a/tests/test_schema_resource.py
+++ b/tests/test_schema_resource.py
@@ -41,49 +41,48 @@ SEARCH_HIT_FIELDS = {
 
 
 def _get_properties(schema: dict[str, Any]) -> dict[str, Any]:
-    """JSON Schema の 'properties' を取得。ネストされた $defs / items.$ref も探索。
+    """JSON Schema から SearchHit 相当 (path + title + snippet) の properties を探索.
 
-    Pydantic v2 の model_json_schema は、ルートに properties を持つ場合と
-    `$ref` + `$defs` でネストされたモデルを間接参照する場合がある。
-    SearchHit 相当 (path + title + snippet を併せ持つ) を優先して返す。
+    Pydantic 生成 schema は (a) ルート直下の properties、(b) $defs 参照、
+    (c) 配列項目へのインライン or $ref、(d) anyOf ブランチ内の properties、
+    のいずれにも該当モデルが現れ得る。いずれのパターンでも SearchHit 相当を
+    優先的に返す。
     """
-    defs = schema.get("$defs") or schema.get("definitions") or {}
+    target_keys = {"path", "title", "snippet"}
 
-    # 候補 1: $defs の中に SearchHit 相当があれば優先的に返す
-    for d in defs.values():
-        if isinstance(d, dict) and "properties" in d:
-            props = d["properties"]
-            if {"path", "title", "snippet"}.issubset(props.keys()):
+    def _walk(node: Any) -> dict[str, Any] | None:
+        if isinstance(node, dict):
+            props = node.get("properties")
+            if isinstance(props, dict) and target_keys.issubset(props.keys()):
                 return props
+            # anyOf / oneOf / items / $defs / definitions / properties を探索
+            for key in ("anyOf", "oneOf", "allOf"):
+                branches = node.get(key)
+                if isinstance(branches, list):
+                    for branch in branches:
+                        hit = _walk(branch)
+                        if hit is not None:
+                            return hit
+            for key in ("items", "$defs", "definitions", "properties"):
+                sub = node.get(key)
+                if isinstance(sub, dict):
+                    # properties dict の value 群 / defs dict の value 群を探索
+                    if key in {"$defs", "definitions", "properties"}:
+                        for v in sub.values():
+                            hit = _walk(v)
+                            if hit is not None:
+                                return hit
+                    else:
+                        hit = _walk(sub)
+                        if hit is not None:
+                            return hit
+        return None
 
-    # 候補 2: ルート直下に properties があり、SearchHit 相当ならそれを返す
-    if "properties" in schema:
-        props = schema["properties"]
-        if {"path", "title", "snippet"}.issubset(props.keys()):
-            return props
-
-    # 候補 3: ルートの properties に含まれる配列フィールドの items.$ref を辿る
-    root_props = schema.get("properties") or {}
-    for prop in root_props.values():
-        if not isinstance(prop, dict):
-            continue
-        ref = None
-        if isinstance(prop.get("items"), dict):
-            ref = prop["items"].get("$ref")
-        ref = ref or prop.get("$ref")
-        if isinstance(ref, str) and ref.startswith("#/$defs/"):
-            name = ref.split("/")[-1]
-            target = defs.get(name)
-            if isinstance(target, dict) and "properties" in target:
-                return target["properties"]
-
-    # fallback: 最初に見つかった properties 持ちの defs
-    for d in defs.values():
-        if isinstance(d, dict) and "properties" in d:
-            return d["properties"]
-
-    # 最終 fallback: ルート properties
-    if "properties" in schema:
+    hit = _walk(schema)
+    if hit is not None:
+        return hit
+    # 最終 fallback: ルート properties があればそれを返す
+    if isinstance(schema.get("properties"), dict):
         return schema["properties"]
     return {}
 


### PR DESCRIPTION
## Summary

- \`vault_get_note\` の output_schema トップレベルを \`{"type": "object",
  "properties": ...}\` 形に戻し、他 6 ツールと shape 対称に。fields subset 許容は
  \`required\` を外すだけで実現。fields=None 時の全フィールド存在は server 側
  Pydantic で保証される。
- \`vault_search\` の output_schema: \`results.items\` を inline anyOf に差し替えた
  後、参照ゼロの \`\$defs/SearchHit\` を削除。古い required を抱える dead schema を
  schema crawler に返さないようにする。
- テストヘルパ (\`_get_properties\` / \`_search_hit_properties\`) は \`\$defs\` 限定から
  \`anyOf\` / \`items\` を再帰探索する形に拡張。schema 表現の変化に壊れにくくなる。

## Commits

- \`e295b50\` Red: detect vault_get_note shape asymmetry and vault_search dead \$defs
- \`9786a44\` Green: unify vault_get_note shape and drop vault_search dead \$defs

## Gates

- \`.venv/bin/pytest\` — **199 passed**
- \`.venv/bin/ruff check\` — clean
- \`.venv/bin/ruff format --check\` — clean

Closes #55