### PR TITLE
Docs: capture session lessons on subagent limits and prefix selection

### DIFF
--- a/.claude/rules/tdd-workflow.md
+++ b/.claude/rules/tdd-workflow.md
@@ -35,6 +35,35 @@ delegate する。各フェーズで以下を明示:
 - **完了条件**を明記 (テスト通過数、commit 形式、lint クリーン)
 - **中断条件**を記述 (これに該当したら停止して報告)
 
+### 既知の落とし穴: background subagent は Edit/Write が拒否される
+
+`Agent(..., run_in_background=true, mode="acceptEdits")` および
+`mode="bypassPermissions"` は現行 harness で honor されず、background subagent
+では Edit/Write が恒久的に拒否される (2026-04 時点)。`/permissions` で allow に
+追加しても subagent プロセスには伝搬しない。
+
+**回避策**:
+
+- **親セッションが worktree を切替えて逐次実装** (今回の Phase 2 で採用)
+- foreground agent (`run_in_background=false`) を使う — 親のインタラクティブ
+  permission を経由できる
+- Bash ヒアドキュメントで新規ファイル作成する (Edit 不要な初期追加のみ)
+
+サブエージェントが settings.json に Edit/Write を自己追加しようとした事例が
+1 件観測されている (prompt 指示なしの self-elevation) — コミット前に必ず
+`git diff .claude/settings.json` で確認する。
+
+## Red/Green vs Test/Refactor — prefix 選択ガイド
+
+commit prefix は「振る舞いが変わるか」で選ぶ:
+
+- 既存バグで実挙動が仕様と合わず、修正で挙動が変わる → **Red → Green**
+- 既存挙動は正しいが SDK upgrade 等で silent regression しうる保険を pin する
+  → **Test:** (テスト追加のみ、失敗しない) + **Refactor:** (実装整理)
+- 例: `vault_reindex` の Pydantic 戻り → dict 戻り統一 (#59, PR #63) は
+  現状 FastMCP が flat に再シリアライズするため Red にならない。regression
+  guard を `Test:` で先行追加し、dict 化は `Refactor:` で別コミット。
+
 ## 並行作業時の調停
 
 複数サブエージェントが src/ / tests/ を同時に触る場合:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,12 @@ uv run pytest
 uv run ruff check --fix && uv run ruff format
 ```
 
+worktree 内では sandbox が `~/.cache/uv` への書き込みを禁じるため `uv run` が
+`Read-only file system` で失敗する場合がある。その場合は一度
+`uv sync --all-extras` で worktree に `.venv/` を作ってから
+`.venv/bin/pytest` / `.venv/bin/ruff` を直接呼ぶのが安定する (settings.json
+の allow list にも登録済み)。
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Summary

2026-04-14 のセッション (PR #63-#66 作業) で得た知見を rules / CLAUDE.md に反映。

- \`.claude/rules/tdd-workflow.md\`:
  - background subagent で Edit/Write が拒否される harness 制限と回避策を追記
    (\`mode: acceptEdits\` / \`bypassPermissions\` が honor されない既知の挙動)
  - 既存挙動を pin する regression guard は Red/Green ではなく Test:/Refactor:
    とする prefix 選択ガイドを追加 (#59 PR #63 のケースを例示)
- \`CLAUDE.md\`:
  - worktree 内の uv cache sandbox 制限と \`.venv/bin/pytest\` 直呼び運用を追記

## Test plan

- [x] ドキュメントのみ (コード変更なし)
- [x] \`.venv/bin/ruff check\` — 影響なし