### PR TITLE
Fix: reject malformed-dot identifiers in validate_identifier (#14)

### DIFF
--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -39,7 +39,8 @@ class MetadataCondition:
     key:
         frontmatter のトップレベルまたはドット区切りキー。
         :func:`vault_search.validation.validate_identifier` で検証済み
-        （``A-Za-z0-9_-.`` のみ）。SQL へ直接埋め込んでも安全。
+        (各セグメントは ``A-Za-z0-9_-`` のみ、空セグメント不可)。
+        SQL へ直接埋め込んでも安全。
     op:
         比較演算子。``eq`` / ``ne`` / ``in`` のいずれか。
         配列型 frontmatter に対しては ``eq`` / ``in`` が「含む」判定、
@@ -169,9 +170,10 @@ def build_sql_fragment(cond: MetadataCondition) -> tuple[str, list[Any]]:
     参照するテーブル別名は ``n`` (``notes`` テーブル) を仮定する。
 
     ``cond.key`` は :func:`validate_identifier` 済みの安全な識別子
-    (``A-Za-z0-9_-.``) なので、JSON パス ``$.<key>`` に直接埋め込んでも
-    SQL インジェクションは発生しない。比較対象値は常にプレースホルダ
-    (``?``) で渡すため、ユーザ値が SQL 断片に混ざることはない。
+    (各セグメント ``A-Za-z0-9_-``、空セグメント不可) なので、JSON パス
+    ``$.<key>`` に直接埋め込んでも SQL インジェクションも malformed JSON
+    path も発生しない。比較対象値は常にプレースホルダ (``?``) で渡すため、
+    ユーザ値が SQL 断片に混ざることはない。
 
     Semantics
     ---------

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -99,8 +99,10 @@ def validate_identifier(
     ------
     ValidationError
         If ``name`` is empty, exceeds ``max_len``, contains control
-        characters (including NUL), attempts path traversal, or contains
-        any character outside ``A-Z a-z 0-9 _ - .``.
+        characters (including NUL), attempts path traversal, has an
+        empty dot-separated segment (leading/trailing/consecutive ``.``),
+        or contains any character outside ``A-Z a-z 0-9 _ -`` within a
+        segment.
     """
     if not isinstance(name, str):
         raise ValidationError(f"{kind} must be a string, got {type(name).__name__}")

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -112,6 +112,16 @@ def validate_identifier(
         raise ValidationError(
             f"{kind} contains control characters; allowed: {_IDENTIFIER_ALLOWED_DESC}"
         )
+    # Detect empty dot-separated segments before the generic char-class check
+    # so the error message names the structural cause (issue #14). Otherwise
+    # `a..b` would be reported as "disallowed characters" even though every
+    # character is in the allowed set, misleading agents into stripping
+    # characters instead of fixing the dot structure.
+    if ".." in name or name.startswith(".") or name.endswith("."):
+        raise ValidationError(
+            f"{kind} has empty dot-separated segment; "
+            f"use 'a.b' for nested keys (no leading/trailing/consecutive '.'): {name!r}"
+        )
     if not _IDENTIFIER_RE.match(name):
         raise ValidationError(
             f"{kind} contains disallowed characters (allowed: {_IDENTIFIER_ALLOWED_DESC}): {name!r}"

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -38,11 +38,15 @@ _LIMIT_MAX = 500
 
 
 # Allowed character class for identifiers (field names, frontmatter keys).
-# Obsidian nested-key convention requires ``.``; ``_`` and ``-`` are common
-# in user-authored frontmatter.
-_IDENTIFIER_PATTERN = r"[A-Za-z0-9_\-.]+"
+# Obsidian nested-key convention requires ``.`` as a segment separator; ``_``
+# and ``-`` are common in user-authored frontmatter. Dots are only permitted
+# between non-empty segments: leading, trailing, and consecutive dots would
+# expand to malformed SQLite JSON paths (e.g. ``$..foo``) and surface as
+# ``sqlite3.OperationalError`` instead of ``ValidationError`` (issue #14).
+_IDENTIFIER_SEGMENT = r"[A-Za-z0-9_\-]+"
+_IDENTIFIER_PATTERN = rf"{_IDENTIFIER_SEGMENT}(?:\.{_IDENTIFIER_SEGMENT})*"
 _IDENTIFIER_RE = re.compile(rf"^{_IDENTIFIER_PATTERN}$")
-_IDENTIFIER_ALLOWED_DESC = "A-Z a-z 0-9 _ - ."
+_IDENTIFIER_ALLOWED_DESC = "A-Z a-z 0-9 _ -, with . as separator between non-empty segments"
 
 # C0 controls (0x00-0x1F) + DEL (0x7F). Tabs/newlines are rejected because
 # they are never meaningful inside a field name or filter value and are a

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -123,15 +123,14 @@ def test_validate_identifier_rejects_disallowed_symbols(name: str) -> None:
 @pytest.mark.parametrize(
     "name",
     [
-        "..",
-        ".a",
-        "a.",
-        "a..",
-        "a..b",
-        ".",
-        ".a.b",
-        "a.b.",
-        "a...b",
+        # Equivalence classes for empty dot-separated segments.
+        # Keep representatives only; broader coverage (`a..`, `.a.b`,
+        # `a.b.`, `a...b`) is subsumed by these classes.
+        "..",  # dot-only (consecutive)
+        ".",  # dot-only (single)
+        ".a",  # leading empty
+        "a.",  # trailing empty
+        "a..b",  # consecutive empty between non-empty segments
     ],
 )
 def test_validate_identifier_rejects_malformed_dots(name: str) -> None:
@@ -143,6 +142,26 @@ def test_validate_identifier_rejects_malformed_dots(name: str) -> None:
     """
     with pytest.raises(ValidationError):
         validate_identifier(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "a.b",  # minimum 2-segment
+        "a.b.c",  # 3-segment
+        "x_y.z-w",  # segments mixing _ and -
+        "_._",  # single-char segments
+        "1.2.3",  # numeric segments
+    ],
+)
+def test_validate_identifier_accepts_dotted_paths(name: str) -> None:
+    """Positive boundary for the segment-joined-by-dot grammar.
+
+    Pairs with ``test_validate_identifier_rejects_malformed_dots`` so a
+    future regex change that accidentally bans valid dotted identifiers
+    is caught (silent regression on Obsidian nested-key support).
+    """
+    assert validate_identifier(name) == name
 
 
 def test_validate_identifier_rejects_non_ascii_japanese() -> None:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -120,6 +120,31 @@ def test_validate_identifier_rejects_disallowed_symbols(name: str) -> None:
         validate_identifier(name)
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        "..",
+        ".a",
+        "a.",
+        "a..",
+        "a..b",
+        ".",
+        ".a.b",
+        "a.b.",
+        "a...b",
+    ],
+)
+def test_validate_identifier_rejects_malformed_dots(name: str) -> None:
+    """Empty dot-segments expand to malformed SQLite JSON paths.
+
+    See issue #14: inputs like ``a..b`` used to pass ``_IDENTIFIER_RE``
+    and produced ``$.a..b`` which SQLite rejects with
+    ``sqlite3.OperationalError``. They must raise ``ValidationError``.
+    """
+    with pytest.raises(ValidationError):
+        validate_identifier(name)
+
+
 def test_validate_identifier_rejects_non_ascii_japanese() -> None:
     with pytest.raises(ValidationError):
         validate_identifier("重要")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -187,9 +187,7 @@ def test_validate_identifier_malformed_dot_message_names_the_cause(name: str) ->
         validate_identifier(name)
     msg = str(exc.value)
     # The new message must name the empty-segment cause...
-    assert "empty" in msg and "segment" in msg, (
-        f"message should reference empty/segment: {msg!r}"
-    )
+    assert "empty" in msg and "segment" in msg, f"message should reference empty/segment: {msg!r}"
     # ...and must NOT mislead with the char-level "disallowed characters"
     # phrasing, which tricks agents into character-stripping retries.
     assert "disallowed characters" not in msg, (

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -164,6 +164,39 @@ def test_validate_identifier_accepts_dotted_paths(name: str) -> None:
     assert validate_identifier(name) == name
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        "..",
+        ".",
+        ".a",
+        "a.",
+        "a..b",
+    ],
+)
+def test_validate_identifier_malformed_dot_message_names_the_cause(name: str) -> None:
+    """Empty-segment errors must name the structural cause, not the chars.
+
+    The previous message said ``"contains disallowed characters"`` for
+    inputs like ``a..b`` even though every individual character is in
+    the allowed set. That misleads agents into stripping characters
+    instead of fixing the dot structure. The message must instead
+    reference "empty"/"segment" so the agent can self-correct.
+    """
+    with pytest.raises(ValidationError) as exc:
+        validate_identifier(name)
+    msg = str(exc.value)
+    # The new message must name the empty-segment cause...
+    assert "empty" in msg and "segment" in msg, (
+        f"message should reference empty/segment: {msg!r}"
+    )
+    # ...and must NOT mislead with the char-level "disallowed characters"
+    # phrasing, which tricks agents into character-stripping retries.
+    assert "disallowed characters" not in msg, (
+        f"message should not blame chars for a structural error: {msg!r}"
+    )
+
+
 def test_validate_identifier_rejects_non_ascii_japanese() -> None:
     with pytest.raises(ValidationError):
         validate_identifier("重要")


### PR DESCRIPTION
## Summary

- `_IDENTIFIER_PATTERN` をセグメント区切り形式 (`segment(?:\.segment)*`) に変更し、先頭/末尾/連続ドットを拒否
- 空ドットセグメント入力 (`..`, `.a`, `a.`, `a..b` 等) が `sqlite3.OperationalError` として上流に漏れていた問題を修正し、`ValidationError` で即 reject する設計意図に復元
- `tests/test_validation.py` に 9 ケースの negative test を追加

Closes #14.

## Test plan

- [x] `uv run pytest` 全 214 テスト green
- [x] `uv run ruff check --fix && uv run ruff format` クリーン
- [x] Red phase でターゲットテストが期待通り失敗することを確認
- [x] Green phase で既存テストに regression がないことを確認
