### PR TITLE
Fix: folder filter silent-miss on trailing slash (#34)

### DIFF
--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -183,10 +183,15 @@ def _folder_filter_clause(folder: str, column: str = "folder") -> tuple[str, lis
     `folder == 'Projects'` が `'Projects Hermes'` 等の兄弟を拾わないよう、
     LIKE パターンを ``escaped + '/%'`` にし、等号比較と OR で結合する。
 
+    入力は `\\` → `/` 置換、末尾 `/` の rstrip で正規化する。正規化後が空
+    文字列 (e.g. `folder='/'`, `'//'`, `'\\'`) の場合は「フィルタなし」を意味
+    する no-op 断片 ``"1=1"`` と空 params を返す。
+
     Parameters
     ----------
     folder:
-        フォルダパス (非空文字列想定; 空文字はフィルタを掛けないので呼び出し側で分岐)。
+        フォルダパス。空文字はフィルタを掛けないので呼び出し側で分岐する前提
+        だが、正規化後に空となるケース (スラッシュのみ) は本関数が no-op で吸収する。
     column:
         SQL 上のカラム名。`n.folder` のようにテーブルエイリアス付きも可。
 
@@ -195,8 +200,14 @@ def _folder_filter_clause(folder: str, column: str = "folder") -> tuple[str, lis
     tuple[str, list[Any]]
         ``(clause, params)``。clause は前置詞を含まない WHERE 断片
         ``"(col = ? OR col LIKE ? ESCAPE '\\')"``、params は ``[folder, folder/%]``。
+        正規化後空の場合は ``("1=1", [])``。
     """
     folder = folder.replace("\\", "/").rstrip("/")
+    if not folder:
+        # `/`, `//`, `\\` 等のスラッシュのみ入力は rstrip 後 '' となり、
+        # 呼び出し側の `if folder:` ガードは素通りしている。ここで no-op
+        # 断片 ("1=1") を返し「フィルタなし」扱いに揃える (Issue #34)。
+        return "1=1", []
     escaped = folder.replace("%", "\\%").replace("_", "\\_")
     clause = f"({column} = ? OR {column} LIKE ? ESCAPE '\\')"
     return clause, [folder, escaped + "/%"]

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -196,7 +196,7 @@ def _folder_filter_clause(folder: str, column: str = "folder") -> tuple[str, lis
         ``(clause, params)``。clause は前置詞を含まない WHERE 断片
         ``"(col = ? OR col LIKE ? ESCAPE '\\')"``、params は ``[folder, folder/%]``。
     """
-    folder = folder.replace("\\", "/")
+    folder = folder.replace("\\", "/").rstrip("/")
     escaped = folder.replace("%", "\\%").replace("_", "\\_")
     clause = f"({column} = ? OR {column} LIKE ? ESCAPE '\\')"
     return clause, [folder, escaped + "/%"]

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -329,6 +329,27 @@ def test_folder_filter_matches_folder_itself(vault_index: VaultIndex, tmp_vault:
     assert "Projects/日本語ノート.md" in paths
 
 
+def test_folder_filter_trailing_slash_normalized(
+    vault_index: VaultIndex, tmp_vault: Path
+) -> None:
+    """末尾スラッシュ付き folder ('Projects/') も 'Projects' と同等に扱う.
+
+    Issue #34: `folder='Projects/'` で silent 0 件になる regression の防止。
+    """
+    # search: 'Projects/' と 'Projects' は同じ結果を返す
+    res_bare = vault_index.search("日本語", folder="Projects")
+    res_slash = vault_index.search("日本語", folder="Projects/")
+    paths_bare = {r["path"] for r in res_bare["results"]}
+    paths_slash = {r["path"] for r in res_slash["results"]}
+    assert paths_slash == paths_bare
+    assert "Projects/日本語ノート.md" in paths_slash
+
+    # recent_notes も同様
+    notes_bare = vault_index.recent_notes(limit=50, folder="Projects")
+    notes_slash = vault_index.recent_notes(limit=50, folder="Projects/")
+    assert {n["path"] for n in notes_slash} == {n["path"] for n in notes_bare}
+
+
 def test_stats_shape(vault_index: VaultIndex) -> None:
     s = vault_index.stats()
     assert set(s.keys()) >= {

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -329,9 +329,7 @@ def test_folder_filter_matches_folder_itself(vault_index: VaultIndex, tmp_vault:
     assert "Projects/日本語ノート.md" in paths
 
 
-def test_folder_filter_trailing_slash_normalized(
-    vault_index: VaultIndex, tmp_vault: Path
-) -> None:
+def test_folder_filter_trailing_slash_normalized(vault_index: VaultIndex, tmp_vault: Path) -> None:
     """末尾スラッシュ付き folder ('Projects/') も 'Projects' と同等に扱う.
 
     Issue #34: `folder='Projects/'` で silent 0 件になる regression の防止。

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -333,19 +333,58 @@ def test_folder_filter_trailing_slash_normalized(vault_index: VaultIndex, tmp_va
     """末尾スラッシュ付き folder ('Projects/') も 'Projects' と同等に扱う.
 
     Issue #34: `folder='Projects/'` で silent 0 件になる regression の防止。
-    """
-    # search: 'Projects/' と 'Projects' は同じ結果を返す
-    res_bare = vault_index.search("日本語", folder="Projects")
-    res_slash = vault_index.search("日本語", folder="Projects/")
-    paths_bare = {r["path"] for r in res_bare["results"]}
-    paths_slash = {r["path"] for r in res_slash["results"]}
-    assert paths_slash == paths_bare
-    assert "Projects/日本語ノート.md" in paths_slash
 
-    # recent_notes も同様
+    境界値:
+    - 単一 `/` 付与 (`Projects/`)
+    - 複数 `/` 付与 (`Projects//`)
+    - バックスラッシュ混在 (`Projects\\`)
+    - バックスラッシュ + `/` (`Projects\\/`)
+    すべて `Projects` と同一結果となる contract を pin する。
+    """
+    # 基準 (非空) — vacuous pass 防止のため最初に非空を assert
+    res_bare = vault_index.search("日本語", folder="Projects")
+    paths_bare = {r["path"] for r in res_bare["results"]}
+    assert "Projects/日本語ノート.md" in paths_bare, "fixture regression: bare folder search returned empty"
+
     notes_bare = vault_index.recent_notes(limit=50, folder="Projects")
-    notes_slash = vault_index.recent_notes(limit=50, folder="Projects/")
-    assert {n["path"] for n in notes_slash} == {n["path"] for n in notes_bare}
+    bare_note_paths = {n["path"] for n in notes_bare}
+    assert "Projects/日本語ノート.md" in bare_note_paths, (
+        "fixture regression: bare folder recent_notes returned empty"
+    )
+
+    # 正規化バリアント: いずれも Projects と同一結果
+    for variant in ("Projects/", "Projects//", "Projects\\", "Projects\\/"):
+        res_v = vault_index.search("日本語", folder=variant)
+        paths_v = {r["path"] for r in res_v["results"]}
+        assert paths_v == paths_bare, f"search mismatch for folder={variant!r}: {paths_v}"
+
+        notes_v = vault_index.recent_notes(limit=50, folder=variant)
+        assert {n["path"] for n in notes_v} == bare_note_paths, (
+            f"recent_notes mismatch for folder={variant!r}"
+        )
+
+
+def test_folder_filter_slash_only_is_noop(vault_index: VaultIndex, tmp_vault: Path) -> None:
+    """`folder='/'` は rstrip 後に空文字化するので **フィルタなし** 扱いとなる.
+
+    Issue #34 推奨: 「空文字列ケース (`/` だけが渡ったケース) も rstrip 後に
+    空なら no-op で扱う」。rstrip 後 '' で `folder = '' OR folder LIKE '/%'`
+    を発行し root 直下のみ silent にマッチする旧挙動への regression 防止。
+    """
+    # 基準 (folder 未指定 = フィルタなし) との一致を確認
+    res_all = vault_index.search("obsidian")
+    paths_all = {r["path"] for r in res_all["results"]}
+    assert len(paths_all) > 0, "fixture regression: no results for 'obsidian'"
+
+    res_slash = vault_index.search("obsidian", folder="/")
+    assert {r["path"] for r in res_slash["results"]} == paths_all
+
+    # 複数スラッシュも同等 (`//`, `\\`, `\\/` 等)
+    for variant in ("//", "\\", "\\/", "/\\"):
+        res_v = vault_index.search("obsidian", folder=variant)
+        assert {r["path"] for r in res_v["results"]} == paths_all, (
+            f"folder={variant!r} expected to be no-op (== no filter), got differing set"
+        )
 
 
 def test_stats_shape(vault_index: VaultIndex) -> None:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -344,7 +344,9 @@ def test_folder_filter_trailing_slash_normalized(vault_index: VaultIndex, tmp_va
     # 基準 (非空) — vacuous pass 防止のため最初に非空を assert
     res_bare = vault_index.search("日本語", folder="Projects")
     paths_bare = {r["path"] for r in res_bare["results"]}
-    assert "Projects/日本語ノート.md" in paths_bare, "fixture regression: bare folder search returned empty"
+    assert "Projects/日本語ノート.md" in paths_bare, (
+        "fixture regression: bare folder search returned empty"
+    )
 
     notes_bare = vault_index.recent_notes(limit=50, folder="Projects")
     bare_note_paths = {n["path"] for n in notes_bare}


### PR DESCRIPTION
## Summary
- `folder="Projects/"` のような末尾スラッシュ付き入力が silent に 0 件を返す regression を修正 (closes #34)
- `_folder_filter_clause` の先頭で `folder.rstrip("/")` による正規化を追加
- `folder="Projects/"` と `folder="Projects"` が同じ結果を返すことを保証する regression guard テストを追加

## Test plan
- [x] `test_folder_filter_trailing_slash_normalized` (search / recent_notes の両方で slash 付き/なしが一致)
- [x] 既存の `test_folder_prefix_does_not_match_sibling` / `test_folder_filter_matches_folder_itself` が維持
- [x] 206 tests passed / ruff check & format clean

https://claude.ai/code/session_01VUrwHPzHcGGvvXkvTNXpLb