### PR TITLE
Add MCP tool annotations for all tools (#22)

### DIFF
--- a/src/vault_search/schemas.py
+++ b/src/vault_search/schemas.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
+from mcp.types import ToolAnnotations
 from pydantic import BaseModel, ConfigDict, Field
 
 from .validation import ValidationError, validate_identifier
@@ -211,6 +212,7 @@ class _ToolSchemaSpec:
     input_schema: dict[str, Any]
     output_model: type[BaseModel]
     envelope_key: str | None = None
+    annotations: ToolAnnotations | None = None
 
 
 _FOLDER_INPUT_SCHEMA: dict[str, Any] = {
@@ -254,6 +256,28 @@ _FIELDS_INPUT_SCHEMA: dict[str, Any] = {
         "指定キーのみを持つ plain dict (list ツールは要素単位で subset) となる。"
     ),
 }
+
+
+# MCP ``ToolAnnotations`` (issue #22 + review round 1, reviewers A-D).
+#
+# Spec-strict mapping:
+#   - 読み取り系は ``readOnlyHint=True`` のみ宣言。MCP spec は
+#     ``destructiveHint`` / ``idempotentHint`` を "meaningful only when
+#     readOnlyHint == false" と定義しているため、読み取り系では None のまま残す
+#     (FastMCP は None フィールドを wire 上で落とす)。
+#   - ``vault_reindex`` は唯一の writer。``destructiveHint=False`` は意図的:
+#     MCP spec の "destructive" は user-facing データの不可逆損失を指し、
+#     派生キャッシュ (``.vault-search.db``) の再構築は vault 本体 (``.md``) を
+#     touch しないため該当しない。auto-approve UX で誤警告が出ないよう False。
+#     ``idempotentHint=True`` は同一入力で同一状態に収束することを示す。
+#   - ``openWorldHint=False`` は全ツールでローカル vault のみを扱うため統一。
+_READ_ONLY_ANNOTATIONS = ToolAnnotations(readOnlyHint=True, openWorldHint=False)
+_REINDEX_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
 
 
 _TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
@@ -309,6 +333,7 @@ _TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
             "required": ["query"],
         },
         output_model=SearchResponse,
+        annotations=_READ_ONLY_ANNOTATIONS,
     ),
     "vault_get_note": _ToolSchemaSpec(
         description="指定パスのノート全文とメタデータを取得する。",
@@ -321,6 +346,7 @@ _TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
             "required": ["path"],
         },
         output_model=NoteDetail,
+        annotations=_READ_ONLY_ANNOTATIONS,
     ),
     "vault_recent": _ToolSchemaSpec(
         description="最近更新されたノート一覧を取得する。",
@@ -335,18 +361,21 @@ _TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
         },
         output_model=RecentNote,
         envelope_key="notes",
+        annotations=_READ_ONLY_ANNOTATIONS,
     ),
     "vault_tags": _ToolSchemaSpec(
         description="全タグとその使用回数を返す。",
         input_schema={"type": "object", "properties": {}},
         output_model=TagCount,
         envelope_key="tags",
+        annotations=_READ_ONLY_ANNOTATIONS,
     ),
     "vault_folders": _ToolSchemaSpec(
         description="フォルダ構造とノート数を返す。",
         input_schema={"type": "object", "properties": {}},
         output_model=FolderCount,
         envelope_key="folders",
+        annotations=_READ_ONLY_ANNOTATIONS,
     ),
     "vault_reindex": _ToolSchemaSpec(
         description="インデックスを再構築する。",
@@ -355,11 +384,13 @@ _TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
             "properties": {"force": {"type": "boolean", "default": False}},
         },
         output_model=ReindexStats,
+        annotations=_REINDEX_ANNOTATIONS,
     ),
     "vault_stats": _ToolSchemaSpec(
         description="インデックスの統計情報を返す。",
         input_schema={"type": "object", "properties": {}},
         output_model=VaultStats,
+        annotations=_READ_ONLY_ANNOTATIONS,
     ),
 }
 
@@ -437,11 +468,16 @@ def _build_tool_entry(spec: _ToolSchemaSpec, tool_name: str) -> dict[str, Any]:
         output_schema = _without_required(item_schema)
     else:
         output_schema = item_schema
-    return {
+    entry: dict[str, Any] = {
         "description": spec.description,
         "input_schema": spec.input_schema,
         "output_schema": output_schema,
     }
+    if spec.annotations is not None:
+        # exclude_none=True で未宣言 hint を落とし、MCP tools/list の wire 形と揃える
+        # (spec で意味を持たない readOnly+destructive/idempotent の組を残さない)。
+        entry["annotations"] = spec.annotations.model_dump(mode="json", exclude_none=True)
+    return entry
 
 
 # ``_TOOL_ENTRIES`` は各ツールの (description / input_schema / output_schema) を

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from .indexer import VaultIndex, VaultWatcher
 from .schemas import (
@@ -68,8 +69,26 @@ def _subset_row(data: dict[str, Any], fields_set: frozenset[str]) -> dict[str, A
 
 mcp = FastMCP("vault-search")
 
+# MCP tool annotations (issue #22).
+# 全ツールはローカル vault のみを扱うため openWorldHint=False。
+# 読み取り系は readOnly=True / destructive=False / idempotent=True。
+# vault_reindex は DB を書き換える唯一の writer (destructive=True) だが、同一入力
+# に対し同一結果に収束するため idempotent=True。
+_READ_ONLY_HINTS = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+_REINDEX_HINTS = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=True,
+    openWorldHint=False,
+)
 
-@mcp.tool()
+
+@mcp.tool(annotations=_READ_ONLY_HINTS)
 def vault_search(
     query: str,
     tags: list[str] | None = None,
@@ -130,7 +149,7 @@ def vault_search(
     }
 
 
-@mcp.tool()
+@mcp.tool(annotations=_READ_ONLY_HINTS)
 def vault_get_note(path: str, fields: list[str] | None = None) -> dict[str, Any]:
     """指定パスのノート全文とメタデータを取得する。
 
@@ -156,7 +175,7 @@ def vault_get_note(path: str, fields: list[str] | None = None) -> dict[str, Any]
     return _subset_row(result, fields_set)
 
 
-@mcp.tool()
+@mcp.tool(annotations=_READ_ONLY_HINTS)
 def vault_recent(
     limit: int = 20,
     offset: int = 0,
@@ -191,7 +210,7 @@ def vault_recent(
     return {"notes": notes}
 
 
-@mcp.tool()
+@mcp.tool(annotations=_READ_ONLY_HINTS)
 def vault_tags() -> dict[str, Any]:
     """全タグとその使用回数を返す。出現回数降順。
 
@@ -203,7 +222,7 @@ def vault_tags() -> dict[str, Any]:
     return {"tags": [TagCount(**row).model_dump(mode="json") for row in _get_index().list_tags()]}
 
 
-@mcp.tool()
+@mcp.tool(annotations=_READ_ONLY_HINTS)
 def vault_folders() -> dict[str, Any]:
     """フォルダ構造とノート数を返す。
 
@@ -220,7 +239,7 @@ def vault_folders() -> dict[str, Any]:
     }
 
 
-@mcp.tool()
+@mcp.tool(annotations=_REINDEX_HINTS)
 def vault_reindex(force: bool = False) -> dict[str, Any]:
     """インデックスを再構築する。
 
@@ -236,7 +255,7 @@ def vault_reindex(force: bool = False) -> dict[str, Any]:
     return ReindexStats(**_get_index().build_index(force=force)).model_dump(mode="json")
 
 
-@mcp.tool()
+@mcp.tool(annotations=_READ_ONLY_HINTS)
 def vault_stats() -> dict[str, Any]:
     """インデックスの統計情報を返す。
 

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -23,11 +23,11 @@ from pathlib import Path
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
-from mcp.types import ToolAnnotations
 
 from .indexer import VaultIndex, VaultWatcher
 from .schemas import (
     _TOOL_ENTRIES,
+    _TOOL_SPECS,
     FolderCount,
     NoteDetail,
     NoteNotFoundError,
@@ -69,26 +69,13 @@ def _subset_row(data: dict[str, Any], fields_set: frozenset[str]) -> dict[str, A
 
 mcp = FastMCP("vault-search")
 
-# MCP tool annotations (issue #22).
-# 全ツールはローカル vault のみを扱うため openWorldHint=False。
-# 読み取り系は readOnly=True / destructive=False / idempotent=True。
-# vault_reindex は DB を書き換える唯一の writer (destructive=True) だが、同一入力
-# に対し同一結果に収束するため idempotent=True。
-_READ_ONLY_HINTS = ToolAnnotations(
-    readOnlyHint=True,
-    destructiveHint=False,
-    idempotentHint=True,
-    openWorldHint=False,
-)
-_REINDEX_HINTS = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=True,
-    openWorldHint=False,
-)
+# MCP tool annotations は ``_TOOL_SPECS`` をカノニカルソースとする
+# (schemas.py: issue #22 + review round 1 の整理を参照)。
+# schema://tools リソースと MCP tools/list の両経路で同一メタデータを公開し、
+# server.py 側で定数を重複定義しない。
 
 
-@mcp.tool(annotations=_READ_ONLY_HINTS)
+@mcp.tool(annotations=_TOOL_SPECS["vault_search"].annotations)
 def vault_search(
     query: str,
     tags: list[str] | None = None,
@@ -149,7 +136,7 @@ def vault_search(
     }
 
 
-@mcp.tool(annotations=_READ_ONLY_HINTS)
+@mcp.tool(annotations=_TOOL_SPECS["vault_get_note"].annotations)
 def vault_get_note(path: str, fields: list[str] | None = None) -> dict[str, Any]:
     """指定パスのノート全文とメタデータを取得する。
 
@@ -175,7 +162,7 @@ def vault_get_note(path: str, fields: list[str] | None = None) -> dict[str, Any]
     return _subset_row(result, fields_set)
 
 
-@mcp.tool(annotations=_READ_ONLY_HINTS)
+@mcp.tool(annotations=_TOOL_SPECS["vault_recent"].annotations)
 def vault_recent(
     limit: int = 20,
     offset: int = 0,
@@ -210,7 +197,7 @@ def vault_recent(
     return {"notes": notes}
 
 
-@mcp.tool(annotations=_READ_ONLY_HINTS)
+@mcp.tool(annotations=_TOOL_SPECS["vault_tags"].annotations)
 def vault_tags() -> dict[str, Any]:
     """全タグとその使用回数を返す。出現回数降順。
 
@@ -222,7 +209,7 @@ def vault_tags() -> dict[str, Any]:
     return {"tags": [TagCount(**row).model_dump(mode="json") for row in _get_index().list_tags()]}
 
 
-@mcp.tool(annotations=_READ_ONLY_HINTS)
+@mcp.tool(annotations=_TOOL_SPECS["vault_folders"].annotations)
 def vault_folders() -> dict[str, Any]:
     """フォルダ構造とノート数を返す。
 
@@ -239,7 +226,7 @@ def vault_folders() -> dict[str, Any]:
     }
 
 
-@mcp.tool(annotations=_REINDEX_HINTS)
+@mcp.tool(annotations=_TOOL_SPECS["vault_reindex"].annotations)
 def vault_reindex(force: bool = False) -> dict[str, Any]:
     """インデックスを再構築する。
 
@@ -255,7 +242,7 @@ def vault_reindex(force: bool = False) -> dict[str, Any]:
     return ReindexStats(**_get_index().build_index(force=force)).model_dump(mode="json")
 
 
-@mcp.tool(annotations=_READ_ONLY_HINTS)
+@mcp.tool(annotations=_TOOL_SPECS["vault_stats"].annotations)
 def vault_stats() -> dict[str, Any]:
     """インデックスの統計情報を返す。
 

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -130,9 +130,7 @@ def test_only_vault_reindex_is_writer() -> None:
     """
     tools = asyncio.run(server_mod.mcp.list_tools())
     writers = sorted(
-        t.name
-        for t in tools
-        if t.annotations is not None and t.annotations.readOnlyHint is False
+        t.name for t in tools if t.annotations is not None and t.annotations.readOnlyHint is False
     )
     assert writers == ["vault_reindex"], (
         f"unexpected writer(s) detected — update this invariant intentionally: {writers}"
@@ -164,9 +162,7 @@ def test_all_tools_closed_world() -> None:
     """全 tool は ``openWorldHint=False`` (ローカル vault のみを扱う設計前提)."""
     tools = asyncio.run(server_mod.mcp.list_tools())
     violations = [
-        t.name
-        for t in tools
-        if t.annotations is None or t.annotations.openWorldHint is not False
+        t.name for t in tools if t.annotations is None or t.annotations.openWorldHint is not False
     ]
     assert violations == [], f"tools violating closed-world invariant: {violations}"
 

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -1,0 +1,100 @@
+"""MCP tool annotations (readOnlyHint / destructiveHint / idempotentHint /
+openWorldHint) が全ツールに付与されていることを検証する regression テスト.
+
+Issue #22 (B7): 厳格な MCP クライアント (Claude Desktop の auto-approve 設定など)
+は annotations を見て承認判定する。未付与だと全 tool が「副作用ありかも」扱いに
+なり UX が劣化するため、各ツールに適切な hint を付与する。
+
+annotation は「ヒント」であり保証ではないが、本プロジェクトの全ツールは以下:
+
+- 読み取り系 (vault_search / vault_get_note / vault_recent / vault_tags /
+  vault_folders / vault_stats): readOnly=true, destructive=false,
+  idempotent=true, openWorld=false (ローカル vault のみ)
+- 書き込み系 (vault_reindex): readOnly=false, destructive=true (全件リビルド時に
+  既存 DB を置換)、idempotent=true (同一入力で同一状態に収束)、openWorld=false
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from vault_search import server as server_mod
+from vault_search.indexer import VaultIndex
+
+# 期待 annotations マトリクス (issue #22 の表を全 tool に拡張).
+# 値は bool リテラル: None 扱いにせず必ず明示する。
+_EXPECTED_ANNOTATIONS: dict[str, dict[str, bool]] = {
+    "vault_search": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "vault_get_note": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "vault_recent": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "vault_tags": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "vault_folders": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "vault_stats": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "vault_reindex": {
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _inject_index(vault_index: VaultIndex, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server_mod, "_index", vault_index)
+
+
+@pytest.mark.parametrize(("tool_name", "expected"), list(_EXPECTED_ANNOTATIONS.items()))
+def test_tool_annotations_match_expected(
+    tool_name: str,
+    expected: dict[str, bool],
+    vault_index: VaultIndex,
+) -> None:
+    """各 tool の MCP annotations が期待値と一致する.
+
+    MCP tools/list 経路 (``list_tools()``) で返る ``Tool.annotations`` を直接検証。
+    """
+    tools = asyncio.run(server_mod.mcp.list_tools())
+    tool = next((t for t in tools if t.name == tool_name), None)
+    assert tool is not None, f"tool not registered: {tool_name}"
+
+    annotations = tool.annotations
+    assert annotations is not None, f"{tool_name} has no annotations"
+
+    for key, expected_value in expected.items():
+        actual = getattr(annotations, key, None)
+        assert actual == expected_value, (
+            f"{tool_name}.{key}: expected {expected_value}, got {actual}"
+        )

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -1,17 +1,22 @@
 """MCP tool annotations (readOnlyHint / destructiveHint / idempotentHint /
-openWorldHint) が全ツールに付与されていることを検証する regression テスト.
+openWorldHint) が全ツールに MCP spec 準拠で付与されていることを検証する regression テスト.
 
-Issue #22 (B7): 厳格な MCP クライアント (Claude Desktop の auto-approve 設定など)
-は annotations を見て承認判定する。未付与だと全 tool が「副作用ありかも」扱いに
-なり UX が劣化するため、各ツールに適切な hint を付与する。
+Issue #22 (B7) + review round 1 (Reviewer A/B/C/D) follow-up:
 
-annotation は「ヒント」であり保証ではないが、本プロジェクトの全ツールは以下:
-
-- 読み取り系 (vault_search / vault_get_note / vault_recent / vault_tags /
-  vault_folders / vault_stats): readOnly=true, destructive=false,
-  idempotent=true, openWorld=false (ローカル vault のみ)
-- 書き込み系 (vault_reindex): readOnly=false, destructive=true (全件リビルド時に
-  既存 DB を置換)、idempotent=true (同一入力で同一状態に収束)、openWorld=false
+* 厳格 MCP クライアント (Claude Desktop の auto-approve 設定など) が annotations を
+  読んで承認判定するため、各ツールに適切な hint を付与する。
+* spec 準拠:
+  - ``readOnlyHint=True`` なツールでは ``idempotentHint`` / ``destructiveHint`` は
+    「意味を持たない」 (MCP spec の ToolAnnotations 定義) ので ``None`` 指定
+    (FastMCP は ``None`` のフィールドを wire 上で落とす)。
+  - ``destructiveHint`` は user-facing データの不可逆損失を指す。派生キャッシュ
+    (``.vault-search.db``) の再構築は user-facing vault を touch しないため、
+    ``vault_reindex`` でも ``False`` とする (auto-approve UX への悪影響を避ける)。
+  - ``openWorldHint=False`` は全ツールで統一 (ローカル vault のみを扱う)。
+* regression guard: 新規 tool 追加時に annotations を付け忘れた場合、universal
+  test が検知する (hardcode allowlist に頼らない)。
+* canonical source 統一: schema://tools リソースも annotations を露出する
+  (MCP tools/list と schema://tools の metadata drift を防ぐ)。
 """
 
 from __future__ import annotations
@@ -22,70 +27,66 @@ import pytest
 
 from vault_search import server as server_mod
 from vault_search.indexer import VaultIndex
+from vault_search.schemas import build_schema_payload
 
-# 期待 annotations マトリクス (issue #22 の表を全 tool に拡張).
-# 値は bool リテラル: None 扱いにせず必ず明示する。
-_EXPECTED_ANNOTATIONS: dict[str, dict[str, bool]] = {
+# 期待 annotations マトリクス (MCP spec 準拠).
+# ``None`` は「MCP spec で意味を持たないため意図的に未設定」を示す。
+_EXPECTED_ANNOTATIONS: dict[str, dict[str, bool | None]] = {
     "vault_search": {
         "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
+        "destructiveHint": None,
+        "idempotentHint": None,
         "openWorldHint": False,
     },
     "vault_get_note": {
         "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
+        "destructiveHint": None,
+        "idempotentHint": None,
         "openWorldHint": False,
     },
     "vault_recent": {
         "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
+        "destructiveHint": None,
+        "idempotentHint": None,
         "openWorldHint": False,
     },
     "vault_tags": {
         "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
+        "destructiveHint": None,
+        "idempotentHint": None,
         "openWorldHint": False,
     },
     "vault_folders": {
         "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
+        "destructiveHint": None,
+        "idempotentHint": None,
         "openWorldHint": False,
     },
     "vault_stats": {
         "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
+        "destructiveHint": None,
+        "idempotentHint": None,
         "openWorldHint": False,
     },
     "vault_reindex": {
         "readOnlyHint": False,
-        "destructiveHint": True,
+        # 派生 DB のみ書き換え、user-facing vault (.md) は touch しない。
+        # MCP spec の "destructive" は user-facing の不可逆損失を指すため False。
+        "destructiveHint": False,
         "idempotentHint": True,
         "openWorldHint": False,
     },
 }
 
-
-@pytest.fixture(autouse=True)
-def _inject_index(vault_index: VaultIndex, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(server_mod, "_index", vault_index)
+_ANNOTATION_FIELDS = ("readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint")
 
 
 @pytest.mark.parametrize(("tool_name", "expected"), list(_EXPECTED_ANNOTATIONS.items()))
 def test_tool_annotations_match_expected(
     tool_name: str,
-    expected: dict[str, bool],
-    vault_index: VaultIndex,
+    expected: dict[str, bool | None],
 ) -> None:
-    """各 tool の MCP annotations が期待値と一致する.
-
-    MCP tools/list 経路 (``list_tools()``) で返る ``Tool.annotations`` を直接検証。
-    """
+    """各 tool の MCP annotations が期待値と一致する (spec 準拠)."""
     tools = asyncio.run(server_mod.mcp.list_tools())
     tool = next((t for t in tools if t.name == tool_name), None)
     assert tool is not None, f"tool not registered: {tool_name}"
@@ -96,5 +97,107 @@ def test_tool_annotations_match_expected(
     for key, expected_value in expected.items():
         actual = getattr(annotations, key, None)
         assert actual == expected_value, (
-            f"{tool_name}.{key}: expected {expected_value}, got {actual}"
+            f"{tool_name}.{key}: expected {expected_value!r}, got {actual!r}"
         )
+
+
+def test_every_registered_tool_has_annotations() -> None:
+    """MCP list_tools で返る全 tool に annotations が付与されている.
+
+    新規 tool 追加時に annotations を付け忘れても hardcode allowlist は
+    検知できないため、``list_tools()`` の出力を基準に universal guard を張る。
+    """
+    tools = asyncio.run(server_mod.mcp.list_tools())
+    missing = [t.name for t in tools if t.annotations is None]
+    assert missing == [], f"tools without annotations: {missing}"
+
+    # _EXPECTED_ANNOTATIONS 側と tools/list の tool 集合が一致することも検査。
+    # 新規 tool 追加時は両方を更新しないとここで失敗する。
+    registered = {t.name for t in tools}
+    expected_covered = set(_EXPECTED_ANNOTATIONS)
+    assert registered == expected_covered, (
+        f"symmetric difference between registered tools and expected matrix: "
+        f"registered-only={registered - expected_covered}, "
+        f"expected-only={expected_covered - registered}"
+    )
+
+
+def test_only_vault_reindex_is_writer() -> None:
+    """書き込み可能 tool は vault_reindex のみ (アーキテクチャ不変条件).
+
+    将来 write-tool を追加した際にこのテストが失敗することで「意図的な設計変更」
+    として明示的にレビュー対象になる。silent に writer が増えないよう固定する。
+    """
+    tools = asyncio.run(server_mod.mcp.list_tools())
+    writers = sorted(
+        t.name
+        for t in tools
+        if t.annotations is not None and t.annotations.readOnlyHint is False
+    )
+    assert writers == ["vault_reindex"], (
+        f"unexpected writer(s) detected — update this invariant intentionally: {writers}"
+    )
+
+
+def test_readonly_tools_do_not_declare_destructive_or_idempotent() -> None:
+    """``readOnlyHint=True`` ツールは destructive/idempotent を宣言しない (MCP spec 準拠).
+
+    MCP spec の ``destructiveHint`` / ``idempotentHint`` は
+    「``readOnlyHint == false`` のときのみ意味を持つ」と定義されているため、
+    readOnly tool では ``None`` のまま残す。spec 違反を防ぐ invariant。
+    """
+    tools = asyncio.run(server_mod.mcp.list_tools())
+    offenders: list[str] = []
+    for tool in tools:
+        if tool.annotations is None or tool.annotations.readOnlyHint is not True:
+            continue
+        if tool.annotations.destructiveHint is not None:
+            offenders.append(f"{tool.name}.destructiveHint={tool.annotations.destructiveHint}")
+        if tool.annotations.idempotentHint is not None:
+            offenders.append(f"{tool.name}.idempotentHint={tool.annotations.idempotentHint}")
+    assert offenders == [], (
+        f"readOnly tools must leave destructive/idempotent unset (MCP spec): {offenders}"
+    )
+
+
+def test_all_tools_closed_world() -> None:
+    """全 tool は ``openWorldHint=False`` (ローカル vault のみを扱う設計前提)."""
+    tools = asyncio.run(server_mod.mcp.list_tools())
+    violations = [
+        t.name
+        for t in tools
+        if t.annotations is None or t.annotations.openWorldHint is not False
+    ]
+    assert violations == [], f"tools violating closed-world invariant: {violations}"
+
+
+def test_schema_tools_resource_exposes_annotations(vault_index: VaultIndex) -> None:
+    """``schema://tools`` リソースも各 tool の annotations を公開する.
+
+    fastmcp-gotchas.md の canonical-unification 原則: MCP ``tools/list`` と
+    ``schema://tools`` は同一メタデータを露出すべき。annotations を MCP 経路
+    にしか出していないと、``schema://tools`` だけを読む構造化 agent が tool
+    の副作用性を判定できず drift する。
+    """
+    payload = build_schema_payload(vault_index)
+    tools_entries = payload["tools"]
+    assert set(tools_entries.keys()) == set(_EXPECTED_ANNOTATIONS), (
+        f"schema://tools tool set mismatch: {set(tools_entries.keys())}"
+    )
+    for tool_name, expected in _EXPECTED_ANNOTATIONS.items():
+        entry = tools_entries[tool_name]
+        assert "annotations" in entry, f"{tool_name}: schema://tools missing 'annotations' key"
+        annotations = entry["annotations"]
+        assert isinstance(annotations, dict), (
+            f"{tool_name}: annotations must be dict, got {type(annotations).__name__}"
+        )
+        for key, expected_value in expected.items():
+            if expected_value is None:
+                # None 相当は dict から落としてよい (MCP wire 挙動と揃える)
+                assert annotations.get(key) is None, (
+                    f"{tool_name}.{key}: expected unset/None, got {annotations.get(key)!r}"
+                )
+            else:
+                assert annotations.get(key) == expected_value, (
+                    f"{tool_name}.{key}: expected {expected_value!r}, got {annotations.get(key)!r}"
+                )

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -78,8 +78,6 @@ _EXPECTED_ANNOTATIONS: dict[str, dict[str, bool | None]] = {
     },
 }
 
-_ANNOTATION_FIELDS = ("readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint")
-
 
 @pytest.mark.parametrize(("tool_name", "expected"), list(_EXPECTED_ANNOTATIONS.items()))
 def test_tool_annotations_match_expected(


### PR DESCRIPTION
## Summary

- Issue #22 (B7): 全 tool に `ToolAnnotations` (readOnlyHint / destructiveHint / idempotentHint / openWorldHint) を付与
- 厳格な MCP クライアント (Claude Desktop auto-approve 等) が承認判定できるよう、pessimistic default に頼らせない
- TDD: Red → Green 形式で実装

## Matrix

| tool | readOnly | destructive | idempotent | openWorld |
|---|---|---|---|---|
| vault_search / vault_get_note / vault_recent / vault_tags / vault_folders / vault_stats | true | false | true | false |
| vault_reindex | false | true | true | false |

全ツールはローカル vault のみを扱うため `openWorldHint=False` で統一。`vault_reindex` は DB を書き換える唯一の writer だが、同一入力で同一状態に収束するため `idempotentHint=True`。

## Test plan

- [x] `tests/test_tool_annotations.py` — parametrized で全 7 ツールの annotations を `list_tools()` 経由で検証
- [x] 全 212 テスト pass
- [x] `ruff check` / `ruff format --check` clean

Closes #22