### PR TITLE
Docs: assign models to reviewers and TDD phases for cost control

### DIFF
--- a/.claude/rules/tdd-workflow.md
+++ b/.claude/rules/tdd-workflow.md
@@ -35,6 +35,24 @@ delegate する。各フェーズで以下を明示:
 - **完了条件**を明記 (テスト通過数、commit 形式、lint クリーン)
 - **中断条件**を記述 (これに該当したら停止して報告)
 
+### モデル指定指針
+
+コスト最適化のため、フェーズ / 用途ごとに `Agent({model: ...})` で明示指定する
+(Agent tool の `model` param は agent definition frontmatter を override する)。
+
+| 用途 | モデル | 根拠 |
+|---|---|---|
+| Red delegate (失敗テスト追加) | Sonnet | テスト骨格組立に十分 |
+| Green delegate (最小実装) | Sonnet | 単機能実装に十分 |
+| Refactor **計画作成** | Sonnet | 機械的な整理案の列挙 |
+| Refactor **計画評価** (実施前) | **Opus** | 盲点・副作用・設計影響の抽象思考が効く |
+| Refactor delegate (実施) | Sonnet | プラン追従の実装は Sonnet 十分 |
+| 一時スクリプト security pre-review | Haiku | `execute-script-safely` 規定通り |
+
+Refactor は「計画 (Sonnet) → 評価 (Opus) → 実施 (Sonnet)」の 3 段を推奨。
+評価ステップを Opus に分離することで、計画段階で Opus を長時間走らせる無駄を
+避けつつ、危険な refactor を実施前に止められる。
+
 ### 既知の落とし穴: background subagent は Edit/Write が拒否される
 
 `Agent(..., run_in_background=true, mode="acceptEdits")` および

--- a/.claude/skills/execute-script-safely/SKILL.md
+++ b/.claude/skills/execute-script-safely/SKILL.md
@@ -18,6 +18,7 @@ description: |
   - python -c "print(1+1)" レベルの 1 行 snippet
     (ただし未知モジュールを import する場合は対象)
 allowed-tools: Agent, Read, Write, Bash
+model: haiku
 ---
 
 # Execute Script Safely

--- a/.claude/skills/review-loop/SKILL.md
+++ b/.claude/skills/review-loop/SKILL.md
@@ -15,6 +15,7 @@ description: |
   - 単純な bugfix 後の軽い確認 → 通常の /simplify で十分
   - 実装前の設計議論 → /grill-me が適切
 allowed-tools: Agent, Bash(gh issue:*), Bash(gh label list:*), Bash(gh pr list:*), Bash(gh pr view:*), Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(git branch:*), TaskCreate, TaskUpdate, TaskList, TaskGet, Read, Write, Edit, Glob, Grep
+model: sonnet
 ---
 
 # Review Loop

--- a/.claude/skills/review-loop/SKILL.md
+++ b/.claude/skills/review-loop/SKILL.md
@@ -45,12 +45,17 @@ allowed-tools: Agent, Bash(gh issue:*), Bash(gh label list:*), Bash(gh pr list:*
 
 **4 視点を並列起動** (独立した Agent として、**既存コードを追認させない**):
 
-| 視点 | 焦点 |
-|---|---|
-| **A: Correctness** | バグ、エッジケース、未検証の仮定、race、leak |
-| **B: Agent DX** | MCP/CLI エージェントが初見で誤用する箇所、schema の機械可読性 |
-| **C: Test Quality** | t-wada スタイル、vacuous pass、brittle、実装ミラー、実質網羅性 |
-| **D: Architecture** | god class、責務漏れ、結合度、拡張性、層越え |
+| 視点 | 焦点 | モデル |
+|---|---|---|
+| **A: Correctness** | バグ、エッジケース、未検証の仮定、race、leak | Sonnet |
+| **B: Agent DX** | MCP/CLI エージェントが初見で誤用する箇所、schema の機械可読性 | Sonnet |
+| **C: Test Quality** | t-wada スタイル、vacuous pass、brittle、実装ミラー、実質網羅性 | Sonnet |
+| **D: Architecture** | god class、責務漏れ、結合度、拡張性、層越え | **Opus** |
+
+モデル指定は `Agent({subagent_type: "general-purpose", model: "sonnet" | "opus", ...})`
+で明示する。Architecture 視点 (D) だけ Opus を残す根拠は、層越えや結合度の
+判断が 1 段抽象的で、Sonnet では見落としやすいため。コスト削減効果は 4 視点
+ラウンドで Opus 4→1 (75% 削減)。
 
 各 Reviewer へのプロンプトに**必ず含める**:
 
@@ -73,6 +78,10 @@ Reviewer 報告を集約し、スコアで振り分け:
 ### Phase 3: 対応実行
 
 - **FIX**: サブエージェントに delegate、TDD 必須 (Red → Green → Refactor 各 commit)
+  - Red / Green / Refactor の **実施** は Sonnet delegate
+  - **Refactor プランの評価**(実施前の設計レビュー) は Opus で別 Agent に回す
+    — 計画の盲点・副作用検知で Opus の抽象思考が効く。プラン自体の作成は
+    Sonnet で十分
 - **Issue 起票**: `gh issue create --label enhancement --body-file <body>` で一括
   - Issue body は「背景 / 再現 / 推奨修正 / スコア / 関連 Issue」構成
   - 事前に `.tmp-issues/*.md` に本文生成しておくと retry 容易


### PR DESCRIPTION
## Summary

review-loop skill と TDD workflow rules に model 指定を明文化し、Opus 使用を
必要最小限に絞る運用を定める。

- **review-loop**: 4 視点のうち A/B/C (Correctness, Agent DX, Test Quality)
  を Sonnet、D (Architecture) のみ Opus
- **TDD delegate**: Red/Green/Refactor 実施は Sonnet、Refactor プランの
  **評価**は Opus、計画作成は Sonnet の 3 段構成を推奨
- Agent tool の `model` param が agent definition frontmatter を override
  する仕様を前提とし、プラグイン側エージェントもラッパー不要

## Rationale

過去の 9 ラウンド review-loop は 4 視点全て Opus 実行だった。D 視点以外は
Sonnet で十分と判断、1 ラウンドあたり Opus 消費を 75% 削減。Refactor
プラン評価の分離は、危険な設計変更を実施前に止める gate として Opus の
抽象思考を残す。

## Test plan

- [x] lint 対象外 (Markdown のみ)
- [x] 記述の整合性: review-loop SKILL.md の reviewer 表と TDD rules の
  モデル指定表が矛盾しないこと

## Note

ユーザーレベル skill (`~/.claude/skills/*`) への同等方針展開は別 PR /
別セッションで実施予定 (本 PR はプロジェクトレベルのみ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)