### PR TITLE
Simplify: drop schema walker dead code in tests (#93)

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -104,41 +104,14 @@ def _call_vault_search_via_mcp(arguments: dict[str, Any]) -> dict[str, Any]:
 
 
 def _search_hit_properties(output_schema: dict[str, Any]) -> dict[str, Any]:
-    """vault_search の output_schema から SearchHit 相当の properties を取り出す.
+    """vault_search の output_schema から SearchHit の properties を取り出す.
 
-    path + title + snippet を全て持つ properties dict を、$defs / items /
-    anyOf ブランチのいずれに格納されていても再帰探索して返す。
+    SearchResponse は ``results: list[SearchHit]`` を持つため Pydantic は
+    ``$defs.SearchHit`` に SearchHit を切り出し ``results.items`` を ``$ref``
+    で参照する。直接パスで取り出せばよい (PR #92 で fields 削除後、
+    anyOf / oneOf ブランチは発生しない)。
     """
-    target_keys = {"path", "title", "snippet"}
-
-    def _walk(node: Any) -> dict[str, Any]:
-        if not isinstance(node, dict):
-            return {}
-        props = node.get("properties")
-        if isinstance(props, dict) and target_keys.issubset(props.keys()):
-            return props
-        for key in ("anyOf", "oneOf", "allOf"):
-            branches = node.get(key)
-            if isinstance(branches, list):
-                for branch in branches:
-                    hit = _walk(branch)
-                    if hit:
-                        return hit
-        for key in ("items", "$defs", "definitions", "properties"):
-            sub = node.get(key)
-            if isinstance(sub, dict):
-                if key in {"$defs", "definitions", "properties"}:
-                    for v in sub.values():
-                        hit = _walk(v)
-                        if hit:
-                            return hit
-                else:
-                    hit = _walk(sub)
-                    if hit:
-                        return hit
-        return {}
-
-    return _walk(output_schema)
+    return output_schema["$defs"]["SearchHit"]["properties"]
 
 
 @pytest.fixture(autouse=True)
@@ -201,8 +174,7 @@ def test_schema_driven_agent_flow(vault_index: VaultIndex) -> None:
     assert len(result["results"]) >= 1
 
     # SearchHit の全 8 フィールドが schema にも実レスポンスにも揃っていること
-    # (schema と実データの drift を検知する — `_search_hit_properties` が
-    # 部分一致で早期 return して 3 フィールドだけで pass しないよう強制)
+    # (schema と実データの drift を検知する)
     expected_hit_fields = {
         "path",
         "title",

--- a/tests/test_schema_resource.py
+++ b/tests/test_schema_resource.py
@@ -40,51 +40,14 @@ SEARCH_HIT_FIELDS = {
 }
 
 
-def _get_properties(schema: dict[str, Any]) -> dict[str, Any]:
-    """JSON Schema から SearchHit 相当 (path + title + snippet) の properties を探索.
+def _search_hit_properties(vault_search_output_schema: dict[str, Any]) -> dict[str, Any]:
+    """vault_search の output_schema から SearchHit の properties を取り出す.
 
-    Pydantic 生成 schema は (a) ルート直下の properties、(b) $defs 参照、
-    (c) 配列項目へのインライン or $ref、(d) anyOf ブランチ内の properties、
-    のいずれにも該当モデルが現れ得る。いずれのパターンでも SearchHit 相当を
-    優先的に返す。
+    SearchResponse は ``results: list[SearchHit]`` を持つため Pydantic は
+    ``$defs.SearchHit`` に SearchHit を切り出す。PR #92 で fields 削除後は
+    anyOf ブランチ等が発生しないため直接パスで取り出せる。
     """
-    target_keys = {"path", "title", "snippet"}
-
-    def _walk(node: Any) -> dict[str, Any] | None:
-        if isinstance(node, dict):
-            props = node.get("properties")
-            if isinstance(props, dict) and target_keys.issubset(props.keys()):
-                return props
-            # anyOf / oneOf / items / $defs / definitions / properties を探索
-            for key in ("anyOf", "oneOf", "allOf"):
-                branches = node.get(key)
-                if isinstance(branches, list):
-                    for branch in branches:
-                        hit = _walk(branch)
-                        if hit is not None:
-                            return hit
-            for key in ("items", "$defs", "definitions", "properties"):
-                sub = node.get(key)
-                if isinstance(sub, dict):
-                    # properties dict の value 群 / defs dict の value 群を探索
-                    if key in {"$defs", "definitions", "properties"}:
-                        for v in sub.values():
-                            hit = _walk(v)
-                            if hit is not None:
-                                return hit
-                    else:
-                        hit = _walk(sub)
-                        if hit is not None:
-                            return hit
-        return None
-
-    hit = _walk(schema)
-    if hit is not None:
-        return hit
-    # 最終 fallback: ルート properties があればそれを返す
-    if isinstance(schema.get("properties"), dict):
-        return schema["properties"]
-    return {}
+    return vault_search_output_schema["$defs"]["SearchHit"]["properties"]
 
 
 # ---------------------------------------------------------------------------
@@ -139,7 +102,7 @@ def test_vault_search_output_schema_describes_search_hit_fields(
 
     payload = build_schema_payload(vault_index)
     out_schema = payload["tools"]["vault_search"]["output_schema"]
-    props = _get_properties(out_schema)
+    props = _search_hit_properties(out_schema)
     assert props, f"No properties found in output_schema: {out_schema}"
 
     for field in SEARCH_HIT_FIELDS:


### PR DESCRIPTION
## Summary

PR #92 で fields 機能と anyOf subset / \$defs inlining を削除した後、tests
側の schema walker (`_search_hit_properties` / `_get_properties`) は
anyOf / oneOf / \$defs / items を再帰探索する過剰汎用性を残したままだった。
現 schema 生成経路は Pydantic の `\$defs.SearchHit` に切り出される直線経路
のみなので、`output_schema["\$defs"]["SearchHit"]["properties"]` の直接参照で
十分。

- `tests/test_integration.py`: `_search_hit_properties` を 1 行実装に短縮
- `tests/test_schema_resource.py`: 旧 `_get_properties` を同名の
  `_search_hit_properties` にリネームして同じく短縮

-79/+14 行。将来 anyOf 等が silently 再混入しても walker が通してしまう
overfit を排除し、B1 (schemas.py 分解) 前に safety net を固める。

## Test plan

- [x] `pytest` → 252 passed
- [x] `ruff check` / `ruff format` clean

Closes #93