### PR TITLE
Refactor: Phase B1 - schemas.py decomposition (exceptions split + decouple VaultIndex + single-source LIMIT_MAX)

### DIFF
--- a/src/vault_search/exceptions.py
+++ b/src/vault_search/exceptions.py
@@ -1,0 +1,18 @@
+"""vault-search-mcp ドメイン例外階層.
+
+schemas.py から分離 (B1-1)。モデル定義と例外定義の責務を分ける。
+"""
+
+from __future__ import annotations
+
+
+class VaultSearchError(Exception):
+    """vault-search-mcp ドメインの基底例外."""
+
+
+class NoteNotFoundError(VaultSearchError):
+    """指定された path のノートがインデックスに存在しない."""
+
+    def __init__(self, path: str) -> None:
+        super().__init__(f"Note not found: {path}")
+        self.path = path

--- a/src/vault_search/schemas.py
+++ b/src/vault_search/schemas.py
@@ -17,23 +17,6 @@ if TYPE_CHECKING:
     from .indexer import VaultIndex
 
 # ---------------------------------------------------------------------------
-# Domain errors
-# ---------------------------------------------------------------------------
-
-
-class VaultSearchError(Exception):
-    """vault-search-mcp ドメインの基底例外."""
-
-
-class NoteNotFoundError(VaultSearchError):
-    """指定された path のノートがインデックスに存在しない."""
-
-    def __init__(self, path: str) -> None:
-        super().__init__(f"Note not found: {path}")
-        self.path = path
-
-
-# ---------------------------------------------------------------------------
 # Search responses
 # ---------------------------------------------------------------------------
 

--- a/src/vault_search/schemas.py
+++ b/src/vault_search/schemas.py
@@ -1,4 +1,4 @@
-"""Pydantic models for MCP tool returns and domain errors.
+"""Pydantic models for MCP tool returns.
 
 これらのモデルは FastMCP が JSON Schema を自動生成する際に
 ツール出力の正確な構造を AI エージェントへ伝達するために使う。
@@ -7,14 +7,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, ConfigDict, Field
-
-if TYPE_CHECKING:
-    from .indexer import VaultIndex
 
 # ---------------------------------------------------------------------------
 # Search responses
@@ -424,9 +422,13 @@ _TOOL_ENTRIES: dict[str, dict[str, Any]] = {
 }
 
 
-def build_schema_payload(index: VaultIndex) -> dict[str, Any]:
-    """AI エージェント向けに全ツールの入出力スキーマと frontmatter キー一覧を集約."""
+def build_schema_payload(frontmatter_keys: Iterable[str]) -> dict[str, Any]:
+    """AI エージェント向けに全ツールの入出力スキーマと frontmatter キー一覧を集約.
+
+    呼び出し側は ``VaultIndex.list_frontmatter_keys()`` 相当の反復可能オブジェクトを
+    渡す。schemas モジュールが indexer に依存しないよう引数化している。
+    """
     return {
         "tools": _TOOL_ENTRIES,
-        "frontmatter_keys": index.list_frontmatter_keys(),
+        "frontmatter_keys": list(frontmatter_keys),
     }

--- a/src/vault_search/schemas.py
+++ b/src/vault_search/schemas.py
@@ -14,6 +14,8 @@ from typing import Any, Literal
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, ConfigDict, Field
 
+from .validation import LIMIT_MAX
+
 # ---------------------------------------------------------------------------
 # Search responses
 # ---------------------------------------------------------------------------
@@ -216,12 +218,14 @@ _FOLDER_INPUT_SCHEMA: dict[str, Any] = {
 # Shared pagination input schemas. ``minimum`` / ``maximum`` are the single
 # source of truth the agent sees via ``schema://tools``; the runtime guard in
 # ``validation.validate_pagination`` enforces the same bounds server-side.
+# ``LIMIT_MAX`` is imported from validation.py so that the agent-facing bound
+# and the server-side guard cannot drift.
 _LIMIT_INPUT_SCHEMA: dict[str, Any] = {
     "type": "integer",
     "minimum": 1,
-    "maximum": 500,
+    "maximum": LIMIT_MAX,
     "default": 20,
-    "description": "最大返却件数 (1-500)。上限超過は ValidationError。",
+    "description": f"最大返却件数 (1-{LIMIT_MAX})。上限超過は ValidationError。",
 }
 
 

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -278,7 +278,7 @@ def schema_resource() -> dict[str, Any]:
     _TOOL_ENTRIES を共通のカノニカルソースとして同一内容になる
     (_inject_rich_output_schemas 参照)。
     """
-    return build_schema_payload(_get_index())
+    return build_schema_payload(_get_index().list_frontmatter_keys())
 
 
 # ---------------------------------------------------------------------------

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -24,13 +24,13 @@ from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
+from .exceptions import NoteNotFoundError
 from .indexer import VaultIndex, VaultWatcher
 from .schemas import (
     _TOOL_ENTRIES,
     _TOOL_SPECS,
     FolderCount,
     NoteDetail,
-    NoteNotFoundError,
     RecentNote,
     ReindexStats,
     SearchHit,

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import re
 
 __all__ = [
+    "LIMIT_MAX",
     "ValidationError",
     "validate_identifier",
     "validate_pagination",
@@ -34,7 +35,9 @@ __all__ = [
 # Hard ceiling on paginated result size. Anchored to the FTS5 cache ceiling
 # (`_MAX_RESULTS` in indexer) so that requested limit never exceeds what the
 # backend actually returns — avoiding silent truncation from the agent's POV.
-_LIMIT_MAX = 500
+# Public (no `_` prefix) because schemas.py references this as the single
+# source of truth for the MCP tool input schema's ``maximum`` constraint.
+LIMIT_MAX = 500
 
 
 # Allowed character class for identifiers (field names, frontmatter keys).
@@ -136,7 +139,7 @@ def validate_pagination(limit: int, offset: int = 0) -> None:
 
     ``limit`` must be a positive integer (zero-result queries waste a round
     trip and usually indicate a hallucinated bound). ``offset`` must be
-    non-negative. ``limit`` is capped at :data:`_LIMIT_MAX` to keep requests
+    non-negative. ``limit`` is capped at :data:`LIMIT_MAX` to keep requests
     aligned with the internal FTS5 cache ceiling.
     """
     if not isinstance(limit, int) or isinstance(limit, bool):
@@ -145,8 +148,8 @@ def validate_pagination(limit: int, offset: int = 0) -> None:
         raise ValidationError(f"offset must be an integer, got {type(offset).__name__}")
     if limit < 1:
         raise ValidationError(f"limit must be >= 1 (got {limit})")
-    if limit > _LIMIT_MAX:
-        raise ValidationError(f"limit must be <= {_LIMIT_MAX} (got {limit})")
+    if limit > LIMIT_MAX:
+        raise ValidationError(f"limit must be <= {LIMIT_MAX} (got {limit})")
     if offset < 0:
         raise ValidationError(f"offset must be >= 0 (got {offset})")
 

--- a/tests/test_mcp_wrapping.py
+++ b/tests/test_mcp_wrapping.py
@@ -109,7 +109,7 @@ def test_vault_search_outputschema_top_level_is_flat(vault_index: VaultIndex) ->
 
 def test_schema_resource_output_schema_remains_rich(vault_index: VaultIndex) -> None:
     """schema://tools の output_schema は SearchResponse の rich schema を維持."""
-    payload = build_schema_payload(vault_index)
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
     output_schema = payload["tools"]["vault_search"]["output_schema"]
     props = output_schema.get("properties", {})
     # 最低でも tier / total / results を直接キーとして持つこと
@@ -184,7 +184,7 @@ def test_mcp_outputschema_is_rich_matches_resource(vault_index: VaultIndex) -> N
     """
 
     tools = asyncio.run(server_mod.mcp.list_tools())
-    payload = build_schema_payload(vault_index)
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
     for tool in tools:
         assert tool.outputSchema is not None, f"{tool.name}: outputSchema missing"
         resource_schema = payload["tools"][tool.name]["output_schema"]

--- a/tests/test_schema_resource.py
+++ b/tests/test_schema_resource.py
@@ -58,14 +58,14 @@ def _search_hit_properties(vault_search_output_schema: dict[str, Any]) -> dict[s
 def test_build_schema_payload_returns_dict(vault_index: VaultIndex) -> None:
     from vault_search.schemas import build_schema_payload
 
-    payload = build_schema_payload(vault_index)
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
     assert isinstance(payload, dict)
 
 
 def test_build_schema_payload_has_tools_key(vault_index: VaultIndex) -> None:
     from vault_search.schemas import build_schema_payload
 
-    payload = build_schema_payload(vault_index)
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
     assert "tools" in payload
     assert isinstance(payload["tools"], dict)
 
@@ -73,7 +73,7 @@ def test_build_schema_payload_has_tools_key(vault_index: VaultIndex) -> None:
 def test_build_schema_payload_contains_all_tool_names(vault_index: VaultIndex) -> None:
     from vault_search.schemas import build_schema_payload
 
-    payload = build_schema_payload(vault_index)
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
     tool_names = set(payload["tools"].keys())
     missing = EXPECTED_TOOL_NAMES - tool_names
     assert not missing, f"Missing tools in payload: {missing}"
@@ -82,7 +82,7 @@ def test_build_schema_payload_contains_all_tool_names(vault_index: VaultIndex) -
 def test_each_tool_entry_has_input_and_output_schema(vault_index: VaultIndex) -> None:
     from vault_search.schemas import build_schema_payload
 
-    payload = build_schema_payload(vault_index)
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
     for name in EXPECTED_TOOL_NAMES:
         entry = payload["tools"][name]
         assert isinstance(entry, dict), f"{name} entry is not dict"
@@ -100,7 +100,7 @@ def test_vault_search_output_schema_describes_search_hit_fields(
     """
     from vault_search.schemas import build_schema_payload
 
-    payload = build_schema_payload(vault_index)
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
     out_schema = payload["tools"]["vault_search"]["output_schema"]
     props = _search_hit_properties(out_schema)
     assert props, f"No properties found in output_schema: {out_schema}"
@@ -119,7 +119,7 @@ def test_frontmatter_keys_listed(vault_index: VaultIndex) -> None:
     """
     from vault_search.schemas import build_schema_payload
 
-    payload = build_schema_payload(vault_index)
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
     assert "frontmatter_keys" in payload
     keys = payload["frontmatter_keys"]
     assert isinstance(keys, list)
@@ -163,7 +163,7 @@ def test_server_exposes_schema_resource_handler(
     assert callable(handler), "schema_resource must be callable"
 
     result = handler()
-    expected = build_schema_payload(vault_index)
+    expected = build_schema_payload(vault_index.list_frontmatter_keys())
 
     assert isinstance(result, dict)
     assert set(result.keys()) == set(expected.keys())
@@ -195,7 +195,7 @@ def test_list_returning_tools_have_envelope_output_schema(vault_index: VaultInde
     """
     from vault_search.schemas import build_schema_payload
 
-    payload = build_schema_payload(vault_index)
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
     for tool_name, env_key in [
         ("vault_tags", "tags"),
         ("vault_folders", "folders"),
@@ -226,7 +226,7 @@ def test_metadata_filter_grammar_structured_in_schema(vault_index: VaultIndex) -
     """
     from vault_search.schemas import build_schema_payload
 
-    payload = build_schema_payload(vault_index)
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
     mf_schema = payload["tools"]["vault_search"]["input_schema"]["properties"]["metadata_filter"]
 
     ap = mf_schema.get("additionalProperties")
@@ -259,7 +259,7 @@ def test_vault_get_note_output_schema_has_top_level_object_shape(vault_index: Va
     """
     from vault_search.schemas import build_schema_payload
 
-    payload = build_schema_payload(vault_index)
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
     schema = payload["tools"]["vault_get_note"]["output_schema"]
 
     assert schema.get("type") == "object", (

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,11 +8,11 @@ from typing import Any
 import pytest
 
 from vault_search import server as server_mod
+from vault_search.exceptions import NoteNotFoundError
 from vault_search.indexer import VaultIndex
 from vault_search.schemas import (
     FolderCount,
     NoteDetail,
-    NoteNotFoundError,
     RecentNote,
     SearchResponse,
     TagCount,

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -173,7 +173,7 @@ def test_schema_tools_resource_exposes_annotations(vault_index: VaultIndex) -> N
     にしか出していないと、``schema://tools`` だけを読む構造化 agent が tool
     の副作用性を判定できず drift する。
     """
-    payload = build_schema_payload(vault_index)
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
     tools_entries = payload["tools"]
     assert set(tools_entries.keys()) == set(_EXPECTED_ANNOTATIONS), (
         f"schema://tools tool set mismatch: {set(tools_entries.keys())}"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -310,3 +310,24 @@ def test_validate_value_error_message_includes_custom_kind() -> None:
     with pytest.raises(ValidationError) as exc:
         validate_value("bad\x00value", kind="frontmatter value")
     assert "frontmatter value" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# LIMIT_MAX single-source invariant — validation.py が真実のソースで、
+# schemas._LIMIT_INPUT_SCHEMA が同じ値を参照していることを pin する。
+# ---------------------------------------------------------------------------
+
+
+def test_limit_input_schema_maximum_matches_limit_max() -> None:
+    from vault_search.schemas import _LIMIT_INPUT_SCHEMA
+    from vault_search.validation import LIMIT_MAX
+
+    assert _LIMIT_INPUT_SCHEMA["maximum"] == LIMIT_MAX
+
+
+def test_limit_input_schema_description_references_limit_max() -> None:
+    """description 文字列中の数値も LIMIT_MAX から展開されていること (stale 防止)."""
+    from vault_search.schemas import _LIMIT_INPUT_SCHEMA
+    from vault_search.validation import LIMIT_MAX
+
+    assert str(LIMIT_MAX) in _LIMIT_INPUT_SCHEMA["description"]


### PR DESCRIPTION
## Summary

Phase B1 の `schemas.py` 責務分解 3 点。Opus 評価に沿って B1-2 (ValidationError 多重継承) は YAGNI 判定で除外。

### 変更内訳

1. **B1-1 exceptions.py 新設** (`Refactor:`)
   - `VaultSearchError` / `NoteNotFoundError` を schemas.py から分離
   - re-export は残さず server.py と tests/test_server.py の import を直接更新

2. **B1-3 build_schema_payload の VaultIndex 依存解消** (`Refactor:`)
   - シグネチャを `(index: VaultIndex)` → `(frontmatter_keys: Iterable[str])` に変更
   - schemas.py の `TYPE_CHECKING` / `VaultIndex` import を削除
   - tests 13 箇所を `vault_index.list_frontmatter_keys()` 渡しに機械置換

3. **B1-4 LIMIT_MAX 単一ソース化** (`Refactor:` + `Test:`)
   - `validation._LIMIT_MAX` → public `LIMIT_MAX` (PEP 8 遵守で cross-module import 可)
   - `schemas._LIMIT_INPUT_SCHEMA` の maximum / description を f-string で LIMIT_MAX 展開 (stale 防止)
   - 単一ソース invariant を pin する test 2 件追加

### 除外項目

- **B1-2 (ValidationError 多重継承)**: 現状 `except VaultSearchError:` が 1 箇所も無く投機的。catcher 要件発生時に別 issue/PR。

### 不変保証

- `schema://tools` の JSON 形状 (tools + frontmatter_keys) は完全不変
- `_inject_rich_output_schemas()` 経路は `_TOOL_ENTRIES` 依存のみで影響なし
- MCP outputSchema の wire 形式変化なし

## Test plan

- [x] `pytest` → 254 passed (2 件は B1-4 invariant pin)
- [x] `ruff check` / `ruff format` clean
- [x] 分割 commit で diff レビュー容易化

Refs HANDOVER.md Phase B1。