### PR TITLE
Simplify: Phase C cleanup (parser/filter/validation helpers)

### DIFF
--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -131,6 +131,22 @@ def _parse_operator_dict(key: str, op_dict: dict[Any, Any]) -> MetadataCondition
     return _parse_ne(key, op_value)
 
 
+def _format_scalar_for_error(v: object) -> str:
+    """エラーメッセージ用に非 str スカラーを index 側の正規化形に合わせて文字列化.
+
+    小文字 ``"true"``/``"false"`` は意図的選択: ``str(True)`` は ``"True"`` を
+    返すが、parser の ``_normalize_scalar`` は YAML / JSON 慣例に合わせて
+    小文字化する (Issue #15 / #49)。エラーヒントも同じ形で示し、エージェントが
+    そのままコピペしてリトライできるようにする。bool 判定を先にするのは
+    ``isinstance(True, int)`` が True になる Python の罠への対応。
+    """
+    if v is True:
+        return "true"
+    if v is False:
+        return "false"
+    return str(v)
+
+
 def _parse_in(key: str, op_value: Any) -> MetadataCondition:
     if not isinstance(op_value, list):
         raise ValidationError(
@@ -142,12 +158,11 @@ def _parse_in(key: str, op_value: Any) -> MetadataCondition:
     validated: list[str] = []
     for idx, item in enumerate(op_value):
         if not isinstance(item, str):
-            stringified = "true" if item is True else "false" if item is False else str(item)
             raise ValidationError(
                 f"metadata_filter[{key!r}]['in'][{idx}] must be a string, "
                 f"got {type(item).__name__}. Frontmatter scalars are normalized "
                 f"to strings at index time; pass the stringified form "
-                f'(e.g. "{stringified}").'
+                f'(e.g. "{_format_scalar_for_error(item)}").'
             )
         validate_value(item, kind="frontmatter value")
         validated.append(item)
@@ -156,14 +171,11 @@ def _parse_in(key: str, op_value: Any) -> MetadataCondition:
 
 def _parse_ne(key: str, op_value: Any) -> MetadataCondition:
     if not isinstance(op_value, str):
-        stringified = (
-            "true" if op_value is True else "false" if op_value is False else str(op_value)
-        )
         raise ValidationError(
             f"metadata_filter[{key!r}]['ne'] must be a string, "
             f"got {type(op_value).__name__}. Frontmatter scalars are normalized "
             f"to strings at index time; pass the stringified form "
-            f'(e.g. {{{key!r}: {{"ne": "{stringified}"}}}}).'
+            f'(e.g. {{{key!r}: {{"ne": "{_format_scalar_for_error(op_value)}"}}}}).'
         )
     validate_value(op_value, kind="frontmatter value")
     return MetadataCondition(key=key, op="ne", value=op_value)

--- a/src/vault_search/parser.py
+++ b/src/vault_search/parser.py
@@ -9,26 +9,19 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import yaml  # type: ignore[import-untyped]
+
 # frontmatter の区切り: --- で始まり --- で終わる YAML ブロック
 _FM_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
-# YAML パーサーが無い環境でも動くよう、軽量な自前パーサーを用意
-# PyYAML があれば使い、なければ簡易パースにフォールバック
-try:
-    import yaml  # type: ignore[import-untyped]
 
-    def _parse_yaml(text: str) -> dict[str, Any]:
-        try:
-            result = yaml.safe_load(text)
-            return result if isinstance(result, dict) else {}
-        except yaml.YAMLError:
-            # Templater テンプレートや壊れた YAML のフォールバック
-            return _parse_yaml_fallback(text)
-
-except ImportError:
-
-    def _parse_yaml(text: str) -> dict[str, Any]:
-        """PyYAML なしの簡易パーサー。key: value の単純構造のみ対応."""
+def _parse_yaml(text: str) -> dict[str, Any]:
+    """PyYAML で frontmatter をパース。壊れていたら fallback に回す."""
+    try:
+        result = yaml.safe_load(text)
+        return result if isinstance(result, dict) else {}
+    except yaml.YAMLError:
+        # Templater テンプレートや壊れた YAML のフォールバック
         return _parse_yaml_fallback(text)
 
 

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -134,6 +134,18 @@ def validate_identifier(
     return name
 
 
+def _validate_strict_int(value: object, name: str) -> None:
+    """Reject non-``int`` *and* ``bool`` (which is a subclass of ``int``).
+
+    ``isinstance(True, int)`` is ``True`` in Python, so a plain ``isinstance``
+    check would silently accept ``True``/``False`` as pagination bounds.
+    Splitting this out keeps the bool-trap reasoning in one place and avoids
+    duplicating the error message across each paginated argument.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValidationError(f"{name} must be an integer, got {type(value).__name__}")
+
+
 def validate_pagination(limit: int, offset: int = 0) -> None:
     """Validate paginated-query bounds, raising on out-of-range values.
 
@@ -142,10 +154,8 @@ def validate_pagination(limit: int, offset: int = 0) -> None:
     non-negative. ``limit`` is capped at :data:`LIMIT_MAX` to keep requests
     aligned with the internal FTS5 cache ceiling.
     """
-    if not isinstance(limit, int) or isinstance(limit, bool):
-        raise ValidationError(f"limit must be an integer, got {type(limit).__name__}")
-    if not isinstance(offset, int) or isinstance(offset, bool):
-        raise ValidationError(f"offset must be an integer, got {type(offset).__name__}")
+    _validate_strict_int(limit, "limit")
+    _validate_strict_int(offset, "offset")
     if limit < 1:
         raise ValidationError(f"limit must be >= 1 (got {limit})")
     if limit > LIMIT_MAX:


### PR DESCRIPTION
## Summary

- **C1 (parser.py)**: pyyaml が hard dep なのに残っていた ``except ImportError`` ブランチを削除。``import yaml`` を top-level へ、``_parse_yaml`` を通常関数として定義し直した。``_parse_yaml_fallback`` は YAMLError 時の救済用途として現役 (Templater / 壊れた YAML 対応) のため維持。
- **C2 (filter.py)**: ``_parse_in`` / ``_parse_ne`` で重複していた非 str スカラーの文字列化 (``"true" if v is True else "false" if v is False else str(v)``) を ``_format_scalar_for_error`` へ抽出。小文字 ``"true"``/``"false"`` が parser の ``_normalize_scalar`` (YAML/JSON 慣例) と揃う意図的選択である旨を docstring に記録。
- **C3 (validation.py)**: ``validate_pagination`` の ``limit``/``offset`` で同一構造の bool-guard + 型チェック + エラーメッセージが重複していたため、raise 込みで ``_validate_strict_int`` へ抽出。``isinstance(True, int)`` の罠の説明を 1 箇所に集約。
- **C4 skip**: envelope key (``"notes"`` / ``"tags"`` / ``"folders"``) の外化は Sonnet/Opus ともに skip 判定 — literal の方が読み手に意図が伝わり、3 key とも値が違うため定数化の旨味もない。

Phase C の進行は ``.claude/rules/tdd-workflow.md`` の Sonnet 計画 → Opus 評価 → 親実装 の 3 段で実施。Opus 評価で C3 の当初案 (``_is_strict_int`` 述語のみ抽出) を「エラーメッセージ重複が残る中途半端」として NO-GO、raise 込み抽出へ差し替え。C2 も関数名 ``_stringify_for_hint`` → ``_format_scalar_for_error`` へリネームした。

## Test plan

- [x] ``.venv/bin/pytest`` — 254 passed
- [x] ``.venv/bin/ruff check`` — clean
- [x] ``.venv/bin/ruff format --check`` — clean
- [x] 各 commit を独立 revert 可能な粒度で分離 (C2 / C3 / C1 の 3 commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)