### PR TITLE
Docs: folder 引数の正規化規則を schema description / docstring に明記 (#74)

### DIFF
--- a/src/vault_search/mcp_contract.py
+++ b/src/vault_search/mcp_contract.py
@@ -77,6 +77,11 @@ _FOLDER_INPUT_SCHEMA: dict[str, Any] = {
         "'Projects Hermes/...' など) は除外される。"
         "vault_folders の結果 (FolderCount.folder) をそのまま渡せる。"
         "root 直下に限定したい場合は現状未サポート (null で全件)。"
+        "末尾 '/' および '\\\\' 区切りは自動で正規化される "
+        "(例: 'Projects/' → 'Projects')。"
+        "スラッシュのみの入力 ('/', '//', '\\\\\\\\') はフィルタなし "
+        "(= folder 指定なしと同等) として扱う。"
+        '例: "Projects"、"Projects/Hermes Agent"、"Projects/"。'
     ),
 }
 

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -92,6 +92,8 @@ def vault_search(
         query: 検索クエリ。スペース区切りで AND 検索。日本語・英語混在可。
         tags: タグフィルタ（例: ["project/hermes-agent", "status/decided"]）。全て AND。
         folder: フォルダプレフィックスフィルタ（例: "Projects/Hermes Agent"）。
+            末尾 '/' および '\\' 区切りは自動で正規化される（例: "Projects/" → "Projects"）。
+            スラッシュのみの入力（'/', '//', '\\\\'）はフィルタなし（= 全件）として扱う。
         limit: 最大返却件数（デフォルト 20）。
         offset: 開始位置（ページネーション用）。
         metadata_filter: frontmatter プロパティでの AND フィルタ。
@@ -156,7 +158,9 @@ def vault_recent(
         offset: ページング用の開始位置（デフォルト 0, >=0）。vault_search と同じ
                 意味論で、最近更新順 (file_mtime DESC) の先頭から offset 件を
                 スキップして limit 件返す。
-        folder: フォルダプレフィックスで絞り込み（例: "Research"）
+        folder: フォルダプレフィックスで絞り込み（例: "Research"）。
+            末尾 '/' および '\\' 区切りは自動で正規化される（例: "Research/" → "Research"）。
+            スラッシュのみの入力（'/', '//', '\\\\'）はフィルタなし（= 全件）として扱う。
 
     Returns:
         常に plain dict を envelope 形式で返す (``{"notes": [dict, ...]}``)。


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `mcp_contract.py` の `_FOLDER_INPUT_SCHEMA.description` に正規化規則を追記
  - `\` → `/` 変換・末尾 `/` の自動 rstrip
  - スラッシュのみ入力（`/`, `//`, `\\`）は folder 指定なしと同等（no-op）
  - 使用例: `"Projects"`, `"Projects/Hermes Agent"`, `"Projects/"`
- `server.py` の `vault_search` / `vault_recent` の `folder:` docstring に同等の注記を追加

## 変更範囲

- `src/vault_search/mcp_contract.py` — `_FOLDER_INPUT_SCHEMA.description`
- `src/vault_search/server.py` — `vault_search` / `vault_recent` の `folder` 引数 docstring

## Test plan

- [ ] `pytest` 全 254 件通過確認済み
- [ ] `ruff check / format` クリーン確認済み
- [ ] 機能変更なし（docs-only）

Closes #74

https://claude.ai/code/session_01TZ7K9UKHyyMFj2r9QmAVZt
EOF
)