### PR TITLE
Test: fix vacuous pass in test_folder_prefix_does_not_match_sibling (#40)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,13 @@ SAMPLE_NOTES: dict[str, str] = {
         "---\n"
         "Research notes about obsidian usage patterns.\n"
     ),
+    # folder prefix テスト用マーカーノート (Projects 配下)
+    # test_folder_prefix_does_not_match_sibling が vacuous pass にならないよう
+    # "obsidian-marker-projects" というユニークトークンで positively ヒットさせる
+    "Projects/marker.md": (
+        "---\ntitle: Projects Marker\n---\n"
+        "obsidian-marker-projects unique token for folder prefix test.\n"
+    ),
     # 除外対象: `_` プレフィックスフォルダ (root level)
     "_archive/old.md": ("---\ntags: [archived]\n---\nArchived content about obsidian.\n"),
     # 除外対象: `.` プレフィックスフォルダ

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -85,8 +85,9 @@ class TestTieredCache:
 
 def test_build_index_counts(vault_index: VaultIndex) -> None:
     stats = vault_index.stats()
-    # `_archive/` と `.trash/` は除外。他 5 件が indexed
-    assert stats["total_notes"] == 5
+    # `_archive/` と `.trash/` は除外。他 6 件が indexed
+    # (Welcome, Projects/日本語ノート, Projects/plain, Projects/marker, malformed, Research/alpha)
+    assert stats["total_notes"] == 6
 
 
 def test_excluded_prefix_folders(vault_index: VaultIndex) -> None:
@@ -296,17 +297,23 @@ def test_list_folders_root_uses_empty_string(vault_index: VaultIndex) -> None:
 
 def test_folder_prefix_does_not_match_sibling(vault_index: VaultIndex, tmp_vault: Path) -> None:
     """folder='Projects' が 'Projects Hermes' のような兄弟を拾わないこと."""
-    # 既存 fixture を壊さない範囲で兄弟フォルダを追加
+    # 兄弟フォルダに同一トークンを含むノートを置く。
+    # folder フィルタが壊れていればこのノートが漏れ込み、アサートが失敗する。
     sibling = tmp_vault / "Projects Hermes" / "note.md"
     sibling.parent.mkdir(parents=True, exist_ok=True)
     sibling.write_text(
-        "---\ntitle: hermes\n---\nunique-hermes-marker content obsidian\n",
+        "---\ntitle: hermes\n---\nobsidian-marker-projects content in sibling\n",
         encoding="utf-8",
     )
     vault_index.build_index()
 
-    # search: folder='Projects' は 'Projects Hermes' 配下をマッチさせない
-    res = vault_index.search("obsidian", folder="Projects")
+    # search: folder='Projects' は 'Projects Hermes' 配下をマッチさせない。
+    # conftest の Projects/marker.md が "obsidian-marker-projects" を含むため
+    # 正しい実装では必ず >= 1 件ヒットする (vacuous pass 防止)。
+    res = vault_index.search("obsidian-marker-projects", folder="Projects")
+    assert len(res["results"]) >= 1, (
+        "Projects/marker.md がヒットしない — fixture または検索の不具合"
+    )
     for r in res["results"]:
         assert r["folder"] == "Projects" or r["folder"].startswith("Projects/"), (
             f"sibling folder leaked in search: {r['folder']}"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -333,9 +333,10 @@ def test_vault_search_rejects_limit_above_max(vault_index: VaultIndex) -> None:
 def test_vault_recent_accepts_offset_parameter(vault_index: VaultIndex) -> None:
     """vault_recent に offset 引数があり、指定分スキップする."""
     fn = _fn(server_mod.vault_recent)
-    full = fn(limit=5)
+    # limit=50 で全件取得し、SAMPLE_NOTES の増減に依存しない形で検証する
+    full = fn(limit=50)
     assert len(full["notes"]) >= 2, "テスト前提: 最低 2 件の recent notes が必要"
-    skipped = fn(limit=5, offset=1)
+    skipped = fn(limit=50, offset=1)
     assert skipped["notes"] == full["notes"][1:], "offset=1 は先頭 1 件を省いた結果を返すこと"
 
 


### PR DESCRIPTION
## Summary

- `Projects/marker.md` を `SAMPLE_NOTES` に追加し、ユニークトークン `"obsidian-marker-projects"` を提供
- 兄弟フォルダ `Projects Hermes/` のノートにも同トークンを配置し、folder フィルタが壊れていれば必ず検出できる構造に変更
- `assert len(results) >= 1` で陽性ガードを追加（vacuous pass を根絶）
- `test_build_index_counts` の期待値を 5 → 6 に更新
- `test_vault_recent_accepts_offset_parameter` の limit を 50 に変更し SAMPLE_NOTES の件数変化に依存しない形に

## 変更ファイル

- `tests/conftest.py` — `Projects/marker.md` を SAMPLE_NOTES へ追加
- `tests/test_indexer.py` — クエリ変更、陽性ガード追加、カウント更新
- `tests/test_server.py` — limit を 50 に変更

## Test plan

- [ ] `pytest tests/test_indexer.py::test_folder_prefix_does_not_match_sibling` がパス
- [ ] `pytest` 全254件がパス
- [ ] `ruff check && ruff format --check` クリーン

Closes #40

https://claude.ai/code/session_01MvY8SkmcqfrHEtPezUzezf