### PR TITLE
Test: metadata_filter LLM ハルシネーション入力 negative tests (Issue #41)

### DIFF
--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -230,3 +230,55 @@ def test_ne_operator_non_string_value_error_hints_stringification() -> None:
     assert "float" in msg
     assert "normalized to strings" in msg
     assert '"4.5"' in msg
+
+
+# ---------------------------------------------------------------------------
+# Negative tests: LLM-hallucinated operator forms (Issue #41)
+#
+# LLM が MongoDB 風演算子 ($in / $eq 等) や非サポート演算子を生成したとき、
+# および in の引数に string を渡したときに ValidationError を送出することを
+# spec として固定化する。
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filter_input",
+    [
+        {"tags": {"$in": ["a", "b"]}},  # MongoDB 風 $ prefix
+        {"tags": {"$eq": "x"}},
+        {"tags": {"$ne": "x"}},
+        {"tags": {"eq": "x"}},  # dict 形式の eq (bare string が正しい)
+        {"tags": {"==": "x"}},  # 比較演算子記号
+        {"tags": {"lt": 1}},  # 未サポート比較演算子
+        {"tags": {"in": "a_string"}},  # in にリストでなく string を渡す
+    ],
+)
+def test_unsupported_operator_raises_validation_error(filter_input: dict) -> None:
+    """LLM がハルシネーションしがちな入力は ValidationError を送出する (Issue #41)."""
+    with pytest.raises(ValidationError):
+        parse_metadata_filter(filter_input)
+
+
+@pytest.mark.parametrize(
+    "filter_input",
+    [
+        {"tags": {"$in": ["a", "b"]}},
+        {"tags": {"$eq": "x"}},
+        {"tags": {"$ne": "x"}},
+        {"tags": {"eq": "x"}},
+        {"tags": {"==": "x"}},
+        {"tags": {"lt": 1}},
+    ],
+)
+def test_invalid_operator_hint_mentions_supported_forms(filter_input: dict) -> None:
+    """未サポート演算子エラーのヒントに対応形式 (in / ne / bare string) が含まれる.
+
+    エージェントがエラーメッセージを読んで自己修正できるよう、
+    サポートされている構文 (ne / in / bare string) がヒントに明示されること。
+    """
+    with pytest.raises(ValidationError) as exc:
+        parse_metadata_filter(filter_input)
+    msg = str(exc.value)
+    assert "in" in msg, f"'in' not found in error message: {msg}"
+    assert "ne" in msg, f"'ne' not found in error message: {msg}"
+    assert "string" in msg, f"'string' not found in error message: {msg}"


### PR DESCRIPTION
## Summary

- `$in` / `$eq` / `$ne` 等 MongoDB 風演算子、dict 形式 `eq`、`==`、`lt`、`in` に string を渡す 7 パターンについて `ValidationError` 送出を `@pytest.mark.parametrize` でそれぞれ固定化 (`test_unsupported_operator_raises_validation_error`)
- 未サポート演算子エラーのメッセージが `in` / `ne` / bare `string` をヒントとして含むことも assert (`test_invalid_operator_hint_mentions_supported_forms`)
- 実装変更なし (`Test:` commit)。現行 `filter.py` が全ケースで既に正しく `ValidationError` を送出することが判明し、spec として pin した形。

## Test plan

- [x] `uv run pytest tests/test_filter.py` — 30 passed
- [x] `uv run pytest` — 267 passed (全スイート)
- [x] `uv run ruff check && uv run ruff format` — clean

Closes #41

https://claude.ai/code/session_01PukpUvDW8YNkcDAizZftvG