### PR TITLE
Fix #13: consolidate Operator Literal as single source of truth in filter.py

### DIFF
--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -20,14 +20,18 @@ frontmatter の任意プロパティを AND 条件で絞り込む dict 構文を
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, get_args
 
 from .validation import ValidationError, validate_identifier, validate_value
 
-__all__ = ["MetadataCondition", "build_sql_fragment", "parse_metadata_filter"]
+__all__ = ["MetadataCondition", "Operator", "build_sql_fragment", "parse_metadata_filter"]
+
+# 演算子の単一 source of truth。``eq`` / ``ne`` / ``in`` の 3 演算子。
+# ``MetadataCondition.op`` と ``_EXPLICIT_OPS`` はここから派生させる。
+Operator = Literal["eq", "ne", "in"]
 
 # 明示的に dict 値で指定できる演算子。``eq`` は str 値による暗黙指定のみ。
-_EXPLICIT_OPS: tuple[str, ...] = ("ne", "in")
+_EXPLICIT_OPS: tuple[str, ...] = tuple(op for op in get_args(Operator) if op != "eq")
 
 
 @dataclass(frozen=True)
@@ -52,7 +56,7 @@ class MetadataCondition:
     """
 
     key: str
-    op: Literal["eq", "ne", "in"]
+    op: Operator
     value: str | tuple[str, ...]
 
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -301,3 +301,43 @@ def test_invalid_operator_hint_mentions_supported_forms(filter_input: dict) -> N
     assert "in" in msg, f"'in' not found in error message: {msg}"
     assert "ne" in msg, f"'ne' not found in error message: {msg}"
     assert "string" in msg, f"'string' not found in error message: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# Operator Literal type consolidation (Issue #13 b)
+# ---------------------------------------------------------------------------
+
+
+def test_operator_literal_exported_from_filter() -> None:
+    """filter.py が Operator 型を公開し、eq/ne/in の 3 演算子を含むこと.
+
+    単一 source of truth として Operator Literal を filter.py で定義し、
+    他箇所が重複定義なしに参照できることを確認する。
+    """
+    import typing
+
+    import vault_search.filter as filter_mod
+
+    assert hasattr(filter_mod, "Operator"), (
+        "filter.py must expose Operator Literal type as single source of truth for operators"
+    )
+    args = set(typing.get_args(filter_mod.Operator))
+    assert args == {"eq", "ne", "in"}, f"Operator must cover exactly eq/ne/in: {args!r}"
+
+
+def test_explicit_ops_derived_from_operator() -> None:
+    """_EXPLICIT_OPS が Operator から eq を除いた派生であること."""
+    import typing
+
+    import vault_search.filter as filter_mod
+
+    assert hasattr(filter_mod, "Operator"), "Operator must be defined to derive _EXPLICIT_OPS"
+    assert hasattr(filter_mod, "_EXPLICIT_OPS"), "_EXPLICIT_OPS must be defined in filter.py"
+
+    expected = frozenset(op for op in typing.get_args(filter_mod.Operator) if op != "eq")
+    actual = frozenset(filter_mod._EXPLICIT_OPS)
+
+    assert actual == expected, (
+        f"_EXPLICIT_OPS {filter_mod._EXPLICIT_OPS!r} must match Operator-minus-eq {expected!r}"
+    )
+    assert "eq" not in filter_mod._EXPLICIT_OPS, "'eq' must not appear in _EXPLICIT_OPS"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Issue #13 (b) の実装。(a) は前回 PR で完了済み。

- `Operator = Literal["eq", "ne", "in"]` を `filter.py` で単一定義し `__all__` に追加
- `_EXPLICIT_OPS` を `tuple(op for op in get_args(Operator) if op != "eq")` で派生させ、ハードコードを除去
- `MetadataCondition.op` の型アノテーションを `Literal["eq", "ne", "in"]` インライン → `Operator` 型参照に統一
- 上記構造を検証する 2 テストを TDD (Red→Green) で追加

## Commits

- `Red:` 失敗テスト追加 (`test_operator_literal_exported_from_filter`, `test_explicit_ops_derived_from_operator`)
- `Green:` 最小実装で通過

## Test plan

- [ ] `uv run pytest` → 256 passed
- [ ] `uv run ruff check --fix && uv run ruff format` → no changes

Closes #13

https://claude.ai/code/session_01Gb6RcxsCjCkswZ1cfGWLya
EOF
)