### PR TITLE
feat: ToolAnnotations.title を全 7 ツールに追加 (Issue #85)

### DIFF
--- a/src/vault_search/mcp_contract.py
+++ b/src/vault_search/mcp_contract.py
@@ -118,8 +118,12 @@ _OFFSET_INPUT_SCHEMA: dict[str, Any] = {
 #     touch しないため該当しない。auto-approve UX で誤警告が出ないよう False。
 #     ``idempotentHint=True`` は同一入力で同一状態に収束することを示す。
 #   - ``openWorldHint=False`` は全ツールでローカル vault のみを扱うため統一。
-_READ_ONLY_ANNOTATIONS = ToolAnnotations(readOnlyHint=True, openWorldHint=False)
+def _read_only(title: str) -> ToolAnnotations:
+    return ToolAnnotations(title=title, readOnlyHint=True, openWorldHint=False)
+
+
 _REINDEX_ANNOTATIONS = ToolAnnotations(
+    title="インデックス再構築",
     readOnlyHint=False,
     destructiveHint=False,
     idempotentHint=True,
@@ -195,7 +199,7 @@ TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
             "required": ["query"],
         },
         output_model=SearchResponse,
-        annotations=_READ_ONLY_ANNOTATIONS,
+        annotations=_read_only("Vault 検索"),
     ),
     "vault_get_note": _ToolSchemaSpec(
         description="指定パスのノート全文とメタデータを取得する。",
@@ -207,7 +211,7 @@ TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
             "required": ["path"],
         },
         output_model=NoteDetail,
-        annotations=_READ_ONLY_ANNOTATIONS,
+        annotations=_read_only("ノート取得"),
     ),
     "vault_recent": _ToolSchemaSpec(
         description="最近更新されたノート一覧を取得する。",
@@ -221,21 +225,21 @@ TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
         },
         output_model=RecentNote,
         envelope_key="notes",
-        annotations=_READ_ONLY_ANNOTATIONS,
+        annotations=_read_only("最近更新ノート"),
     ),
     "vault_tags": _ToolSchemaSpec(
         description="全タグとその使用回数を返す。",
         input_schema={"type": "object", "properties": {}},
         output_model=TagCount,
         envelope_key="tags",
-        annotations=_READ_ONLY_ANNOTATIONS,
+        annotations=_read_only("タグ一覧"),
     ),
     "vault_folders": _ToolSchemaSpec(
         description="フォルダ構造とノート数を返す。",
         input_schema={"type": "object", "properties": {}},
         output_model=FolderCount,
         envelope_key="folders",
-        annotations=_READ_ONLY_ANNOTATIONS,
+        annotations=_read_only("フォルダ一覧"),
     ),
     "vault_reindex": _ToolSchemaSpec(
         description="インデックスを再構築する。",
@@ -250,7 +254,7 @@ TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
         description="インデックスの統計情報を返す。",
         input_schema={"type": "object", "properties": {}},
         output_model=VaultStats,
-        annotations=_READ_ONLY_ANNOTATIONS,
+        annotations=_read_only("インデックス統計"),
     ),
 }
 

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -165,6 +165,57 @@ def test_all_tools_closed_world() -> None:
     assert violations == [], f"tools violating closed-world invariant: {violations}"
 
 
+# Issue #85: ToolAnnotations.title 設定を検証する regression テスト。
+# 各ツールに human-readable な title が付与されていることを確認する。
+_EXPECTED_TITLES: dict[str, str] = {
+    "vault_search": "Vault 検索",
+    "vault_get_note": "ノート取得",
+    "vault_recent": "最近更新ノート",
+    "vault_tags": "タグ一覧",
+    "vault_folders": "フォルダ一覧",
+    "vault_reindex": "インデックス再構築",
+    "vault_stats": "インデックス統計",
+}
+
+
+@pytest.mark.parametrize(("tool_name", "expected_title"), list(_EXPECTED_TITLES.items()))
+def test_tool_annotations_title(tool_name: str, expected_title: str) -> None:
+    """各 tool の MCP annotations.title が human-readable な日本語ラベルを持つ (Issue #85)."""
+    tools = asyncio.run(server_mod.mcp.list_tools())
+    tool = next((t for t in tools if t.name == tool_name), None)
+    assert tool is not None, f"tool not registered: {tool_name}"
+
+    annotations = tool.annotations
+    assert annotations is not None, f"{tool_name} has no annotations"
+    assert annotations.title == expected_title, (
+        f"{tool_name}.title: expected {expected_title!r}, got {annotations.title!r}"
+    )
+
+
+def test_all_tools_have_title() -> None:
+    """MCP list_tools で返る全 tool の annotations.title が設定済みである (Issue #85)."""
+    tools = asyncio.run(server_mod.mcp.list_tools())
+    missing = [
+        t.name
+        for t in tools
+        if t.annotations is None or t.annotations.title is None
+    ]
+    assert missing == [], f"tools without annotations.title: {missing}"
+
+
+def test_schema_tools_resource_exposes_title(vault_index: VaultIndex) -> None:
+    """``schema://tools`` リソースの annotations dict にも title が含まれる (Issue #85)."""
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
+    tools_entries = payload["tools"]
+    for tool_name, expected_title in _EXPECTED_TITLES.items():
+        entry = tools_entries[tool_name]
+        annotations = entry.get("annotations", {})
+        assert annotations.get("title") == expected_title, (
+            f"{tool_name}: schema://tools annotations.title expected {expected_title!r}, "
+            f"got {annotations.get('title')!r}"
+        )
+
+
 def test_schema_tools_resource_exposes_annotations(vault_index: VaultIndex) -> None:
     """``schema://tools`` リソースも各 tool の annotations を公開する.
 

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -195,11 +195,7 @@ def test_tool_annotations_title(tool_name: str, expected_title: str) -> None:
 def test_all_tools_have_title() -> None:
     """MCP list_tools で返る全 tool の annotations.title が設定済みである (Issue #85)."""
     tools = asyncio.run(server_mod.mcp.list_tools())
-    missing = [
-        t.name
-        for t in tools
-        if t.annotations is None or t.annotations.title is None
-    ]
+    missing = [t.name for t in tools if t.annotations is None or t.annotations.title is None]
     assert missing == [], f"tools without annotations.title: {missing}"
 
 


### PR DESCRIPTION
## Summary

- `mcp_contract.py` の各ツールの `ToolAnnotations` に `title` を追加
- Claude Desktop / MCP Inspector 等の UI で human-readable な日本語ラベルが表示されるようになる
- `_read_only(title)` ヘルパーで読み取り専用ツールの annotations を簡潔に構築

| ツール | title |
|---|---|
| `vault_search` | Vault 検索 |
| `vault_get_note` | ノート取得 |
| `vault_recent` | 最近更新ノート |
| `vault_tags` | タグ一覧 |
| `vault_folders` | フォルダ一覧 |
| `vault_reindex` | インデックス再構築 |
| `vault_stats` | インデックス統計 |

## 実装方針

`_READ_ONLY_ANNOTATIONS` (共有インスタンス) を `_read_only(title: str)` ヘルパーに置き換え、各ツールで個別の `ToolAnnotations` を生成。`_REINDEX_ANNOTATIONS` にも `title` を付与。

`_build_tool_entry` で `annotations.model_dump(exclude_none=True)` を呼ぶ既存実装により、`schema://tools` リソースへの公開も自動で同期される。

## Test plan

- [x] `test_tool_annotations_title` — 各ツールの `annotations.title` が期待値と一致 (パラメータ化)
- [x] `test_all_tools_have_title` — 全ツールに `title` が設定済みであることを確認
- [x] `test_schema_tools_resource_exposes_title` — `schema://tools` リソースにも `title` が含まれる
- [x] 既存 annotation テスト (263 tests) 全通過
- [x] ruff check/format クリーン

Closes #85

https://claude.ai/code/session_01XfuTJqBPQ4LSWvkbFczcoa