### PR TITLE
Test: ne 演算子配列型境界値テスト追加 (Issue #43)

### DIFF
--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -107,6 +107,57 @@ def test_ne_array_excludes_element_containing(conn: sqlite3.Connection) -> None:
 
 
 # ---------------------------------------------------------------------------
+# ne 配列型境界値テスト (Issue #43)
+#
+# 仕様まとめ:
+#   - 空配列 []         : key が存在し要素が一切ない → ne にマッチ
+#   - 1 要素一致        : 配列内に value が見つかる → 除外
+#   - 多要素 (一致含む) : 1 つでも value を含めば → 除外
+#   - 重複要素          : NOT EXISTS は重複の有無を問わず同じ → 除外
+#   - キー missing      : IS NOT NULL ガードで除外 (eq と対称の 3 値論理)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fm, ne_value, should_match",
+    [
+        ({"tags": []}, "x", True),
+        ({"tags": ["x"]}, "x", False),
+        ({"tags": ["x", "y", "z"]}, "x", False),
+        ({"tags": ["x", "x"]}, "x", False),
+        ({"other": "y"}, "x", False),
+    ],
+    ids=[
+        "empty-array",
+        "single-element-match",
+        "multi-element-has-match",
+        "duplicate-elements",
+        "missing-key",
+    ],
+)
+def test_ne_array_boundary_values(
+    conn: sqlite3.Connection,
+    fm: dict[str, object],
+    ne_value: str,
+    should_match: bool,
+) -> None:
+    """ne 演算子の配列型境界値テスト (Issue #43).
+
+    仕様:
+    - 空配列はマッチ: key が存在し value を含まない → NOT EXISTS = True
+    - 配列内に value が存在すれば除外 (1 要素 / 多要素 / 重複どれも同様)
+    - キー missing は eq/ne 両方からマッチしない (3 値論理)
+    """
+    conn.execute("INSERT INTO notes VALUES (?, ?)", ("target.md", json.dumps(fm)))
+    conn.commit()
+    hits = _select(conn, MetadataCondition("tags", "ne", ne_value))
+    if should_match:
+        assert "target.md" in hits, f"target.md (fm={fm!r}) should match ne={ne_value!r}"
+    else:
+        assert "target.md" not in hits, f"target.md (fm={fm!r}) should not match ne={ne_value!r}"
+
+
+# ---------------------------------------------------------------------------
 # in
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `ne` 演算子の配列型境界値テストが欠落していた問題 (Issue #43) を修正
- `@pytest.mark.parametrize` で以下 5 ケースを列挙し、仕様を明示
  - 空配列 `[]` → `ne: "x"` → **マッチ** (要素なし = NOT EXISTS が True)
  - 1 要素一致 `["x"]` → `ne: "x"` → 除外
  - 多要素一致含む `["x","y","z"]` → `ne: "x"` → 除外
  - 重複要素 `["x","x"]` → `ne: "x"` → 除外
  - キー missing → `ne: "x"` → 除外 (3 値論理、eq と対称)

## 設計判断

- 空配列の `ne` マッチは SQL の `NOT EXISTS(json_each([]) WHERE value=?)` が
  True を返す挙動と一致。docstring に明記。
- キー missing は IS NOT NULL ガードで除外 (既存仕様と変更なし)。

## Test plan

- [ ] `pytest tests/test_filter.py` — 22 passed (新規 5 ケース含む)
- [ ] `pytest` フルスイート — 259 passed

Closes #43

https://claude.ai/code/session_011uZjRh3FJbWr6WeZV8iAqZ