### PR TITLE
Test: MCP convert_result 経路での int/bool frontmatter filter regression guard (Issue #90)

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -346,3 +347,113 @@ def test_vault_recent_rejects_negative_offset(vault_index: VaultIndex) -> None:
     fn = _fn(server_mod.vault_recent)
     with pytest.raises((ValueError, ValidationError)):
         fn(limit=5, offset=-1)
+
+
+# ---------------------------------------------------------------------------
+# Issue #90: int / bool frontmatter filter の MCP convert_result 経路 regression guard
+# VaultIndex.search 直接呼び出しでは FastMCP の convert_result / structuredContent
+# シリアライズを通らないため、MCP tool 経由での別途 guard が必要。
+# ---------------------------------------------------------------------------
+
+_INT_BOOL_NOTES: dict[str, str] = {
+    "hi.md": (
+        "---\n"
+        "title: High Priority\n"
+        "priority: 5\n"
+        "published: true\n"
+        "---\n"
+        "High priority note with numeric frontmatter.\n"
+    ),
+    "lo.md": (
+        "---\n"
+        "title: Low Priority\n"
+        "priority: 1\n"
+        "published: false\n"
+        "---\n"
+        "Low priority note with different values.\n"
+    ),
+}
+
+
+@pytest.fixture
+def _vault_index_with_int(tmp_path: Path) -> VaultIndex:
+    """int/bool フロントマター付きの一時 Vault を作る local fixture.
+
+    SAMPLE_NOTES を汚染しないよう独立した tmp_path サブディレクトリを使う
+    (conftest.py の ``vault_index`` fixture と db ファイル名が衝突しないよう
+    ``int_vault/`` / ``int_test.db`` で分離)。
+    """
+    root = tmp_path / "int_vault"
+    root.mkdir()
+    for rel, body in _INT_BOOL_NOTES.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+    db_path = tmp_path / "int_test.db"
+    idx = VaultIndex(root, db_path=db_path)
+    idx.build_index()
+    return idx
+
+
+def test_mcp_tool_vault_search_metadata_filter_int(
+    _vault_index_with_int: VaultIndex,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """int frontmatter の eq filter が _fn 経路で機能する."""
+    monkeypatch.setattr(server_mod, "_index", _vault_index_with_int)
+    fn = _fn(server_mod.vault_search)
+    res = fn("", None, None, 20, 0, {"priority": "5"})
+    assert isinstance(res, dict)
+    paths = {hit["path"] for hit in res["results"]}
+    assert "hi.md" in paths
+    assert "lo.md" not in paths
+
+
+def test_mcp_tool_vault_search_metadata_filter_bool(
+    _vault_index_with_int: VaultIndex,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """bool frontmatter の eq filter が _fn 経路で機能する."""
+    monkeypatch.setattr(server_mod, "_index", _vault_index_with_int)
+    fn = _fn(server_mod.vault_search)
+    res = fn("", None, None, 20, 0, {"published": "true"})
+    assert isinstance(res, dict)
+    paths = {hit["path"] for hit in res["results"]}
+    assert "hi.md" in paths
+    assert "lo.md" not in paths
+
+
+def test_mcp_convert_result_vault_search_metadata_filter_int(
+    _vault_index_with_int: VaultIndex,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """int frontmatter filter が FastMCP convert_result 経路で正しくシリアライズされる guard.
+
+    VaultIndex.search 直呼びでは通らない FastMCP の structuredContent 経路を
+    明示的に通すことで、将来 MCP 層で silent degradation が起きても検知できる。
+    """
+    monkeypatch.setattr(server_mod, "_index", _vault_index_with_int)
+    structured = _call_tool_structured(
+        "vault_search",
+        {"query": "", "metadata_filter": {"priority": "5"}},
+    )
+    assert isinstance(structured, dict)
+    paths = {hit["path"] for hit in structured["results"]}
+    assert "hi.md" in paths
+    assert "lo.md" not in paths
+
+
+def test_mcp_convert_result_vault_search_metadata_filter_bool(
+    _vault_index_with_int: VaultIndex,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """bool frontmatter filter が FastMCP convert_result 経路で正しくシリアライズされる guard."""
+    monkeypatch.setattr(server_mod, "_index", _vault_index_with_int)
+    structured = _call_tool_structured(
+        "vault_search",
+        {"query": "", "metadata_filter": {"published": "true"}},
+    )
+    assert isinstance(structured, dict)
+    paths = {hit["path"] for hit in structured["results"]}
+    assert "hi.md" in paths
+    assert "lo.md" not in paths


### PR DESCRIPTION
## Summary

- `tests/test_server.py` に int/bool frontmatter filter の regression guard テストを追加 (Issue #90)
- `_fn` 経路 2 件 + FastMCP `convert_result` 経路 2 件の計 4 テスト
- `_INT_BOOL_NOTES` / `_vault_index_with_int` local fixture を追加 (SAMPLE_NOTES 汚染なし)

## 背景

PR #70 で追加された `test_metadata_filter_matches_int_frontmatter` 等は `VaultIndex.search` を直接呼ぶ経路であり、FastMCP の `convert_result` / structuredContent serialization を経由しない。本 PR は MCP tool 経路でのシリアライズを明示的にカバーし、将来の silent degradation を検知できるようにする。

## 変更内容

**`tests/test_server.py`**
- `_INT_BOOL_NOTES`: `priority: 5` (int) / `published: true` (bool) を持つ 2 件の local fixture データ
- `_vault_index_with_int` fixture: 独立サブディレクトリ (`int_vault/`, `int_test.db`) に構築、SAMPLE_NOTES と分離
- `test_mcp_tool_vault_search_metadata_filter_int`: `_fn` 経路での int filter
- `test_mcp_tool_vault_search_metadata_filter_bool`: `_fn` 経路での bool filter
- `test_mcp_convert_result_vault_search_metadata_filter_int`: `_call_tool_structured` 経路での int filter guard
- `test_mcp_convert_result_vault_search_metadata_filter_bool`: `_call_tool_structured` 経路での bool filter guard

## Test plan

- [x] 新規 4 テスト全 PASSED
- [x] 全テストスイート 258 passed
- [x] `ruff check` / `ruff format --check` クリーン

Closes #90

https://claude.ai/code/session_01WvESwTWswvWYJ19r2AZ2y8