### PR TITLE
fix: Tier 1 fuzzy 境界値テストを挟み撃ちに改善 (issue #24)

### DIFF
--- a/src/vault_search/cache.py
+++ b/src/vault_search/cache.py
@@ -56,7 +56,11 @@ class TieredCache:
     def get(
         self, query: str, filters: dict[str, Any] | None = None
     ) -> tuple[int, list[dict[str, Any]] | None]:
-        """キャッシュ検索。返り値: (tier, results). tier=-1 はミス."""
+        """キャッシュ検索。返り値: (tier, results). tier=-1 はミス。
+
+        Tier 1 (fuzzy) は Jaccard 類似度 >= fuzzy_threshold のとき適用。
+        境界値 (= threshold) はヒット扱い。フィルタ付きクエリは Tier 1 をスキップ。
+        """
         now = time.monotonic()
         key = self._cache_key(query, filters)
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -26,14 +26,14 @@ class TestTieredCache:
         assert got == result
 
     def test_tier1_fuzzy_hit(self) -> None:
-        """Jaccard >= 0.8 で類似クエリがヒットする."""
+        """threshold を明確に上回る Jaccard (9/10=0.9) でヒットする."""
         cache = TieredCache(fuzzy_threshold=0.8)
-        # tokens: {"alpha", "beta", "gamma", "delta"}
         result = [{"path": "a.md"}]
-        cache.put("alpha beta gamma delta", None, result)
-        # tokens: {"alpha", "beta", "gamma", "delta", "epsilon"}
-        # intersection=4, union=5 → 0.8 (境界)
-        tier, got = cache.get("alpha beta gamma delta epsilon", None)
+        # tokens: {"a","b","c","d","e","f","g","h","i"} — 9 tokens
+        cache.put("a b c d e f g h i", None, result)
+        # tokens: {"a","b","c","d","e","f","g","h","i","j"} — 10 tokens
+        # intersection=9, union=10 → Jaccard=9/10=0.9 > 0.8
+        tier, got = cache.get("a b c d e f g h i j", None)
         assert tier == 1
         assert got == result
 
@@ -224,10 +224,10 @@ def test_search_tier0_cache_hit(vault_index: VaultIndex) -> None:
 
 
 def test_search_tier1_fuzzy(vault_index: VaultIndex) -> None:
-    """類似クエリは Tier 1 fuzzy hit."""
-    vault_index.search("alpha beta gamma delta")
-    res = vault_index.search("alpha beta gamma delta epsilon")
-    # Jaccard = 4/5 = 0.8 → ヒット
+    """threshold を上回る Jaccard (5/6≈0.833) で Tier 1 fuzzy hit."""
+    vault_index.search("alpha beta gamma delta epsilon")
+    res = vault_index.search("alpha beta gamma delta epsilon zeta")
+    # intersection=5, union=6 → Jaccard=5/6≈0.833 > 0.8 → ヒット
     assert res["tier"] == 1
 
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -37,6 +37,28 @@ class TestTieredCache:
         assert tier == 1
         assert got == result
 
+    def test_tier1_fuzzy_hit_at_threshold(self) -> None:
+        """Jaccard が threshold 丁度 (4/5=0.8) でもヒットする — >= semantics を pin."""
+        cache = TieredCache(fuzzy_threshold=0.8)
+        result = [{"path": "a.md"}]
+        cache.put("alpha beta gamma delta", None, result)
+        # intersection=4, union=5 → Jaccard=4/5=0.8 (= threshold)
+        tier, got = cache.get("alpha beta gamma delta epsilon", None)
+        assert tier == 1
+        assert got == result
+
+    def test_tier1_fuzzy_miss_just_below_threshold(self) -> None:
+        """Jaccard が threshold 未満 (7/9≈0.778) でミスになる."""
+        cache = TieredCache(fuzzy_threshold=0.8)
+        result = [{"path": "a.md"}]
+        # tokens: {"a","b","c","d","e","f","g"} — 7 tokens
+        cache.put("a b c d e f g", None, result)
+        # tokens: {"a","b","c","d","e","f","g","h","i"} — 9 tokens
+        # intersection=7, union=9 → Jaccard=7/9≈0.778 < 0.8
+        tier, got = cache.get("a b c d e f g h i", None)
+        assert tier == -1
+        assert got is None
+
     def test_tier2_miss_low_similarity(self) -> None:
         cache = TieredCache(fuzzy_threshold=0.8)
         cache.put("alpha beta", None, [{"path": "a"}])


### PR DESCRIPTION
## Summary

Closes #24

- **`Test:` コミット**: Jaccard=0.8 境界ジャストを両側から pin する 2 つのガードテストを追加
  - `test_tier1_fuzzy_hit_at_threshold`: Jaccard=4/5=0.8 (= threshold) でもヒット → `>=` semantics を明示 pin
  - `test_tier1_fuzzy_miss_just_below_threshold`: Jaccard=7/9≈0.778 (< threshold) でミス → 下側ガード
- **`Refactor:` コミット**: 既存の境界ジャスト値テストを余裕のある値に更新 + 仕様コメント追記
  - `test_tier1_fuzzy_hit`: Jaccard 0.8 → **9/10=0.9** (threshold を明確に上回る)
  - `test_search_tier1_fuzzy`: Jaccard 4/5=0.8 → **5/6≈0.833**
  - `cache.py TieredCache.get()` docstring: `>= fuzzy_threshold` の意味と境界はヒット扱いを明文化

## Test plan

- [ ] `pytest tests/test_indexer.py` — 59 件通過 (新規 2 件含む)
- [ ] `pytest` — 256 件全通過
- [ ] `ruff check` / `ruff format` — クリーン

https://claude.ai/code/session_01PayX2uC8mNMWVa6YdLKydG