### PR TITLE
fix: VaultWatcher rename/reindex ログ observability 改善 (#78)

### DIFF
--- a/src/vault_search/watcher.py
+++ b/src/vault_search/watcher.py
@@ -46,14 +46,17 @@ class VaultWatcher:
 
             def _schedule_if_valid(raw_path: str) -> None:
                 if not raw_path.endswith(".md"):
+                    logger.debug("skipped non-.md path: %s", raw_path)
                     return
                 try:
                     rel = str(Path(raw_path).relative_to(watcher._index.vault_root)).replace(
                         "\\", "/"
                     )
                 except ValueError:
+                    logger.debug("skipped path outside vault: %s", raw_path)
                     return
                 if any(p.startswith(".") or p.startswith("_") for p in Path(rel).parts):
+                    logger.debug("skipped excluded path: %s", rel)
                     return
                 watcher._schedule_update(rel)
 
@@ -64,6 +67,11 @@ class VaultWatcher:
                     # FileMovedEvent はリネーム/移動。src_path (旧) と
                     # dest_path (新) の両方をインデックス更新対象にする (#58)。
                     if isinstance(event, FileMovedEvent):
+                        logger.info(
+                            "rename detected: %s -> %s",
+                            event.src_path,
+                            event.dest_path,
+                        )
                         _schedule_if_valid(event.src_path)
                         _schedule_if_valid(event.dest_path)
                         return
@@ -102,9 +110,10 @@ class VaultWatcher:
             paths = list(self._pending.keys())
             self._pending.clear()
 
-        for rel_path in paths:
+        n = len(paths)
+        for i, rel_path in enumerate(paths):
             try:
                 self._index.update_single(rel_path)
-                logger.debug("Updated index: %s", rel_path)
+                logger.info("indexed: %s (pending=%d)", rel_path, n - i - 1)
             except Exception:
                 logger.exception("Failed to update index for %s", rel_path)

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -153,3 +154,69 @@ def test_watcher_removes_on_delete(vault: Path, index: VaultIndex) -> None:
     with _running_watcher(index):
         note.unlink()
         assert _wait_until(lambda: not _indexed(index, "gone.md"))
+
+
+# ---------------------------------------------------------------------------
+# Logging observability — issue #78
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_logs_rename_detected_at_info(
+    vault: Path, index: VaultIndex, caplog: pytest.LogCaptureFixture
+) -> None:
+    """FileMovedEvent で logger.info('rename detected: ...') が出ること (#78)."""
+    src = vault / "A.md"
+    src.write_text("# A\nbody\n", encoding="utf-8")
+    index.build_index()
+    dest = vault / "B.md"
+
+    with caplog.at_level(logging.INFO, logger="vault_search.watcher"):
+        with _running_watcher(index):
+            src.rename(dest)
+            _wait_until(lambda: _indexed(index, "B.md"))
+
+    info_msgs = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    assert any("rename detected" in m for m in info_msgs), (
+        f"Expected 'rename detected' in INFO logs, got: {info_msgs}"
+    )
+
+
+def test_watcher_logs_indexed_at_info_on_flush(
+    vault: Path, index: VaultIndex, caplog: pytest.LogCaptureFixture
+) -> None:
+    """_flush 成功後に logger.info('indexed: ...') が出ること (#78)."""
+    index.build_index()
+
+    with caplog.at_level(logging.INFO, logger="vault_search.watcher"):
+        with _running_watcher(index):
+            note = vault / "new_note.md"
+            note.write_text("# New\nbody\n", encoding="utf-8")
+            _wait_until(lambda: _indexed(index, "new_note.md"))
+
+    info_msgs = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    assert any("indexed:" in m for m in info_msgs), (
+        f"Expected 'indexed:' in INFO logs, got: {info_msgs}"
+    )
+
+
+def test_watcher_logs_debug_on_hidden_dest_exclusion(
+    vault: Path, index: VaultIndex, caplog: pytest.LogCaptureFixture
+) -> None:
+    """隠しフォルダへの rename で dest_path 除外時に logger.debug が出ること (#78)."""
+    src = vault / "note.md"
+    src.write_text("# N\n", encoding="utf-8")
+    index.build_index()
+    hidden_dir = vault / ".archive"
+    hidden_dir.mkdir()
+
+    with caplog.at_level(logging.DEBUG, logger="vault_search.watcher"):
+        with _running_watcher(index):
+            src.rename(hidden_dir / "note.md")
+            # src 側の update_single が走るまで待つ
+            _wait_until(lambda: not _indexed(index, "note.md"))
+            time.sleep(0.2)  # dest 除外の debug log が出る余裕を持たせる
+
+    debug_msgs = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+    assert any(".archive" in m or "excluded" in m or "skip" in m for m in debug_msgs), (
+        f"Expected exclusion debug log for hidden dest, got: {debug_msgs}"
+    )


### PR DESCRIPTION
## Summary

- `FileMovedEvent` 分岐で `logger.info("rename detected: %s -> %s")` を追加し、rename イベントを既定ログレベルで可視化
- `_schedule_if_valid` の各早期 return (非.md / vault 外パス / 隠し・アンダースコアパス) に `logger.debug` を追加し、無音 drop を解消
- `_flush` 成功ログを `logger.debug` → `logger.info("indexed: %s (pending=%d)")` に昇格し、インデックス更新の確認が容易に

## Test plan

- [ ] `test_watcher_logs_rename_detected_at_info` — FileMovedEvent で INFO "rename detected" が出ること
- [ ] `test_watcher_logs_indexed_at_info_on_flush` — _flush 成功で INFO "indexed:" が出ること
- [ ] `test_watcher_logs_debug_on_hidden_dest_exclusion` — 隠しフォルダへの rename で dest 除外時に DEBUG が出ること
- [ ] 既存 watcher テスト 7 件がすべて通ること (regression なし)

closes #78

https://claude.ai/code/session_01ED44C7oqa8oDiQLZRi7rAA