### PR TITLE
fix: ValidationError.error_code の ClassVar shadowing を修正 (issue #122)

### DIFF
--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import re
 from collections.abc import Sequence
-from typing import ClassVar
 
 from .exceptions import VaultSearchError
 
@@ -79,8 +78,7 @@ class ValidationError(VaultSearchError, ValueError):
     message:
         Human-readable description of the validation failure.
     error_code:
-        Optional override for the class-level ``error_code`` attribute.
-        When provided, the instance shadows the class attribute.
+        Per-instance error code; defaults to ``"VALIDATION_ERROR"``.
     hint:
         Optional short guidance for self-correction (e.g. "see schema://tools").
     did_you_mean:
@@ -89,21 +87,19 @@ class ValidationError(VaultSearchError, ValueError):
         Optional sorted list of all allowed values / keys.
     """
 
-    error_code: ClassVar[str] = "VALIDATION_ERROR"
+    error_code: str = "VALIDATION_ERROR"
 
     def __init__(
         self,
         message: str,
         *,
-        error_code: str | None = None,
+        error_code: str = "VALIDATION_ERROR",
         hint: str | None = None,
         did_you_mean: Sequence[str] | None = None,
         allowed: Sequence[str] | None = None,
     ) -> None:
         super().__init__(message)
-        if error_code is not None:
-            # instance attribute shadows the class-level ClassVar
-            self.error_code = error_code
+        self.error_code = error_code
         self.hint = hint
         self.did_you_mean: tuple[str, ...] = tuple(did_you_mean) if did_you_mean else ()
         self.allowed: tuple[str, ...] = tuple(allowed) if allowed else ()


### PR DESCRIPTION
## 概要

issue #122 で報告された `ClassVar[str]` + instance attribute shadowing を修正する。

## 問題

`validation.py` の `ValidationError` が次の矛盾した宣言を持っていた:

```python
error_code: ClassVar[str] = "VALIDATION_ERROR"  # ClassVar として宣言

def __init__(self, ...):
    if error_code is not None:
        self.error_code = error_code  # mypy: cannot assign to ClassVar on instance
```

Python runtime では動作するが、mypy は ClassVar への instance assignment を reject する。型チェック CI 導入時に破綻するため事前修正。

## 修正内容 (issue 推奨 option b)

`ClassVar` 制約を外し、通常の class attribute + instance attribute パターンに変更:

```python
# ClassVar[str] → str
error_code: str = "VALIDATION_ERROR"

def __init__(
    self,
    message: str,
    *,
    error_code: str = "VALIDATION_ERROR",  # str | None → str (default 明示)
    ...
) -> None:
    super().__init__(message)
    self.error_code = error_code  # 常時 assign、conditional 不要
    ...
```

## 影響範囲

- クラス属性 `error_code = "VALIDATION_ERROR"` は残るため `ValidationError.error_code` の class-level アクセスは変わらず動作
- `__init__` 引数の型が `str | None` → `str` に変わるが、既存の呼び出し (`error_code="SOME_CODE"` または省略) は全て互換

## テスト

- 388 tests pass (変更なし)
- ruff lint / format clean
- `from typing import ClassVar` を `validation.py` から除去 (未使用)

Closes #122