### PR TITLE
Phase D3: metadata_filter schema 強化 — propertyNames + single-operator description (#75 #36)

### DIFF
--- a/src/vault_search/mcp_contract.py
+++ b/src/vault_search/mcp_contract.py
@@ -29,7 +29,7 @@ from .schemas import (
     TagCount,
     VaultStats,
 )
-from .validation import LIMIT_MAX
+from .validation import IDENTIFIER_JSON_PATTERN, IDENTIFIER_MAX_LEN, LIMIT_MAX
 
 __all__ = [
     "TOOL_ENTRIES",
@@ -158,6 +158,7 @@ TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
                         "frontmatter の各キーに対する AND フィルタ条件。"
                         "キーは frontmatter プロパティ名。値は str (暗黙 eq) または "
                         '{"in": list[str]} / {"ne": str}。'
+                        "各キーにつき exactly one operator (str / in / ne のいずれか 1 つ) を指定すること。"
                         '例: {"status": "active", "priority": {"in": ["high"]}}。'
                         "比較値は常に文字列。frontmatter のスカラーは index 時に正規化される: "
                         'int 5→"5" / float 4.5→"4.5" / bool true→"true" false→"false" / '
@@ -171,6 +172,10 @@ TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
                         "数値・日付の範囲比較 (gt/lt/gte) は未対応 — 必要なら取得後に"
                         "クライアント側でフィルタすること。"
                     ),
+                    "propertyNames": {
+                        "pattern": IDENTIFIER_JSON_PATTERN,
+                        "maxLength": IDENTIFIER_MAX_LEN,
+                    },
                     "additionalProperties": {
                         "oneOf": [
                             {

--- a/src/vault_search/mcp_contract.py
+++ b/src/vault_search/mcp_contract.py
@@ -158,7 +158,8 @@ TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
                         "frontmatter の各キーに対する AND フィルタ条件。"
                         "キーは frontmatter プロパティ名。値は str (暗黙 eq) または "
                         '{"in": list[str]} / {"ne": str}。'
-                        "各キーにつき exactly one operator (str / in / ne のいずれか 1 つ) を指定すること。"
+                        "各キーにつき exactly one operator "
+                        "(str / in / ne のいずれか 1 つ) を指定すること。"
                         '例: {"status": "active", "priority": {"in": ["high"]}}。'
                         "比較値は常に文字列。frontmatter のスカラーは index 時に正規化される: "
                         'int 5→"5" / float 4.5→"4.5" / bool true→"true" false→"false" / '

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -29,6 +29,8 @@ from typing import ClassVar
 from .exceptions import VaultSearchError
 
 __all__ = [
+    "IDENTIFIER_JSON_PATTERN",
+    "IDENTIFIER_MAX_LEN",
     "LIMIT_MAX",
     "ValidationError",
     "validate_identifier",
@@ -65,6 +67,12 @@ _CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
 # targets may be free-form human text.
 _DEFAULT_IDENTIFIER_MAX_LEN = 128
 _DEFAULT_VALUE_MAX_LEN = 1024
+
+# Public constants derived from the private definitions above.
+# Single source of truth for JSON Schema constraints that must match the
+# runtime validation logic (used in mcp_contract.py for ``propertyNames``).
+IDENTIFIER_JSON_PATTERN = _IDENTIFIER_RE.pattern
+IDENTIFIER_MAX_LEN = _DEFAULT_IDENTIFIER_MAX_LEN
 
 
 class ValidationError(VaultSearchError, ValueError):

--- a/tests/test_mcp_contract.py
+++ b/tests/test_mcp_contract.py
@@ -53,21 +53,25 @@ def test_metadata_filter_has_property_names() -> None:
 
 
 def test_property_names_pattern_matches_validation() -> None:
-    """propertyNames["pattern"] が validation.IDENTIFIER_JSON_PATTERN と同値であること (単一ソース真実性)."""
+    """propertyNames.pattern が IDENTIFIER_JSON_PATTERN と同値."""
     from vault_search.mcp_contract import TOOL_SPECS
-    from vault_search.validation import IDENTIFIER_JSON_PATTERN  # type: ignore[attr-defined]
+    from vault_search.validation import IDENTIFIER_JSON_PATTERN
 
-    mf_schema = TOOL_SPECS["vault_search"].input_schema["properties"]["metadata_filter"]
-    assert mf_schema["propertyNames"]["pattern"] == IDENTIFIER_JSON_PATTERN
+    mf = TOOL_SPECS["vault_search"].input_schema["properties"]
+    assert mf["metadata_filter"]["propertyNames"]["pattern"] == (
+        IDENTIFIER_JSON_PATTERN
+    )
 
 
 def test_property_names_max_length_matches_validation() -> None:
-    """propertyNames["maxLength"] が validation.IDENTIFIER_MAX_LEN と同値であること (単一ソース真実性)."""
+    """propertyNames.maxLength が IDENTIFIER_MAX_LEN と同値."""
     from vault_search.mcp_contract import TOOL_SPECS
-    from vault_search.validation import IDENTIFIER_MAX_LEN  # type: ignore[attr-defined]
+    from vault_search.validation import IDENTIFIER_MAX_LEN
 
-    mf_schema = TOOL_SPECS["vault_search"].input_schema["properties"]["metadata_filter"]
-    assert mf_schema["propertyNames"]["maxLength"] == IDENTIFIER_MAX_LEN
+    mf = TOOL_SPECS["vault_search"].input_schema["properties"]
+    assert mf["metadata_filter"]["propertyNames"]["maxLength"] == (
+        IDENTIFIER_MAX_LEN
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -76,14 +80,18 @@ def test_property_names_max_length_matches_validation() -> None:
 
 
 def test_metadata_filter_description_mentions_single_operator() -> None:
-    """metadata_filter の description に「キーごとに演算子は 1 つ」の制約が明記されていること (Issue #36)."""
+    """metadata_filter description に 1-operator-per-key 制約が明記."""
     from vault_search.mcp_contract import TOOL_SPECS
 
-    desc: str = TOOL_SPECS["vault_search"].input_schema["properties"]["metadata_filter"]["description"]
+    props = TOOL_SPECS["vault_search"].input_schema["properties"]
+    desc: str = props["metadata_filter"]["description"]
     # "1 operator", "one operator", "exactly one" のいずれかを含む
     desc_lower = desc.lower()
     assert (
         "1 operator" in desc_lower
         or "one operator" in desc_lower
         or "exactly one" in desc_lower
-    ), f"metadata_filter description does not mention single-operator-per-key constraint: {desc!r}"
+    ), (
+        "metadata_filter description does not mention "
+        f"single-operator-per-key constraint: {desc!r}"
+    )

--- a/tests/test_mcp_contract.py
+++ b/tests/test_mcp_contract.py
@@ -22,3 +22,68 @@ def test_limit_input_schema_description_references_limit_max() -> None:
     from vault_search.validation import LIMIT_MAX
 
     assert str(LIMIT_MAX) in _LIMIT_INPUT_SCHEMA["description"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #75: propertyNames constraint
+# ---------------------------------------------------------------------------
+
+
+def test_identifier_json_pattern_exported() -> None:
+    """IDENTIFIER_JSON_PATTERN が validation モジュールから import 可能で非空文字列であること."""
+    from vault_search.validation import IDENTIFIER_JSON_PATTERN  # type: ignore[attr-defined]
+
+    assert isinstance(IDENTIFIER_JSON_PATTERN, str)
+    assert len(IDENTIFIER_JSON_PATTERN) > 0
+
+
+def test_identifier_max_len_exported() -> None:
+    """IDENTIFIER_MAX_LEN が validation モジュールから import 可能で 128 であること."""
+    from vault_search.validation import IDENTIFIER_MAX_LEN  # type: ignore[attr-defined]
+
+    assert IDENTIFIER_MAX_LEN == 128
+
+
+def test_metadata_filter_has_property_names() -> None:
+    """metadata_filter スキーマに propertyNames キーが存在すること (Issue #75)."""
+    from vault_search.mcp_contract import TOOL_SPECS
+
+    mf_schema = TOOL_SPECS["vault_search"].input_schema["properties"]["metadata_filter"]
+    assert "propertyNames" in mf_schema
+
+
+def test_property_names_pattern_matches_validation() -> None:
+    """propertyNames["pattern"] が validation.IDENTIFIER_JSON_PATTERN と同値であること (単一ソース真実性)."""
+    from vault_search.mcp_contract import TOOL_SPECS
+    from vault_search.validation import IDENTIFIER_JSON_PATTERN  # type: ignore[attr-defined]
+
+    mf_schema = TOOL_SPECS["vault_search"].input_schema["properties"]["metadata_filter"]
+    assert mf_schema["propertyNames"]["pattern"] == IDENTIFIER_JSON_PATTERN
+
+
+def test_property_names_max_length_matches_validation() -> None:
+    """propertyNames["maxLength"] が validation.IDENTIFIER_MAX_LEN と同値であること (単一ソース真実性)."""
+    from vault_search.mcp_contract import TOOL_SPECS
+    from vault_search.validation import IDENTIFIER_MAX_LEN  # type: ignore[attr-defined]
+
+    mf_schema = TOOL_SPECS["vault_search"].input_schema["properties"]["metadata_filter"]
+    assert mf_schema["propertyNames"]["maxLength"] == IDENTIFIER_MAX_LEN
+
+
+# ---------------------------------------------------------------------------
+# Issue #36: oneOf description improvement
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_filter_description_mentions_single_operator() -> None:
+    """metadata_filter の description に「キーごとに演算子は 1 つ」の制約が明記されていること (Issue #36)."""
+    from vault_search.mcp_contract import TOOL_SPECS
+
+    desc: str = TOOL_SPECS["vault_search"].input_schema["properties"]["metadata_filter"]["description"]
+    # "1 operator", "one operator", "exactly one" のいずれかを含む
+    desc_lower = desc.lower()
+    assert (
+        "1 operator" in desc_lower
+        or "one operator" in desc_lower
+        or "exactly one" in desc_lower
+    ), f"metadata_filter description does not mention single-operator-per-key constraint: {desc!r}"


### PR DESCRIPTION
## Summary

- **#75**: `metadata_filter` の input schema に `propertyNames` 制約 (pattern + maxLength) を追加。MCP client が事前に identifier 形式を検証可能に。
- **#36**: `metadata_filter` description に「exactly one operator per key」を明記。弱いクライアント / LLM が `{"in": [...], "ne": "..."}` のようなハイブリッドを生成しないよう誘導。
- `validation.py` から `IDENTIFIER_JSON_PATTERN` / `IDENTIFIER_MAX_LEN` を public export (single source of truth)。

## 変更内容

### `src/vault_search/validation.py`
- public 定数追加: `IDENTIFIER_JSON_PATTERN = _IDENTIFIER_RE.pattern` / `IDENTIFIER_MAX_LEN = _DEFAULT_IDENTIFIER_MAX_LEN`
- `__all__` に追加

### `src/vault_search/mcp_contract.py`
- `metadata_filter` schema に `propertyNames: {pattern, maxLength}` 追加
- description に "各キーにつき exactly one operator (str / in / ne のいずれか 1 つ) を指定すること。" を追記

### `tests/test_mcp_contract.py`
- 6 新規テスト (public 定数 export / schema propertyNames / single-source-of-truth / description 制約)

## TDD history (Red → Green → Refactor)

- `9002dec` — Red: 6 failing tests
- `6a50fcd` — Green: 実装 (14+ / 1- lines)
- `a3e67ab` — Refactor: E501 lint fix

## #36 についての補足

既存のランタイム検証 (`filter.py` の `len(op_dict) != 1` チェック) と schema 側の `additionalProperties: false` (各 oneOf branch) は既に multi-operator を reject していたため、本 PR では **description による明示化のみ** を実施。tagged union 化 (breaking change) は YAGNI defer。

## Test plan

- [x] `tests/test_mcp_contract.py` 8/8 pass (新規 6 + 既存 2)
- [x] 全テストスイート 394/394 pass
- [x] `ruff check` clean
- [x] Pattern 単一ソース不変条件 (`propertyNames.pattern == IDENTIFIER_JSON_PATTERN`) が pin 済み

Closes #75
Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)