### PR TITLE
range alias 追加・テスト改善・hint 重複解消 (#121 #124 #125 #126)

### DIFF
--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -38,7 +38,8 @@ _EXPLICIT_OPS: tuple[str, ...] = tuple(op for op in get_args(Operator) if op != 
 # Numeric / date range comparison aliases. These are not supported in
 # metadata_filter (index-time string normalization makes ordered comparison
 # semantically undefined); detecting them lets agents self-correct to a
-# client-side post-filter instead of retrying aliases like gt/gte/>=. (#87)
+# client-side post-filter instead of retrying aliases like gt/gte/>= or
+# after/before/between/from/to/range. (#87, #121)
 _RANGE_OP_ALIASES: frozenset[str] = frozenset(
     {
         "gt",
@@ -184,8 +185,7 @@ def _parse_operator_dict(key: str, op_dict: dict[Any, Any]) -> MetadataCondition
         raise ValidationError(
             f"Unsupported operator {op!r} for key {key!r}: "
             f"numeric/date range comparison is not supported in metadata_filter. "
-            f"Retrieve the notes first and apply post-filter on the client side. "
-            f"For equality checks use a bare string (implicit eq), ne, or in.",
+            f"Retrieve the notes first and apply post-filter on the client side.",
             error_code="UNSUPPORTED_RANGE_OPERATOR",
             hint=(
                 "metadata_filter values are stored as strings (index-time "

--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -138,7 +138,6 @@ def parse_metadata_filter(
             raise ValidationError(
                 msg,
                 error_code="UNKNOWN_FRONTMATTER_KEY",
-                hint="see schema://tools for the frontmatter_keys list",
                 did_you_mean=suggestions,
                 allowed=sorted(known_keys),
             )

--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -53,6 +53,13 @@ _RANGE_OP_ALIASES: frozenset[str] = frozenset(
         "less_than",
         "greater_than_or_equal",
         "less_than_or_equal",
+        # Issue #121: natural-language aliases LLMs tend to generate
+        "after",
+        "before",
+        "between",
+        "range",
+        "from",
+        "to",
     }
 )
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -136,14 +136,14 @@ class TestValidationErrorStructured:
         assert err.hint == "see schema://tools"
 
     def test_did_you_mean_kwarg(self) -> None:
-        """did_you_mean keyword arg が err.did_you_mean として参照できる."""
+        """did_you_mean keyword arg が err.did_you_mean として tuple で参照できる."""
         err = ValidationError("msg", did_you_mean=["priority"])
-        assert err.did_you_mean == ["priority"] or err.did_you_mean == ("priority",)
+        assert err.did_you_mean == ("priority",)
 
     def test_allowed_kwarg(self) -> None:
-        """allowed keyword arg が err.allowed として参照できる (list or tuple)."""
+        """allowed keyword arg が err.allowed として tuple で参照できる."""
         err = ValidationError("msg", allowed=["a", "b"])
-        assert list(err.allowed) == ["a", "b"]
+        assert err.allowed == ("a", "b")
 
     def test_default_hint_is_none(self) -> None:
         """デフォルト (kw なし) のとき err.hint は None."""

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -423,7 +423,8 @@ class TestParseMetadataFilterUnknownKey:
         err = exc.value
         assert err.error_code == "UNKNOWN_FRONTMATTER_KEY"
         assert "priority" in err.did_you_mean
-        assert "schema://tools" in (err.hint or "")
+        assert "schema://tools" in str(err)  # message に含まれる (hint は削除済み)
+        assert err.hint is None
 
     def test_known_key_passes(self) -> None:
         """known_keys に含まれるキーは ValidationError を送出しない."""

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -505,6 +505,13 @@ _RANGE_ALIASES = [
     "less_than",
     "greater_than_or_equal",
     "less_than_or_equal",
+    # Issue #121: natural-language aliases LLMs tend to generate
+    "after",
+    "before",
+    "between",
+    "range",
+    "from",
+    "to",
 ]
 
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -337,7 +337,9 @@ def test_unsupported_operator_raises_validation_error(filter_input: dict) -> Non
         {"tags": {"$ne": "x"}},
         {"tags": {"eq": "x"}},
         {"tags": {"==": "x"}},
-        {"tags": {"lt": 1}},
+        # Note: range aliases (lt/gt/after/between/…) are excluded here because
+        # they route to UNSUPPORTED_RANGE_OPERATOR with a different message.
+        # They are fully covered by TestRangeOperatorAliasDetection.
     ],
 )
 def test_invalid_operator_hint_mentions_supported_forms(filter_input: dict) -> None:
@@ -345,6 +347,7 @@ def test_invalid_operator_hint_mentions_supported_forms(filter_input: dict) -> N
 
     エージェントがエラーメッセージを読んで自己修正できるよう、
     サポートされている構文 (ne / in / bare string) がヒントに明示されること。
+    range alias は TestRangeOperatorAliasDetection で別途検証する。
     """
     with pytest.raises(ValidationError) as exc:
         parse_metadata_filter(filter_input)
@@ -522,7 +525,7 @@ class TestRangeOperatorAliasDetection:
     """range 比較 alias に対する ValidationError の構造的属性を検証する (Issue #87).
 
     Red フェーズ: 以下の未実装振る舞いが FAIL することを確認する。
-    - 12 alias すべてで error_code="UNSUPPORTED_RANGE_OPERATOR" が送出される
+    - 18 alias すべてで error_code="UNSUPPORTED_RANGE_OPERATOR" が送出される
     - hint が non-None で "post-filter" または "client" を含む
     - str(err) に問題のキー名と alias 名が含まれる
     """

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -464,7 +464,8 @@ class TestParseMetadataFilterUnknownKey:
             parse_metadata_filter({"priorty": "5"}, known_keys=["priority", "status"])
         msg = str(exc.value)
         assert "priority" in msg, (
-            f"did_you_mean candidate 'priority' must appear in error message for agent DX; got: {msg!r}"
+            "did_you_mean candidate 'priority' must appear in error message "
+            f"for agent DX; got: {msg!r}"
         )
 
     def test_no_close_match_message_includes_allowed_keys(self) -> None:
@@ -477,7 +478,8 @@ class TestParseMetadataFilterUnknownKey:
         msg = str(exc.value)
         # At least one known key should appear in the message for agent self-correction
         assert any(k in msg for k in ["status", "priority", "tags"]), (
-            f"At least one known key must appear in error message when no close match exists; got: {msg!r}"
+            "At least one known key must appear in error message when no close "
+            f"match exists; got: {msg!r}"
         )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -488,7 +488,12 @@ def test_mcp_tool_vault_search_unknown_key_raises_validation_error(
 def test_mcp_tool_vault_search_unknown_key_did_you_mean_is_sequence(
     vault_index: VaultIndex,
 ) -> None:
-    """ValidationError.did_you_mean が tuple/list であることの基本 guard."""
+    """完全に無関係なキーで did_you_mean が空 tuple、allowed が非空であることを検証する.
+
+    completely_bogus_key_xyzzy は SAMPLE_NOTES のどのキーとも類似しないため
+    difflib は候補を返さない → did_you_mean == ()。
+    一方 allowed には vault の known_keys が入るため len > 0 になる。
+    """
     from vault_search.validation import ValidationError
 
     fn = _fn(server_mod.vault_search)
@@ -497,7 +502,8 @@ def test_mcp_tool_vault_search_unknown_key_did_you_mean_is_sequence(
 
     err = exc_info.value
     assert err.error_code == "UNKNOWN_FRONTMATTER_KEY"
-    assert isinstance(err.did_you_mean, (list, tuple))
+    assert err.did_you_mean == ()  # 候補なし: 完全に無関係なキーなので空
+    assert len(err.allowed) > 0  # known_keys (SAMPLE_NOTES のキー群) が返る
 
 
 def test_mcp_tool_vault_search_no_metadata_filter_does_not_raise(


### PR DESCRIPTION
## Summary

- **#121**: `_RANGE_OP_ALIASES` に LLM が生成しやすい自然言語 alias 6 種 (`after`, `before`, `between`, `range`, `from`, `to`) を追加。これらが `metadata_filter` に渡された場合、generic `VALIDATION_ERROR` ではなく `UNSUPPORTED_RANGE_OPERATOR` + post-filter 案内を返すようになる
- **#124**: `test_exceptions.py` の `did_you_mean`/`allowed` アサーションを list/tuple 両許容から strict tuple 直接比較に統一。実装は既に tuple 固定なので型不変条件を pin する
- **#125**: `test_mcp_tool_vault_search_unknown_key_did_you_mean_is_sequence` を `isinstance` 型ガードのみから `did_you_mean == ()` + `len(allowed) > 0` の仕様検証に強化
- **#126**: `UNKNOWN_FRONTMATTER_KEY` の `hint=` を削除。message 末尾と同一内容かつ大文字小文字不一致で付加価値ゼロ。`schema://tools` 参照は message に残る

## Commits

| Prefix | 内容 |
|--------|------|
| `Red` | `_RANGE_ALIASES` に 6 aliases 追加 → 18 test case FAIL |
| `Green` | `_RANGE_OP_ALIASES` に同 6 aliases 追加 → 全通 |
| `Test` | `did_you_mean`/`allowed` を strict tuple 比較に (#124) |
| `Test` | unknown key テストを仕様検証に強化 (#125) |
| `Refactor` | `UNKNOWN_FRONTMATTER_KEY` の hint 重複を除去 + `test_filter.py:426` 修正 (#126) |
| `Simplify` | 既存 E501 lint エラー 2 件修正 |
| `Simplify` | stale コメント修正・`between` hint 誤誘導を除去・`lt` を専用テストクラスに分離 |

## Test plan

- [ ] `pytest` 405 passed
- [ ] `ruff check` clean
- [ ] `_RANGE_OP_ALIASES` に `after`/`before`/`between`/`range`/`from`/`to` が含まれ `UNSUPPORTED_RANGE_OPERATOR` を返すことを `TestRangeOperatorAliasDetection` (18 alias × 3 tests = 54 cases) で検証
- [ ] `err.did_you_mean == ("priority",)` の strict tuple 比較が通ることを確認
- [ ] 完全に無関係なキーで `did_you_mean == ()` かつ `len(allowed) > 0` を MCP 経路で検証
- [ ] `UNKNOWN_FRONTMATTER_KEY` エラーで `err.hint is None` かつ `str(err)` に `schema://tools` が含まれることを確認

## Notes

- Opus レビューで `hint=` 削除が `test_filter.py:426` を破壊することを事前検知し、同一コミットで修正
- `between` のエラーメッセージ末尾の「For equality checks use a bare string」を削除。range 系 alias を使うエージェントへの誤誘導を解消（post-filter 案内のみ残す）
- `lt` を `test_invalid_operator_hint_mentions_supported_forms` から除外。range alias は `TestRangeOperatorAliasDetection` で網羅済み

https://claude.ai/code/session_01X1ZwHAv9PpPHkTiJeMzKvF