### PR TITLE
#117 known_keys 検証ロジックを filter.py から validation.py に抽出

### DIFF
--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -19,12 +19,16 @@ frontmatter の任意プロパティを AND 条件で絞り込む dict 構文を
 
 from __future__ import annotations
 
-import difflib
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, get_args
 
-from .validation import ValidationError, validate_identifier, validate_value
+from .validation import (
+    ValidationError,
+    validate_identifier,
+    validate_known_key,
+    validate_value,
+)
 
 __all__ = ["MetadataCondition", "Operator", "build_sql_fragment", "parse_metadata_filter"]
 
@@ -119,29 +123,8 @@ def parse_metadata_filter(
             raise ValidationError(f"metadata_filter key must be a string, got {type(key).__name__}")
         validate_identifier(key, kind="frontmatter key")
 
-        if known_keys is not None and key not in known_keys:
-            suggestions = difflib.get_close_matches(key, known_keys, n=3, cutoff=0.6)
-            if suggestions:
-                suggestion_str = ", ".join(suggestions)
-                msg = (
-                    f"Unknown frontmatter key {key!r}; "
-                    f"did you mean: {suggestion_str}? "
-                    f"See schema://tools for the frontmatter_keys list"
-                )
-            else:
-                preview = ", ".join(sorted(known_keys)[:5])
-                suffix = ", ..." if len(known_keys) > 5 else ""
-                msg = (
-                    f"Unknown frontmatter key {key!r}; "
-                    f"valid keys include: {preview}{suffix}. "
-                    f"See schema://tools for the full list"
-                )
-            raise ValidationError(
-                msg,
-                error_code="UNKNOWN_FRONTMATTER_KEY",
-                did_you_mean=suggestions,
-                allowed=sorted(known_keys),
-            )
+        if known_keys is not None:
+            validate_known_key(key, known_keys, kind="frontmatter key")
 
         conditions.append(_parse_entry(key, value))
 

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -22,6 +22,7 @@ Design notes
 
 from __future__ import annotations
 
+import difflib
 import re
 from collections.abc import Sequence
 
@@ -33,6 +34,7 @@ __all__ = [
     "LIMIT_MAX",
     "ValidationError",
     "validate_identifier",
+    "validate_known_key",
     "validate_pagination",
     "validate_value",
 ]
@@ -173,6 +175,59 @@ def validate_identifier(
             f"{kind} contains disallowed characters (allowed: {_IDENTIFIER_ALLOWED_DESC}): {name!r}"
         )
     return name
+
+
+def validate_known_key(
+    name: str,
+    known_keys: Sequence[str],
+    *,
+    kind: str,
+) -> str:
+    """Validate that ``name`` appears in ``known_keys`` and return it unchanged.
+
+    Intended for frontmatter keys (and, later, known tags / folders) where the
+    index contains an authoritative allow-list and an agent may hallucinate a
+    near-miss. Unknown keys raise :class:`ValidationError` with
+    ``error_code="UNKNOWN_FRONTMATTER_KEY"`` and the full ``known_keys`` sorted
+    list in ``allowed``; close matches (``difflib.get_close_matches``,
+    ``cutoff=0.6``) appear in ``did_you_mean``.
+
+    Parameters
+    ----------
+    name:
+        Candidate key. Callers should pass the value through
+        :func:`validate_identifier` first so SQL / path-traversal shapes are
+        rejected before similarity matching.
+    known_keys:
+        Authoritative allow-list (from the index). Empty sequence is
+        permitted; every ``name`` is unknown in that case.
+    kind:
+        Human-readable label (e.g. ``"frontmatter key"``) interpolated into
+        the error message so the agent knows which input to fix.
+    """
+    if name in known_keys:
+        return name
+    suggestions = difflib.get_close_matches(name, known_keys, n=3, cutoff=0.6)
+    if suggestions:
+        msg = (
+            f"Unknown {kind} {name!r}; "
+            f"did you mean: {', '.join(suggestions)}? "
+            f"See schema://tools for the frontmatter_keys list"
+        )
+    else:
+        preview = ", ".join(sorted(known_keys)[:5])
+        suffix = ", ..." if len(known_keys) > 5 else ""
+        msg = (
+            f"Unknown {kind} {name!r}; "
+            f"valid keys include: {preview}{suffix}. "
+            f"See schema://tools for the full list"
+        )
+    raise ValidationError(
+        msg,
+        error_code="UNKNOWN_FRONTMATTER_KEY",
+        did_you_mean=suggestions,
+        allowed=sorted(known_keys),
+    )
 
 
 def _validate_strict_int(value: object, name: str) -> None:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -12,6 +12,7 @@ import pytest
 from vault_search.validation import (
     ValidationError,
     validate_identifier,
+    validate_known_key,
     validate_value,
 )
 
@@ -310,3 +311,54 @@ def test_validate_value_error_message_includes_custom_kind() -> None:
     with pytest.raises(ValidationError) as exc:
         validate_value("bad\x00value", kind="frontmatter value")
     assert "frontmatter value" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# validate_known_key — Issue #117
+#
+# filter.py の parse_metadata_filter から抽出した unknown key 検出ヘルパ。
+# known_keys に含まれる場合は入力を素通し、未知キーは
+# ValidationError(error_code="UNKNOWN_FRONTMATTER_KEY") を
+# did_you_mean (difflib) + allowed (sorted) 付きで送出する。
+# ---------------------------------------------------------------------------
+
+
+class TestValidateKnownKey:
+    """validate_known_key の直接テスト (Issue #117)."""
+
+    def test_known_key_returns_unchanged(self) -> None:
+        assert (
+            validate_known_key("priority", ["priority", "status"], kind="frontmatter key")
+            == "priority"
+        )
+
+    def test_unknown_key_raises_with_error_code(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            validate_known_key("priorty", ["priority", "status"], kind="frontmatter key")
+        err = exc.value
+        assert err.error_code == "UNKNOWN_FRONTMATTER_KEY"
+        assert "priority" in err.did_you_mean
+        assert tuple(sorted(err.allowed)) == ("priority", "status")
+        assert "schema://tools" in str(err)
+
+    def test_no_close_match_still_raises_with_allowed(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            validate_known_key(
+                "nonexistent",
+                ["status", "priority", "tags"],
+                kind="frontmatter key",
+            )
+        err = exc.value
+        assert err.error_code == "UNKNOWN_FRONTMATTER_KEY"
+        assert err.did_you_mean == ()
+        assert set(err.allowed) == {"status", "priority", "tags"}
+
+    def test_empty_known_keys_rejects_any_key(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            validate_known_key("xyz", [], kind="frontmatter key")
+        assert exc.value.error_code == "UNKNOWN_FRONTMATTER_KEY"
+
+    def test_kind_label_appears_in_message(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            validate_known_key("xyz", ["a"], kind="frontmatter key")
+        assert "frontmatter key" in str(exc.value)


### PR DESCRIPTION
## Summary

- **#117**: `parse_metadata_filter` 内にあった unknown frontmatter key 検出 (`difflib.get_close_matches` + error message 組み立て) を `validation.py` の独立関数 `validate_known_key()` として抽出
- filter 層は SQL/演算子の責務に集中、domain-aware な入力検証は validation 層に集約 (Phase D2 review Score 7/10 指摘の解消)
- 振る舞いは保持 — 既存の `TestParseMetadataFilterUnknownKey` 6 件が引き続き通過

## Commits

| Prefix | 内容 |
|--------|------|
| `Red` | `validate_known_key` の直接テスト 5 件を `tests/test_validation.py` に追加 → ImportError で失敗 |
| `Green` | `validation.py` に `validate_known_key(name, known_keys, *, kind)` を追加 (`difflib` import も移管)。filter.py は未変更 |
| `Refactor` | filter.py の inline 検出ブロック (22 行) を `validate_known_key` 呼出 1 行に置換。`import difflib` を削除 |

## API

```python
def validate_known_key(
    name: str,
    known_keys: Sequence[str],
    *,
    kind: str,  # e.g. "frontmatter key"、将来的に "tag" "folder" 等に転用
) -> str:
```

- 既存エラーメッセージとの互換: `kind="frontmatter key"` を渡すことで `"Unknown frontmatter key ..."` 形式を維持
- `error_code="UNKNOWN_FRONTMATTER_KEY"` 固定 (tag/folder 対応時に parametrize を再検討)
- `did_you_mean` は difflib 候補 (cutoff=0.6)、`allowed` はソート済み known_keys

## Test plan

- [x] `pytest` 416 passed (既存 411 + Red 追加 5)
- [x] `ruff check` clean (既存 `test_mcp_contract.py` の format drift は main から引き継ぎで本 PR 無関係)
- [x] `TestParseMetadataFilterUnknownKey` (filter.py 側の既存 6 件) が引き続き通過 → 振る舞い保持
- [x] 新規 `TestValidateKnownKey` (5 件) で API 契約を pin

## Notes

- `error_code` を parametrize しなかった理由: YAGNI。現状 tag/folder validation の具体要件なし。必要時に 1 行追加
- Phase A の 2 つ目として #120 (error_code を enum 化) が続く予定。本 PR は `error_code="UNKNOWN_FRONTMATTER_KEY"` をまだ bare string で扱うが、#120 が landed したら自動的に enum 化される

🤖 Generated with [Claude Code](https://claude.com/claude-code)