### PR TITLE
#119 known_keys pass-through を廃止し indexer.search が自己解決

### DIFF
--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -14,7 +14,7 @@ import json
 import logging
 import sqlite3
 import threading
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -333,7 +333,6 @@ class VaultIndex:
         tags: list[str] | None = None,
         folder: str | None = None,
         metadata_filter: dict[str, Any] | None = None,
-        known_keys: Sequence[str] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> dict[str, Any]:
@@ -355,11 +354,9 @@ class VaultIndex:
             frontmatter 任意プロパティを対象とする AND フィルタ。
             構文は :func:`vault_search.filter.parse_metadata_filter` を参照。
             不正構造は :class:`ValidationError` を送出する。
-        known_keys:
-            ``metadata_filter`` のキー検証に使う既知 frontmatter キーのリスト。
-            渡された場合は unknown frontmatter key を ``ValidationError`` として
-            拒否する (agent UX 向け、Issue #19)。``None`` の場合はキー検証を
-            スキップするため後方互換が保たれる。
+            unknown frontmatter key は ``list_frontmatter_keys()`` を内部で
+            呼び出して自己検証する (Issue #119)。``UNKNOWN_FRONTMATTER_KEY``
+            を持つ ``ValidationError`` として拒否される。
         limit, offset:
             ページング用。
 
@@ -369,7 +366,11 @@ class VaultIndex:
         いずれかが指定されていれば、DB 全体を対象に構造化フィルタだけで
         絞り込む。全引数が空の場合は空結果を返す。
         """
-        # Validate (raises ValidationError on malformed input)
+        # Validate (raises ValidationError on malformed input).
+        # metadata_filter が指定された場合のみ known_keys を取得する:
+        # list_frontmatter_keys() は現状 DB フルスキャン (#118) のため、
+        # filter なしの通常検索でコストを払わない。
+        known_keys = self.list_frontmatter_keys() if metadata_filter else None
         conditions = parse_metadata_filter(metadata_filter, known_keys=known_keys)
 
         filters: dict[str, Any] | None = None

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -116,7 +116,6 @@ def vault_search(
         tags=tags,
         folder=folder,
         metadata_filter=metadata_filter,
-        known_keys=_get_index().list_frontmatter_keys() if metadata_filter else None,
         limit=limit,
         offset=offset,
     )

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -576,24 +576,34 @@ def test_metadata_filter_missing_key_excludes(vault_index: VaultIndex) -> None:
     assert res["total"] == 2
 
 
-def test_metadata_filter_nonexistent_key_returns_empty(
+def test_metadata_filter_nonexistent_key_raises(
     vault_index: VaultIndex,
 ) -> None:
-    """存在しないキー (どのノートも持っていない) で eq すると total=0.
+    """存在しないキーは ValidationError (Issue #119).
 
-    Control group: 同じ空クエリで filter なし相当 (status=active) は 2 件
-    返るのに対し、bogus_key での filter では 0 件に絞られることを確認。
-    これにより「実装が filter 値を無視して全件返す」regression を検知する。
+    indexer が自身で ``list_frontmatter_keys()`` を呼んで known_keys を自己解決
+    する設計変更に伴い、未知キーは silent に 0 件を返すのではなく
+    ``UNKNOWN_FRONTMATTER_KEY`` で即座に拒否する。
+
+    Control: 存在するキーでの filter は引き続き >=1 件返る
+    (filter 値が無視されていない regression guard)。
     """
-    # Control: 存在するキーでの filter は >=1 件返る
     control = vault_index.search("", metadata_filter={"status": "active"})
     assert control["total"] >= 1
 
-    res = vault_index.search("", metadata_filter={"bogus_key_xyzzy": "x"})
-    assert res["total"] == 0, (
-        f"expected 0 hits for nonexistent frontmatter key, got total={res['total']}"
-    )
-    assert res["results"] == []
+    with pytest.raises(ValidationError) as exc:
+        vault_index.search("", metadata_filter={"bogus_key_xyzzy": "x"})
+    assert exc.value.error_code == "UNKNOWN_FRONTMATTER_KEY"
+
+
+def test_search_rejects_known_keys_kwarg(vault_index: VaultIndex) -> None:
+    """Issue #119: known_keys パラメータは削除された (leaky abstraction 解消)."""
+    with pytest.raises(TypeError):
+        vault_index.search(  # type: ignore[call-arg]
+            "",
+            metadata_filter={"status": "active"},
+            known_keys=["status"],
+        )
 
 
 def test_metadata_filter_invalid_operator_raises(vault_index: VaultIndex) -> None:


### PR DESCRIPTION
## Summary

- **#119**: `VaultIndex.search()` の ``known_keys: Sequence[str] | None`` パラメータを削除
- indexer 内部で `metadata_filter` 指定時のみ `self.list_frontmatter_keys()` を呼び、parse_metadata_filter に渡す (Option (a))
- filter 層の検証都合が public API に leak していた leaky abstraction を解消 (Phase D2 review score 7/10 指摘)

## Design choice: Option (a) vs (b)

Issue 本文が提案した 2 案のうち、**Option (a) indexer 内部自己解決** を採用。

Option (b) (server.py が `parse_metadata_filter` を直接呼び conditions を渡す) は indexer.search の signature を大きく変える必要があり、~15 箇所の既存 test_indexer 呼出を書き換える広範囲改修になる。Phase E1 (#46/#29/#117 filter 層責務分割) に自然に統合される候補。

本 PR は leak している1 パラメータを除去する最小改修に留める。

## Behavior change

直接 `VaultIndex.search()` を呼び出す経路 (主にテスト) でも unknown frontmatter key は `UNKNOWN_FRONTMATTER_KEY` `ValidationError` で即座に拒否される。以前は `known_keys=None` デフォルトで silent に 0 件返却していた。

MCP tool (`vault_search`) 経路の user-visible な挙動は変わらない (従来から server.py が known_keys を渡していたため)。

## Commits

| Prefix | 内容 |
|--------|------|
| `Red` | `test_metadata_filter_nonexistent_key_returns_empty` を `..._raises` にリネームして ValidationError を期待。`test_search_rejects_known_keys_kwarg` を追加し kwarg 削除を pin |
| `Green` | indexer.search から known_keys を削除、内部自己解決。`from collections.abc import Sequence` を削除。server.py の known_keys= 引数を削除 |

Refactor フェーズは省略。Green の変更が既に<20 行 / 2 ファイルのミニマル構成で、切り出せる housekeeping 項目がなかったため。

## Test plan

- [x] `pytest` 417 passed (baseline 416 から +1、既存 1 件を 2 件に分割)
- [x] `ruff check` clean
- [x] `vault_index.search(..., known_keys=[])` が `TypeError` を送出 (#119 核心)
- [x] `vault_index.search("", metadata_filter={"bogus_key_xyzzy": "x"})` が `UNKNOWN_FRONTMATTER_KEY` ValidationError を送出
- [x] MCP tool 経路の既存テスト (`test_mcp_tool_vault_search_unknown_key_*`) は無変更で通過

## Notes

- パフォーマンス: `list_frontmatter_keys()` は metadata_filter 指定時のみ呼ばれる。tags / folder 単独の検索には影響なし。DB フルスキャンの cache 化は別途 #118 で対応
- 将来 known tags / known folders の検証を追加する際も、同じ「indexer が内部で関連リストを取得する」パターンを踏襲すれば pass-through 累積を防げる

🤖 Generated with [Claude Code](https://claude.com/claude-code)