### PR TITLE
Perf: list_frontmatter_keys を in-memory キャッシュ化 (#118 / #10)

### DIFF
--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -257,9 +257,7 @@ class VaultIndex:
 
             conn.commit()
 
-            # キャッシュ無効化
-            self._cache.invalidate()
-            self._frontmatter_keys_cache = None
+            self._invalidate_caches()
 
             logger.info(
                 "Index built: added=%d updated=%d deleted=%d skipped=%d errors=%d",
@@ -311,8 +309,7 @@ class VaultIndex:
             if not full_path.exists():
                 conn.execute("DELETE FROM notes WHERE path = ?", (rel_path,))
                 conn.commit()
-                self._cache.invalidate()
-                self._frontmatter_keys_cache = None
+                self._invalidate_caches()
                 return True
 
             note = parse_note(full_path, self.vault_root)
@@ -322,9 +319,13 @@ class VaultIndex:
             mtime = full_path.stat().st_mtime
             self._upsert_note(conn, note, mtime)
             conn.commit()
-            self._cache.invalidate()
-            self._frontmatter_keys_cache = None
+            self._invalidate_caches()
             return True
+
+    def _invalidate_caches(self) -> None:
+        """書込み経路で tiered cache と frontmatter_keys cache を同時に落とす."""
+        self._cache.invalidate()
+        self._frontmatter_keys_cache = None
 
     # ------------------------------------------------------------------
     # Search — 3段パイプライン
@@ -371,9 +372,9 @@ class VaultIndex:
         絞り込む。全引数が空の場合は空結果を返す。
         """
         # Validate (raises ValidationError on malformed input).
-        # metadata_filter が指定された場合のみ known_keys を取得する:
-        # list_frontmatter_keys() は現状 DB フルスキャン (#118) のため、
-        # filter なしの通常検索でコストを払わない。
+        # metadata_filter が指定された場合のみ known_keys を取得する
+        # (filter なしでは不要なので呼ばない)。list_frontmatter_keys() は
+        # 書込み経路で invalidate される in-memory cache 付き (#118)。
         known_keys = self.list_frontmatter_keys() if metadata_filter else None
         conditions = parse_metadata_filter(metadata_filter, known_keys=known_keys)
 

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -135,6 +135,7 @@ class VaultIndex:
 
         self._cache = TieredCache()
         self._lock = threading.Lock()
+        self._frontmatter_keys_cache: list[str] | None = None
         self._init_db()
 
     def _init_db(self) -> None:
@@ -258,6 +259,7 @@ class VaultIndex:
 
             # キャッシュ無効化
             self._cache.invalidate()
+            self._frontmatter_keys_cache = None
 
             logger.info(
                 "Index built: added=%d updated=%d deleted=%d skipped=%d errors=%d",
@@ -310,6 +312,7 @@ class VaultIndex:
                 conn.execute("DELETE FROM notes WHERE path = ?", (rel_path,))
                 conn.commit()
                 self._cache.invalidate()
+                self._frontmatter_keys_cache = None
                 return True
 
             note = parse_note(full_path, self.vault_root)
@@ -320,6 +323,7 @@ class VaultIndex:
             self._upsert_note(conn, note, mtime)
             conn.commit()
             self._cache.invalidate()
+            self._frontmatter_keys_cache = None
             return True
 
     # ------------------------------------------------------------------
@@ -590,7 +594,17 @@ class VaultIndex:
             return [{"folder": r["folder"], "count": r["count"]} for r in rows]
 
     def list_frontmatter_keys(self) -> list[str]:
-        """Vault 内 frontmatter のトップレベルキーをソート済みで返す."""
+        """Vault 内 frontmatter のトップレベルキーをソート済みで返す.
+
+        初回呼出時に DB をスキャンしてキャッシュし、以降は書込み経路で
+        invalidate されるまでキャッシュを返す (Issue #118 / #10)。
+        """
+        if self._frontmatter_keys_cache is None:
+            self._frontmatter_keys_cache = self._query_frontmatter_keys_from_db()
+        return list(self._frontmatter_keys_cache)
+
+    def _query_frontmatter_keys_from_db(self) -> list[str]:
+        """Frontmatter のトップレベルキー集合を DB から取得する (キャッシュ無視)."""
         with self.connection() as conn:
             rows = conn.execute(
                 "SELECT DISTINCT key FROM notes, json_each(notes.frontmatter) "

--- a/tests/test_frontmatter_keys_cache.py
+++ b/tests/test_frontmatter_keys_cache.py
@@ -1,0 +1,91 @@
+"""Issue #118 / #10: ``list_frontmatter_keys`` キャッシュ挙動の pin テスト.
+
+設計: ``VaultIndex._query_frontmatter_keys_from_db()`` を分離し、
+``list_frontmatter_keys()`` 外側でキャッシュする。
+build_index / update_single / _upsert_note 等の書込み経路で invalidate する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from vault_search.indexer import VaultIndex
+
+
+def test_list_frontmatter_keys_uses_cache_on_repeated_calls(
+    vault_index: VaultIndex,
+) -> None:
+    """2 回目以降の呼出は DB スキャンを走らせない (cache 命中)."""
+    first = vault_index.list_frontmatter_keys()
+    assert first, "sanity: sample vault に frontmatter キーがあるはず"
+
+    with patch.object(
+        vault_index,
+        "_query_frontmatter_keys_from_db",
+        wraps=vault_index._query_frontmatter_keys_from_db,
+    ) as spy:
+        second = vault_index.list_frontmatter_keys()
+        third = vault_index.list_frontmatter_keys()
+
+    assert spy.call_count == 0, (
+        f"cache 命中時は DB スキャンしないはず (call_count={spy.call_count})"
+    )
+    assert second == first
+    assert third == first
+
+
+def test_list_frontmatter_keys_invalidated_after_update_single_add(
+    vault_index: VaultIndex, tmp_vault: Path
+) -> None:
+    """update_single でキーが追加されたら次の呼出で反映される."""
+    before = set(vault_index.list_frontmatter_keys())
+    assert "brand_new_key_xyzzy" not in before
+
+    (tmp_vault / "new_with_key.md").write_text(
+        "---\nbrand_new_key_xyzzy: test\n---\nbody\n",
+        encoding="utf-8",
+    )
+    assert vault_index.update_single("new_with_key.md") is True
+
+    after = set(vault_index.list_frontmatter_keys())
+    assert "brand_new_key_xyzzy" in after
+
+
+def test_list_frontmatter_keys_invalidated_after_update_single_delete(
+    vault_index: VaultIndex, tmp_vault: Path
+) -> None:
+    """最後のキー所有者が削除されたらキー集合から消える.
+
+    sample vault の ``categories`` は Welcome.md と Research/alpha.md が持つ。
+    両方を削除すればキーは無くなる。
+    """
+    _ = vault_index.list_frontmatter_keys()  # populate cache
+    assert "categories" in set(vault_index.list_frontmatter_keys())
+
+    (tmp_vault / "Welcome.md").unlink()
+    (tmp_vault / "Research" / "alpha.md").unlink()
+    assert vault_index.update_single("Welcome.md") is True
+    assert vault_index.update_single("Research/alpha.md") is True
+
+    after = set(vault_index.list_frontmatter_keys())
+    assert "categories" not in after
+
+
+def test_list_frontmatter_keys_invalidated_after_build_index(
+    tmp_vault: Path, tmp_path: Path
+) -> None:
+    """build_index(force=True) 後も最新キー集合が返る."""
+    db_path = tmp_path / "test.db"
+    idx = VaultIndex(tmp_vault, db_path=db_path)
+    idx.build_index()
+    _ = idx.list_frontmatter_keys()  # populate cache
+
+    (tmp_vault / "added.md").write_text(
+        "---\nextra_key_from_rebuild: 1\n---\n",
+        encoding="utf-8",
+    )
+    idx.build_index(force=True)
+
+    keys = set(idx.list_frontmatter_keys())
+    assert "extra_key_from_rebuild" in keys


### PR DESCRIPTION
## Summary

- `VaultIndex.list_frontmatter_keys()` が `schema://tools` resource および
  `metadata_filter` 指定付き `vault_search` 呼出ごとに毎回 `notes × json_each`
  のフルスキャンを走らせていた (10k-note vault では重い) のを、in-memory
  cache 化して初回のみに削減
- 書込み経路 (`build_index` / `update_single` の add/delete) で
  `_invalidate_caches()` helper により `TieredCache` と
  `_frontmatter_keys_cache` を同時 invalidate、stale にならない保証

## Implementation

### Red (`b00b72a`)

`tests/test_frontmatter_keys_cache.py` を新規追加。pin した挙動:

1. 2 回目以降の `list_frontmatter_keys()` で DB スキャンしない
   (`_query_frontmatter_keys_from_db` を `patch.object(wraps=...)` でスパイ)
2. `update_single` で frontmatter キー追加後、次の呼出で反映
3. キーを持つ最後のノートを削除後、キーが消える
4. `build_index(force=True)` 後もキー集合が最新

### Green (`ccc8dca`)

- `VaultIndex._frontmatter_keys_cache: list[str] | None` を `__init__` に追加
- `list_frontmatter_keys()` を cache 参照 + `_query_frontmatter_keys_from_db()`
  フォールバック構造に変更
- 戻り値は `list(cache)` のコピー (呼出側 mutation からガード)
- 3 書込み経路で `self._frontmatter_keys_cache = None`

### Refactor (`f164cba`)

- 3 箇所の「2 行 invalidation」重複を `_invalidate_caches()` helper に集約
- `search()` 内の stale コメント "現状 DB フルスキャン (#118)" を更新

## Decisions

- **案A (in-memory set + invalidate) を採用**: issue #118 の案A。差分更新
  (`_upsert_note` 時に set.add) より、書込み全体で cache を落として次回
  再ビルドする方が実装がシンプルで正確 (DELETE 時に「他ノートがキーを
  共有しているか」判定不要)。キーの増減頻度に比べ list_frontmatter_keys
  呼出頻度の方が遥かに高いため、ヒット率は実用上 >99%
- **TTL キャッシュ (案B) を採用せず**: invalidate を確実に発火できる以上、
  TTL は不要。watcher 経由の差分更新も `update_single` 経由で
  invalidate される
- **Refactor は行う判断**: Green で 3 箇所に散在した invalidation 重複は
  将来 cache 種類が増えた際の追随漏れリスク。helper 化で 1 箇所に集約

## Test plan

- [x] 新規 4 テスト全通過 (Red → Green で 1→0 fail)
- [x] 全 423 テスト通過 (前 419 + 新規 4)
- [x] `ruff check` / `ruff format --check` clean
- [x] cache 命中時 DB スキャンが発生しないことを mock で pin
- [x] 書込み経路 (add/delete/force rebuild) での invalidation pin

## Closes

- Closes #118
- Closes #10 (同一課題、#118 で具体案が出たため統合クローズ)