### PR TITLE
Feat: parse_metadata_filter で複数 unknown key を batch 報告 (#123)

### DIFF
--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -157,7 +157,9 @@ def _raise_unknown_keys(
     単一 key 時は既存の ``validate_known_key`` と同形式のメッセージを返し、
     ``did_you_mean`` / ``allowed`` 属性も populated (backward compat)。
     複数 key 時は ``Unknown frontmatter keys: ...`` 形式で各 key ごとの候補を
-    列挙し、構造化情報は ``unknown_keys`` 属性に格納する。
+    列挙し、候補なしキーは明示的に ``(no close match)`` と注釈する。
+    構造化情報は ``unknown_keys`` 属性に格納し、``did_you_mean`` にも全候補を
+    flatten populate することで agent の旧分岐ロジックと対称性を保つ。
     """
     allowed_sorted = sorted(known_keys)
 
@@ -171,8 +173,11 @@ def _raise_unknown_keys(
             unknown_keys=unknowns,
         )
 
-    # Multi-key path
-    parts = [f"{k!r} (did you mean: {', '.join(s)})" if s else repr(k) for k, s in unknowns.items()]
+    # Multi-key path: 各キーに候補/なしを明示注釈して混在ケースの曖昧さを解消。
+    parts = [
+        f"{k!r} (did you mean: {', '.join(s)})" if s else f"{k!r} (no close match)"
+        for k, s in unknowns.items()
+    ]
     keys_str = ", ".join(parts)
     if any(not s for s in unknowns.values()):
         # 少なくとも 1 キーに候補なし → 全 allowed preview を message に添える
@@ -181,13 +186,20 @@ def _raise_unknown_keys(
         msg = (
             f"Unknown frontmatter keys: {keys_str}. "
             f"Valid keys include: {preview}{suffix}. "
-            f"See schema://tools for the full list"
+            f"See schema://tools for the frontmatter_keys list"
         )
     else:
-        msg = f"Unknown frontmatter keys: {keys_str}. See schema://tools for the full list"
+        msg = (
+            f"Unknown frontmatter keys: {keys_str}. "
+            f"See schema://tools for the frontmatter_keys list"
+        )
+    # did_you_mean は単一/複数で非対称にならないよう全候補を flatten populate。
+    # 旧 agent が ``if err.did_you_mean:`` で分岐した場合でも候補ゼロ扱いにならない。
+    all_candidates = tuple(c for s in unknowns.values() for c in s)
     raise ValidationError(
         msg,
         error_code="UNKNOWN_FRONTMATTER_KEY",
+        did_you_mean=all_candidates,
         allowed=allowed_sorted,
         unknown_keys=unknowns,
     )

--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -26,6 +26,7 @@ from typing import Any, Literal, NoReturn, get_args
 
 from .validation import (
     ValidationError,
+    format_unknown_key_message,
     validate_identifier,
     validate_value,
 )
@@ -162,9 +163,8 @@ def _raise_unknown_keys(
 
     if len(unknowns) == 1:
         ((key, suggestions),) = unknowns.items()
-        msg = _format_single_unknown(key, suggestions, allowed_sorted)
         raise ValidationError(
-            msg,
+            format_unknown_key_message(key, "frontmatter key", suggestions, allowed_sorted),
             error_code="UNKNOWN_FRONTMATTER_KEY",
             did_you_mean=suggestions,
             allowed=allowed_sorted,
@@ -190,27 +190,6 @@ def _raise_unknown_keys(
         error_code="UNKNOWN_FRONTMATTER_KEY",
         allowed=allowed_sorted,
         unknown_keys=unknowns,
-    )
-
-
-def _format_single_unknown(
-    key: str,
-    suggestions: tuple[str, ...],
-    allowed_sorted: list[str],
-) -> str:
-    """単一 unknown key の message を構築 (validate_known_key と同形式)."""
-    if suggestions:
-        return (
-            f"Unknown frontmatter key {key!r}; "
-            f"did you mean: {', '.join(suggestions)}? "
-            f"See schema://tools for the frontmatter_keys list"
-        )
-    preview = ", ".join(allowed_sorted[:5])
-    suffix = ", ..." if len(allowed_sorted) > 5 else ""
-    return (
-        f"Unknown frontmatter key {key!r}; "
-        f"valid keys include: {preview}{suffix}. "
-        f"See schema://tools for the full list"
     )
 
 

--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -19,14 +19,14 @@ frontmatter の任意プロパティを AND 条件で絞り込む dict 構文を
 
 from __future__ import annotations
 
+import difflib
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Literal, get_args
+from typing import Any, Literal, NoReturn, get_args
 
 from .validation import (
     ValidationError,
     validate_identifier,
-    validate_known_key,
     validate_value,
 )
 
@@ -103,9 +103,13 @@ def parse_metadata_filter(
 
     - ``None`` または空 dict → 空 list
     - 各キーは :func:`validate_identifier` (kind="frontmatter key") で検証
-    - ``known_keys`` が ``None`` 以外の場合、各キーが ``known_keys`` に含まれるか検証
-      (識別子形式チェックの**後**に実施)。含まれない場合は
-      ``ValidationError(error_code="UNKNOWN_FRONTMATTER_KEY")`` を送出する。
+    - ``known_keys`` が ``None`` 以外の場合、全キーを走査して ``known_keys`` に
+      含まれないものを **一括** 収集し、1 個の
+      ``ValidationError(error_code="UNKNOWN_FRONTMATTER_KEY")`` として送出する
+      (#123)。各 unknown key に対する ``did_you_mean`` 候補は
+      ``unknown_keys`` 属性 (dict[str, tuple[str, ...]]) に構造化保持され、
+      単一 key 時は従来通り ``did_you_mean`` / ``allowed`` も populated
+      (backward compat)。
     - str 値 → ``op="eq"``、値は :func:`validate_value` で検証
     - dict 値 → ``{"in": list[str]}`` / ``{"ne": str}`` のみ許可
         - ``in``: 値は非空 list[str]、各要素を :func:`validate_value` で検証
@@ -117,18 +121,97 @@ def parse_metadata_filter(
     if not isinstance(raw, dict):
         raise ValidationError(f"metadata_filter must be a dict, got {type(raw).__name__}")
 
-    conditions: list[MetadataCondition] = []
-    for key, value in raw.items():
+    # First pass: validate per-key type/identifier structure (fail-first).
+    # 構造エラーは入力 shape 全体の破綻を示唆するため batch しない。
+    for key in raw:
         if not isinstance(key, str):
             raise ValidationError(f"metadata_filter key must be a string, got {type(key).__name__}")
         validate_identifier(key, kind="frontmatter key")
 
-        if known_keys is not None:
-            validate_known_key(key, known_keys, kind="frontmatter key")
+    # Second pass: collect ALL unknown keys and raise once if any (#123).
+    # LLM agent は複数キーを同時に hallucinate しやすいため、first-fail では
+    # self-correction に N round-trip かかる。1 回の batch 報告に統合する。
+    if known_keys is not None:
+        unknowns: dict[str, tuple[str, ...]] = {}
+        for key in raw:
+            if key not in known_keys:
+                unknowns[key] = tuple(difflib.get_close_matches(key, known_keys, n=3, cutoff=0.6))
+        if unknowns:
+            _raise_unknown_keys(unknowns, known_keys)
 
+    # Third pass: parse individual entries. op / value 検証は fail-first。
+    conditions: list[MetadataCondition] = []
+    for key, value in raw.items():
         conditions.append(_parse_entry(key, value))
 
     return conditions
+
+
+def _raise_unknown_keys(
+    unknowns: dict[str, tuple[str, ...]],
+    known_keys: Sequence[str],
+) -> NoReturn:
+    """収集済み unknown key を 1 個の ValidationError にまとめて raise (#123).
+
+    単一 key 時は既存の ``validate_known_key`` と同形式のメッセージを返し、
+    ``did_you_mean`` / ``allowed`` 属性も populated (backward compat)。
+    複数 key 時は ``Unknown frontmatter keys: ...`` 形式で各 key ごとの候補を
+    列挙し、構造化情報は ``unknown_keys`` 属性に格納する。
+    """
+    allowed_sorted = sorted(known_keys)
+
+    if len(unknowns) == 1:
+        ((key, suggestions),) = unknowns.items()
+        msg = _format_single_unknown(key, suggestions, allowed_sorted)
+        raise ValidationError(
+            msg,
+            error_code="UNKNOWN_FRONTMATTER_KEY",
+            did_you_mean=suggestions,
+            allowed=allowed_sorted,
+            unknown_keys=unknowns,
+        )
+
+    # Multi-key path
+    parts = [f"{k!r} (did you mean: {', '.join(s)})" if s else repr(k) for k, s in unknowns.items()]
+    keys_str = ", ".join(parts)
+    if any(not s for s in unknowns.values()):
+        # 少なくとも 1 キーに候補なし → 全 allowed preview を message に添える
+        preview = ", ".join(allowed_sorted[:5])
+        suffix = ", ..." if len(allowed_sorted) > 5 else ""
+        msg = (
+            f"Unknown frontmatter keys: {keys_str}. "
+            f"Valid keys include: {preview}{suffix}. "
+            f"See schema://tools for the full list"
+        )
+    else:
+        msg = f"Unknown frontmatter keys: {keys_str}. See schema://tools for the full list"
+    raise ValidationError(
+        msg,
+        error_code="UNKNOWN_FRONTMATTER_KEY",
+        allowed=allowed_sorted,
+        unknown_keys=unknowns,
+    )
+
+
+def _format_single_unknown(
+    key: str,
+    suggestions: tuple[str, ...],
+    allowed_sorted: list[str],
+) -> str:
+    """単一 unknown key の message を構築 (validate_known_key と同形式)."""
+    if suggestions:
+        return (
+            f"Unknown frontmatter key {key!r}; "
+            f"did you mean: {', '.join(suggestions)}? "
+            f"See schema://tools for the frontmatter_keys list"
+        )
+    preview = ", ".join(allowed_sorted[:5])
+    suffix = ", ..." if len(allowed_sorted) > 5 else ""
+    return (
+        f"Unknown frontmatter key {key!r}; "
+        f"valid keys include: {preview}{suffix}. "
+        f"See schema://tools for the full list"
+    )
 
 
 def _parse_entry(key: str, value: Any) -> MetadataCondition:

--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -166,7 +166,7 @@ def _raise_unknown_keys(
     if len(unknowns) == 1:
         ((key, suggestions),) = unknowns.items()
         raise ValidationError(
-            format_unknown_key_message(key, "frontmatter key", suggestions, allowed_sorted),
+            format_unknown_key_message(key, "frontmatter key", suggestions, known_keys),
             error_code="UNKNOWN_FRONTMATTER_KEY",
             did_you_mean=suggestions,
             allowed=allowed_sorted,

--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -174,12 +174,15 @@ def _raise_unknown_keys(
         )
 
     # Multi-key path: 各キーに候補/なしを明示注釈して混在ケースの曖昧さを解消。
+    # unknown key 名でソートして、入力挿入順に依存しない決定的 message / did_you_mean
+    # を生成する (R2-3)。log 検索性と snapshot 再現性のため。
+    sorted_unknowns = dict(sorted(unknowns.items()))
     parts = [
         f"{k!r} (did you mean: {', '.join(s)})" if s else f"{k!r} (no close match)"
-        for k, s in unknowns.items()
+        for k, s in sorted_unknowns.items()
     ]
     keys_str = ", ".join(parts)
-    if any(not s for s in unknowns.values()):
+    if any(not s for s in sorted_unknowns.values()):
         # 少なくとも 1 キーに候補なし → 全 allowed preview を message に添える
         preview = ", ".join(allowed_sorted[:5])
         suffix = ", ..." if len(allowed_sorted) > 5 else ""
@@ -195,13 +198,15 @@ def _raise_unknown_keys(
         )
     # did_you_mean は単一/複数で非対称にならないよう全候補を flatten populate。
     # 旧 agent が ``if err.did_you_mean:`` で分岐した場合でも候補ゼロ扱いにならない。
-    all_candidates = tuple(c for s in unknowns.values() for c in s)
+    # ``dict.fromkeys`` で挿入順を保持しつつ重複候補を排除 (R2-2)。
+    # 2 つの unknown key が同じ candidate を提示した場合の二重提示を回避する。
+    all_candidates = tuple(dict.fromkeys(c for s in sorted_unknowns.values() for c in s))
     raise ValidationError(
         msg,
         error_code="UNKNOWN_FRONTMATTER_KEY",
         did_you_mean=all_candidates,
         allowed=allowed_sorted,
-        unknown_keys=unknowns,
+        unknown_keys=sorted_unknowns,
     )
 
 
@@ -218,7 +223,7 @@ def _parse_entry(key: str, value: Any) -> MetadataCondition:
         f"metadata_filter[{key!r}] must be a string (implicit eq) or a dict "
         f"(explicit operator), got {type(value).__name__}. "
         f"Frontmatter scalars are normalized to strings at index time; "
-        f'pass the stringified form (e.g. {{{key!r}: "{value}"}}).'
+        f'pass the stringified form (e.g. {{{key!r}: "{_format_scalar_for_error(value)}"}}).'
     )
 
 

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -101,7 +101,11 @@ def vault_search(
             対応演算子: 暗黙 eq (str 値) / ``{"ne": str}`` / ``{"in": list[str]}``。
             リスト型 frontmatter 値は「含む」判定 (tags と同様)。
             unknown frontmatter key を指定すると ValidationError
-            (did_you_mean 付き) を返す (Issue #19)。
+            (did_you_mean 付き) を返す (Issue #19)。複数 unknown key を同時に
+            指定した場合は 1 回の ValidationError にまとめて報告され、各キーの
+            did_you_mean 候補は ``err.unknown_keys[key]`` を参照する (Issue #123)。
+            unknown key と unsupported operator が混在する場合、unknown key が
+            優先して報告される (3-pass 検証順)。
 
     Returns:
         常に plain dict を返す ({"tier", "total", "results": [dict]})。

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -104,8 +104,9 @@ def vault_search(
             (did_you_mean 付き) を返す (Issue #19)。複数 unknown key を同時に
             指定した場合は 1 回の ValidationError にまとめて報告され、各キーの
             did_you_mean 候補は ``err.unknown_keys[key]`` を参照する (Issue #123)。
-            unknown key と unsupported operator が混在する場合、unknown key が
-            優先して報告される (3-pass 検証順)。
+            検証優先順位は: 識別子構造エラー (malformed dot 等) → unknown key
+            (batch) → operator/value エラー (fail-first)。identifier エラーと
+            unknown key が混在する場合、identifier エラーが先に報告される。
 
     Returns:
         常に plain dict を返す ({"tier", "total", "results": [dict]})。

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import difflib
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from .exceptions import ErrorCode, VaultSearchError
 
@@ -92,9 +92,18 @@ class ValidationError(VaultSearchError, ValueError):
     hint:
         Optional short guidance for self-correction (e.g. "see schema://tools").
     did_you_mean:
-        Optional list of close-match candidates (from difflib).
+        Optional list of close-match candidates (from difflib). Populated for
+        single-unknown-key errors for backward compatibility; multi-key errors
+        expose per-key candidates via ``unknown_keys`` instead.
     allowed:
         Optional sorted list of all allowed values / keys.
+    unknown_keys:
+        Optional per-key close-match map for batched unknown-key reports
+        (``error_code="UNKNOWN_FRONTMATTER_KEY"`` from
+        :func:`~vault_search.filter.parse_metadata_filter`). Each entry maps an
+        unknown key to its suggestion tuple (empty tuple when no close match
+        exists). Single-key errors still populate this with one entry so agents
+        can inspect the structured form uniformly (#123).
     """
 
     error_code: ErrorCode = "VALIDATION_ERROR"
@@ -107,12 +116,16 @@ class ValidationError(VaultSearchError, ValueError):
         hint: str | None = None,
         did_you_mean: Sequence[str] | None = None,
         allowed: Sequence[str] | None = None,
+        unknown_keys: Mapping[str, Sequence[str]] | None = None,
     ) -> None:
         super().__init__(message)
         self.error_code = error_code
         self.hint = hint
         self.did_you_mean: tuple[str, ...] = tuple(did_you_mean) if did_you_mean else ()
         self.allowed: tuple[str, ...] = tuple(allowed) if allowed else ()
+        self.unknown_keys: dict[str, tuple[str, ...]] = (
+            {k: tuple(v) for k, v in unknown_keys.items()} if unknown_keys else {}
+        )
 
 
 def validate_identifier(
@@ -227,6 +240,7 @@ def validate_known_key(
         error_code="UNKNOWN_FRONTMATTER_KEY",
         did_you_mean=suggestions,
         allowed=sorted(known_keys),
+        unknown_keys={name: tuple(suggestions)},
     )
 
 

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -195,7 +195,7 @@ def format_unknown_key_message(
     name: str,
     kind: str,
     suggestions: Sequence[str],
-    allowed_sorted: Sequence[str],
+    known_keys: Sequence[str],
 ) -> str:
     """Build the single-unknown-key error message shared across validators.
 
@@ -203,6 +203,10 @@ def format_unknown_key_message(
     :func:`~vault_search.filter.parse_metadata_filter` (single-unknown batch
     path) so both produce identical text for the 1-key case and agents can
     rely on one canonical error shape (#123).
+
+    ``known_keys`` は順不同で渡してよい — 関数内で ``sorted()`` してから preview
+    を組み立てる。callsite に「ソート済みで渡す」暗黙契約を強いず、drift
+    リスクを低減する (Round 1 review D4)。
     """
     if suggestions:
         return (
@@ -210,6 +214,7 @@ def format_unknown_key_message(
             f"did you mean: {', '.join(suggestions)}? "
             f"See schema://tools for the frontmatter_keys list"
         )
+    allowed_sorted = sorted(known_keys)
     preview = ", ".join(allowed_sorted[:5])
     suffix = ", ..." if len(allowed_sorted) > 5 else ""
     return (
@@ -250,12 +255,11 @@ def validate_known_key(
     if name in known_keys:
         return name
     suggestions = tuple(difflib.get_close_matches(name, known_keys, n=3, cutoff=0.6))
-    allowed_sorted = sorted(known_keys)
     raise ValidationError(
-        format_unknown_key_message(name, kind, suggestions, allowed_sorted),
+        format_unknown_key_message(name, kind, suggestions, known_keys),
         error_code="UNKNOWN_FRONTMATTER_KEY",
         did_you_mean=suggestions,
-        allowed=allowed_sorted,
+        allowed=sorted(known_keys),
         unknown_keys={name: suggestions},
     )
 

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -33,6 +33,7 @@ __all__ = [
     "IDENTIFIER_MAX_LEN",
     "LIMIT_MAX",
     "ValidationError",
+    "format_unknown_key_message",
     "validate_identifier",
     "validate_known_key",
     "validate_pagination",
@@ -190,6 +191,34 @@ def validate_identifier(
     return name
 
 
+def format_unknown_key_message(
+    name: str,
+    kind: str,
+    suggestions: Sequence[str],
+    allowed_sorted: Sequence[str],
+) -> str:
+    """Build the single-unknown-key error message shared across validators.
+
+    Used by :func:`validate_known_key` (single-key path) and
+    :func:`~vault_search.filter.parse_metadata_filter` (single-unknown batch
+    path) so both produce identical text for the 1-key case and agents can
+    rely on one canonical error shape (#123).
+    """
+    if suggestions:
+        return (
+            f"Unknown {kind} {name!r}; "
+            f"did you mean: {', '.join(suggestions)}? "
+            f"See schema://tools for the frontmatter_keys list"
+        )
+    preview = ", ".join(allowed_sorted[:5])
+    suffix = ", ..." if len(allowed_sorted) > 5 else ""
+    return (
+        f"Unknown {kind} {name!r}; "
+        f"valid keys include: {preview}{suffix}. "
+        f"See schema://tools for the full list"
+    )
+
+
 def validate_known_key(
     name: str,
     known_keys: Sequence[str],
@@ -220,27 +249,14 @@ def validate_known_key(
     """
     if name in known_keys:
         return name
-    suggestions = difflib.get_close_matches(name, known_keys, n=3, cutoff=0.6)
-    if suggestions:
-        msg = (
-            f"Unknown {kind} {name!r}; "
-            f"did you mean: {', '.join(suggestions)}? "
-            f"See schema://tools for the frontmatter_keys list"
-        )
-    else:
-        preview = ", ".join(sorted(known_keys)[:5])
-        suffix = ", ..." if len(known_keys) > 5 else ""
-        msg = (
-            f"Unknown {kind} {name!r}; "
-            f"valid keys include: {preview}{suffix}. "
-            f"See schema://tools for the full list"
-        )
+    suggestions = tuple(difflib.get_close_matches(name, known_keys, n=3, cutoff=0.6))
+    allowed_sorted = sorted(known_keys)
     raise ValidationError(
-        msg,
+        format_unknown_key_message(name, kind, suggestions, allowed_sorted),
         error_code="UNKNOWN_FRONTMATTER_KEY",
         did_you_mean=suggestions,
-        allowed=sorted(known_keys),
-        unknown_keys={name: tuple(suggestions)},
+        allowed=allowed_sorted,
+        unknown_keys={name: suggestions},
     )
 
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -590,6 +590,90 @@ class TestParseMetadataFilterMultipleUnknownKeys:
 
 
 # ---------------------------------------------------------------------------
+# Round 1 review findings — multi-key UX refinements (Issue #123 follow-ups)
+#
+# #123 PR #135 round 1 レビューで指摘された以下を固定化:
+# - A2/B2: multi-key 時も did_you_mean に全候補 flatten (agent が旧 API で分岐
+#   しても候補ゼロにならない)
+# - B3: 混在 suggestion 時に「候補なし」が明示される ("no close match")
+# - B5: schema reference 文言を single/multi で統一 ("frontmatter_keys list")
+# ---------------------------------------------------------------------------
+
+
+class TestMultiKeyMessageRefinements:
+    """Round 1 review の multi-key message / 属性対称性を pin する."""
+
+    def test_multi_key_did_you_mean_flattened_for_backward_compat(self) -> None:
+        """multi-key 時も did_you_mean に全候補が flatten で入る (A2/B2).
+
+        旧 agent コードが ``if err.did_you_mean:`` で候補提示を分岐している場合、
+        multi-key 時に空 tuple になると「候補ゼロ」扱いで分岐が崩れる。
+        単一/複数で非対称にならないよう全候補を flatten populate する。
+        """
+        with pytest.raises(ValidationError) as exc:
+            parse_metadata_filter(
+                {"priorty": "5", "statu": "active"},
+                known_keys=["priority", "status"],
+            )
+        err = exc.value
+        # 各 unknown key の候補が全て did_you_mean に含まれる (順不同)
+        assert "priority" in err.did_you_mean, (
+            f"did_you_mean must include 'priority' for 'priorty'; got {err.did_you_mean!r}"
+        )
+        assert "status" in err.did_you_mean, (
+            f"did_you_mean must include 'status' for 'statu'; got {err.did_you_mean!r}"
+        )
+
+    def test_multi_key_did_you_mean_empty_when_no_candidates(self) -> None:
+        """multi-key で全 key に候補なしの場合、did_you_mean は空のまま."""
+        with pytest.raises(ValidationError) as exc:
+            parse_metadata_filter(
+                {"foo": "a", "bar": "b"},
+                known_keys=["priority"],
+            )
+        err = exc.value
+        # 候補なしキーのみ → did_you_mean は空
+        assert err.did_you_mean == (), (
+            f"did_you_mean must be empty when no candidates; got {err.did_you_mean!r}"
+        )
+
+    def test_multi_key_no_close_match_annotated_explicitly(self) -> None:
+        """候補なしキーは message で明示的に "no close match" と示される (B3).
+
+        混在ケース (``'foo'`` 候補なし、``'priorty'`` 候補 ``priority``) で
+        括弧が前キーにかかって見えて agent が誤読する懸念を解消。
+        """
+        with pytest.raises(ValidationError) as exc:
+            parse_metadata_filter(
+                {"xyzqqq": "a", "priorty": "5"},
+                known_keys=["priority", "status"],
+            )
+        msg = str(exc.value)
+        assert "no close match" in msg, (
+            f"no-close-match key must be annotated explicitly; got {msg!r}"
+        )
+        # priorty の候補は従来通り括弧付きで示される
+        assert "did you mean: priority" in msg, f"candidate must remain visible; got {msg!r}"
+
+    def test_multi_key_schema_reference_mentions_frontmatter_keys(self) -> None:
+        """multi-key message でも ``frontmatter_keys`` リソース名を明示する (B5).
+
+        単一 key は "for the frontmatter_keys list" で具体的だが、multi-key が
+        "for the full list" だと agent が schema://tools のどこを見るべきか
+        判断しづらい。文言を統一して navigation 先を明示する。
+        """
+        with pytest.raises(ValidationError) as exc:
+            parse_metadata_filter(
+                {"typo1": "a", "typo2": "b"},
+                known_keys=["priority", "status"],
+            )
+        msg = str(exc.value)
+        assert "frontmatter_keys" in msg, (
+            f"multi-key message must reference 'frontmatter_keys' for navigation; got {msg!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Range operator alias detection (Issue #87)
 #
 # gt / lt / gte / lte / > / < / >= / <= / greater_than / less_than 等の

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -282,6 +282,30 @@ def test_implicit_eq_non_string_error_hints_stringification() -> None:
     assert '"5"' in msg  # 具体例
 
 
+def test_implicit_eq_bool_value_error_hints_lowercase_stringification() -> None:
+    """暗黙 eq に bool を渡したエラーヒントは YAML/index 正規化と同じ小文字 ``"true"`` を示す.
+
+    #123 Round 2 review A-R2-1: ne / in 経路は ``_format_scalar_for_error`` 経由で
+    ``"true"`` (小文字) を hint に出すが、implicit eq の fallback hint は生 str
+    のため ``"True"`` (大文字) になり、agent がコピペすると index 側の
+    ``"true"`` と silent miss する。ne / in と対称に小文字化する。
+    """
+    with pytest.raises(ValidationError) as exc:
+        parse_metadata_filter({"archived": True})
+    msg = str(exc.value)
+    assert "bool" in msg
+    assert "normalized to strings" in msg
+    # 実際 index には "true" (小文字) で格納されるため、hint も小文字で示す
+    assert '"true"' in msg, (
+        f"bool True の hint は小文字 'true' を示すべき (YAML/normalization 整合); got {msg!r}"
+    )
+    # 大文字 "True" で示さないことを明示 (silent miss 防止)
+    assert '"True"' not in msg, (
+        f"bool True の hint に大文字 'True' が混入すると agent の copy-paste が "
+        f"silent miss する; got {msg!r}"
+    )
+
+
 def test_in_operator_non_string_item_error_hints_stringification() -> None:
     """in のリスト要素に bool を渡したエラーも stringify を指示する."""
     with pytest.raises(ValidationError) as exc:
@@ -741,6 +765,46 @@ class TestMultiKeyMessageRefinements:
         msg = str(exc.value)
         assert "frontmatter_keys" in msg, (
             f"multi-key message must reference 'frontmatter_keys' for navigation; got {msg!r}"
+        )
+
+    def test_multi_key_did_you_mean_deduplicated(self) -> None:
+        """2 つの unknown key が同じ候補を提示した場合、did_you_mean は dedup される (R2-2).
+
+        e.g. ``{"prio": ..., "priori": ...}`` は両方 ``"priority"`` を候補に挙げる。
+        agent が ``for candidate in err.did_you_mean`` でリトライ UI を組むと、
+        同一候補の二重提示は UX を悪化させる。順序を保持しつつ dedup する。
+        """
+        with pytest.raises(ValidationError) as exc:
+            parse_metadata_filter(
+                {"prio": "5", "priori": "3"},
+                known_keys=["priority", "status"],
+            )
+        err = exc.value
+        # "priority" は重複なく 1 回のみ含まれる
+        assert err.did_you_mean.count("priority") == 1, (
+            f"did_you_mean must dedup candidates; got {err.did_you_mean!r}"
+        )
+
+    def test_multi_key_message_key_order_deterministic(self) -> None:
+        """multi-key message / did_you_mean の key 順が入力挿入順に依存しない (R2-3).
+
+        agent が ``{"a": ..., "b": ...}`` と ``{"b": ..., "a": ...}`` を投げた際、
+        エラーメッセージが文字単位で異なると log 検索性・snapshot test の
+        再現性が劣化する。unknown key 名のソート順で固定する。
+        """
+        with pytest.raises(ValidationError) as exc1:
+            parse_metadata_filter({"zapple": "a", "aapple": "b"}, known_keys=["banana"])
+        with pytest.raises(ValidationError) as exc2:
+            parse_metadata_filter({"aapple": "b", "zapple": "a"}, known_keys=["banana"])
+        # 同一入力内容で挿入順が違っても message は一致する (deterministic)
+        assert str(exc1.value) == str(exc2.value), (
+            "multi-key message must be deterministic under input reordering; "
+            f"got:\n  1st: {str(exc1.value)!r}\n  2nd: {str(exc2.value)!r}"
+        )
+        # message 内で 'aapple' が 'zapple' より先に現れる (alphabetical sort)
+        msg = str(exc1.value)
+        assert msg.index("aapple") < msg.index("zapple"), (
+            f"keys must appear in alphabetical order; got {msg!r}"
         )
 
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -487,6 +487,109 @@ class TestParseMetadataFilterUnknownKey:
 
 
 # ---------------------------------------------------------------------------
+# Multiple unknown key collection (Issue #123)
+#
+# 複数 unknown key が 1 回の ValidationError にまとめて報告されることを pin する。
+# 旧挙動は「最初の 1 件で raise」で、agent が typo を 2 つ同時に hallucinate
+# した場合 2 round-trip が必要だった。LLM agent は複数キーを同時に間違えやすい
+# ため、全 unknown key を collect してから一括報告することで self-correction
+# 効率を改善する。
+# ---------------------------------------------------------------------------
+
+
+class TestParseMetadataFilterMultipleUnknownKeys:
+    """parse_metadata_filter が複数 unknown key を batch 収集する (Issue #123).
+
+    ValidationError に新規属性 ``unknown_keys: dict[str, tuple[str, ...]]`` を
+    追加し、各 unknown key に対する did_you_mean 候補を構造化保持する。
+    単一 key 時は従来の ``did_you_mean`` / ``allowed`` 属性も populated のまま
+    (backward compat)。
+    """
+
+    def test_multiple_unknown_keys_reported_together(self) -> None:
+        """2 つ以上の unknown key が 1 回の ValidationError で報告される."""
+        with pytest.raises(ValidationError) as exc:
+            parse_metadata_filter(
+                {"priorty": "5", "statu": "active"},
+                known_keys=["priority", "status"],
+            )
+        err = exc.value
+        assert err.error_code == "UNKNOWN_FRONTMATTER_KEY"
+        msg = str(err)
+        # 両方の unknown key 名がメッセージに含まれる (first-fail-only なら片方欠落)
+        assert "priorty" in msg, f"first unknown key missing from message: {msg!r}"
+        assert "statu" in msg, f"second unknown key missing from message: {msg!r}"
+        # 各キーの did_you_mean 候補もメッセージに含まれる (agent の 1-shot 修正用)
+        assert "priority" in msg, f"suggestion for 'priorty' missing: {msg!r}"
+        assert "status" in msg, f"suggestion for 'statu' missing: {msg!r}"
+
+    def test_unknown_keys_attribute_structured_per_key(self) -> None:
+        """unknown_keys 属性が各 key ごとの did_you_mean 候補を dict で保持する."""
+        with pytest.raises(ValidationError) as exc:
+            parse_metadata_filter(
+                {"priorty": "5", "statu": "active"},
+                known_keys=["priority", "status", "tags"],
+            )
+        err = exc.value
+        assert hasattr(err, "unknown_keys"), (
+            "ValidationError must expose unknown_keys dict for multi-key DX"
+        )
+        # dict[str, tuple[str, ...]] — キーは unknown key、値は候補 tuple
+        assert set(err.unknown_keys.keys()) == {"priorty", "statu"}
+        assert "priority" in err.unknown_keys["priorty"]
+        assert "status" in err.unknown_keys["statu"]
+
+    def test_three_unknown_keys_all_collected(self) -> None:
+        """3 つの unknown key すべてが報告され、first-fail-only が再発しないことを pin."""
+        with pytest.raises(ValidationError) as exc:
+            parse_metadata_filter(
+                {"foo": "a", "bar": "b", "baz": "c"},
+                known_keys=["priority"],
+            )
+        err = exc.value
+        assert err.error_code == "UNKNOWN_FRONTMATTER_KEY"
+        assert set(err.unknown_keys.keys()) == {"foo", "bar", "baz"}, (
+            "all 3 unknown keys must be collected (regression guard against "
+            f"first-fail-only); got {err.unknown_keys!r}"
+        )
+
+    def test_mixed_known_and_unknown_only_reports_unknown(self) -> None:
+        """known key と unknown key が混在する場合、unknown のみ報告される."""
+        with pytest.raises(ValidationError) as exc:
+            parse_metadata_filter(
+                {"priority": "5", "typo1": "a", "typo2": "b"},
+                known_keys=["priority", "status"],
+            )
+        err = exc.value
+        assert set(err.unknown_keys.keys()) == {"typo1", "typo2"}
+        assert "priority" not in err.unknown_keys, (
+            f"known keys must not appear in unknown_keys; got {err.unknown_keys!r}"
+        )
+
+    def test_single_unknown_key_backward_compat(self) -> None:
+        """unknown key が 1 つの場合、従来の did_you_mean 属性も populated."""
+        with pytest.raises(ValidationError) as exc:
+            parse_metadata_filter({"priorty": "5"}, known_keys=["priority", "status"])
+        err = exc.value
+        # 新属性にも 1 エントリある
+        assert set(err.unknown_keys.keys()) == {"priorty"}
+        assert "priority" in err.unknown_keys["priorty"]
+        # 従来の did_you_mean / allowed 属性は単一 key 時の backward compat で維持
+        assert "priority" in err.did_you_mean
+        assert set(err.allowed) == {"priority", "status"}
+
+    def test_multiple_unknown_keys_allowed_full_sorted(self) -> None:
+        """multi-unknown 時も allowed は known_keys のソート済み全集合を含む."""
+        with pytest.raises(ValidationError) as exc:
+            parse_metadata_filter(
+                {"typo1": "a", "typo2": "b"},
+                known_keys=["priority", "status", "tags"],
+            )
+        err = exc.value
+        assert set(err.allowed) == {"priority", "status", "tags"}
+
+
+# ---------------------------------------------------------------------------
 # Range operator alias detection (Issue #87)
 #
 # gt / lt / gte / lte / > / < / >= / <= / greater_than / less_than 等の

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -807,6 +807,24 @@ class TestMultiKeyMessageRefinements:
             f"keys must appear in alphabetical order; got {msg!r}"
         )
 
+    def test_multi_key_unknown_keys_iteration_order_alphabetical(self) -> None:
+        """``err.unknown_keys`` の iteration 順も alphabetical で固定 (R3 D-1 coverage).
+
+        message の順序と attribute iteration 順は一致すべき (agent が dict
+        iteration で UI を組む場合の一貫性)。既存テストは ``set()`` 比較のみで
+        順序を固定していなかった coverage gap を補強。
+        """
+        with pytest.raises(ValidationError) as exc:
+            parse_metadata_filter(
+                {"zapple": "a", "aapple": "b", "mango": "c"},
+                known_keys=["banana"],
+            )
+        err = exc.value
+        assert list(err.unknown_keys.keys()) == ["aapple", "mango", "zapple"], (
+            f"unknown_keys must iterate in alphabetical order; "
+            f"got {list(err.unknown_keys.keys())!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Range operator alias detection (Issue #87)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -507,7 +507,13 @@ class TestParseMetadataFilterMultipleUnknownKeys:
     """
 
     def test_multiple_unknown_keys_reported_together(self) -> None:
-        """2 つ以上の unknown key が 1 回の ValidationError で報告される."""
+        """2 つ以上の unknown key が 1 回の ValidationError で報告される.
+
+        ``known_keys`` にも ``"priority"`` を含めたケースで「メッセージに
+        ``"priority"`` が含まれる」だけだと valid-keys preview 経由で通過する
+        vacuous pass 余地がある。構造化属性 ``unknown_keys`` と
+        ``did you mean: priority`` の逐語 pattern の両方で pin する。
+        """
         with pytest.raises(ValidationError) as exc:
             parse_metadata_filter(
                 {"priorty": "5", "statu": "active"},
@@ -515,13 +521,20 @@ class TestParseMetadataFilterMultipleUnknownKeys:
             )
         err = exc.value
         assert err.error_code == "UNKNOWN_FRONTMATTER_KEY"
+        # 構造化属性で両キー batch 収集を primary に検証
+        assert set(err.unknown_keys.keys()) == {"priorty", "statu"}
         msg = str(err)
         # 両方の unknown key 名がメッセージに含まれる (first-fail-only なら片方欠落)
         assert "priorty" in msg, f"first unknown key missing from message: {msg!r}"
         assert "statu" in msg, f"second unknown key missing from message: {msg!r}"
-        # 各キーの did_you_mean 候補もメッセージに含まれる (agent の 1-shot 修正用)
-        assert "priority" in msg, f"suggestion for 'priorty' missing: {msg!r}"
-        assert "status" in msg, f"suggestion for 'statu' missing: {msg!r}"
+        # 候補が "did you mean: ..." 逐語 pattern で現れることを pin
+        # (単に ``"priority" in msg`` だと valid-keys preview 経由で vacuous に通る)
+        assert "did you mean: priority" in msg, (
+            f"suggestion for 'priorty' must appear in 'did you mean:' pattern; got {msg!r}"
+        )
+        assert "did you mean: status" in msg, (
+            f"suggestion for 'statu' must appear in 'did you mean:' pattern; got {msg!r}"
+        )
 
     def test_unknown_keys_attribute_structured_per_key(self) -> None:
         """unknown_keys 属性が各 key ごとの did_you_mean 候補を dict で保持する."""
@@ -579,14 +592,72 @@ class TestParseMetadataFilterMultipleUnknownKeys:
         assert set(err.allowed) == {"priority", "status"}
 
     def test_multiple_unknown_keys_allowed_full_sorted(self) -> None:
-        """multi-unknown 時も allowed は known_keys のソート済み全集合を含む."""
+        """multi-unknown 時も allowed は known_keys をソート済み tuple で含む."""
         with pytest.raises(ValidationError) as exc:
             parse_metadata_filter(
                 {"typo1": "a", "typo2": "b"},
-                known_keys=["priority", "status", "tags"],
+                known_keys=["tags", "priority", "status"],
             )
         err = exc.value
-        assert set(err.allowed) == {"priority", "status", "tags"}
+        # 集合比較ではなく順序付き tuple で pin (C2 review: "sorted" 主張の担保)
+        assert tuple(err.allowed) == ("priority", "status", "tags"), (
+            f"allowed must be sorted ascending; got {err.allowed!r}"
+        )
+
+    def test_multi_key_no_candidates_message_includes_valid_keys(self) -> None:
+        """全キーに候補なしの multi-key batch で message が valid keys を列挙 (C3).
+
+        ``known_keys=["zzz"]`` と close match 不能な key の組み合わせで、
+        ``_raise_unknown_keys`` の「候補なし混在」分岐が正しく valid keys
+        preview を付加することを pin する。
+        """
+        with pytest.raises(ValidationError) as exc:
+            parse_metadata_filter(
+                {"foo": "a", "bar": "b"},
+                known_keys=["zzz"],
+            )
+        err = exc.value
+        assert err.error_code == "UNKNOWN_FRONTMATTER_KEY"
+        # 各 key の候補は空 tuple
+        assert err.unknown_keys == {"foo": (), "bar": ()}, (
+            f"all keys must have empty suggestions; got {err.unknown_keys!r}"
+        )
+        msg = str(err)
+        # message に valid keys preview と "no close match" が含まれる
+        assert "zzz" in msg, f"valid keys preview missing; got {msg!r}"
+        assert "no close match" in msg, f"no-close-match annotation missing; got {msg!r}"
+
+    def test_known_keys_none_allows_multiple_keys(self) -> None:
+        """known_keys=None で複数キーを渡しても batch 収集経路に落ちず通る (C5).
+
+        ``if known_keys is not None:`` の早期 skip が壊れた場合の regression
+        guard。multi-key 収集経路が誤って None でも発動する変更を検知する。
+        """
+        conditions = parse_metadata_filter(
+            {"foo": "a", "bar": "b", "baz": "c"},
+            known_keys=None,
+        )
+        assert len(conditions) == 3
+        assert {c.key for c in conditions} == {"foo", "bar", "baz"}
+
+    def test_unknown_key_takes_precedence_over_bad_operator(self) -> None:
+        """3-pass 化で unknown key 検出が op/value error より先に発火する (A3).
+
+        旧 per-key interleave では ``{"known": {"bad_op": 5}, "typo": "x"}`` が
+        bad_op で先に fail していたが、3-pass 化後は pass 2 が typo を検出して
+        UNKNOWN_FRONTMATTER_KEY を raise する。この契約変更を明示的に pin する。
+        """
+        with pytest.raises(ValidationError) as exc:
+            parse_metadata_filter(
+                {"priority": {"bad_op": 5}, "typo": "x"},
+                known_keys=["priority", "status"],
+            )
+        err = exc.value
+        assert err.error_code == "UNKNOWN_FRONTMATTER_KEY", (
+            "unknown key detection must precede per-entry operator validation; "
+            f"got error_code={err.error_code!r}"
+        )
+        assert "typo" in err.unknown_keys
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -362,3 +362,41 @@ class TestValidateKnownKey:
         with pytest.raises(ValidationError) as exc:
             validate_known_key("xyz", ["a"], kind="frontmatter key")
         assert "frontmatter key" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# ValidationError.unknown_keys 契約 (Issue #123 round 1 review D5)
+#
+# ``unknown_keys`` 属性は ``parse_metadata_filter`` の batch 経路専用だが、
+# ValidationError の契約は validation 層の単体テストとして独立に pin する。
+# 将来 subclass 化 (#32 follow-up) や属性名変更時の source of truth。
+# ---------------------------------------------------------------------------
+
+
+class TestValidationErrorUnknownKeysAttribute:
+    """ValidationError.unknown_keys 属性の直接契約テスト."""
+
+    def test_default_is_empty_dict(self) -> None:
+        """unknown_keys を渡さないと空 dict になる."""
+        err = ValidationError("msg")
+        assert err.unknown_keys == {}
+
+    def test_mapping_converted_to_dict_of_tuple(self) -> None:
+        """渡した Mapping は ``dict[str, tuple[str, ...]]`` に正規化される."""
+        err = ValidationError(
+            "msg",
+            unknown_keys={"priorty": ["priority"], "statu": ["status"]},
+        )
+        assert isinstance(err.unknown_keys, dict)
+        assert err.unknown_keys["priorty"] == ("priority",)
+        assert err.unknown_keys["statu"] == ("status",)
+
+    def test_empty_sequence_preserved_per_key(self) -> None:
+        """候補なしキーは空 tuple として保持される (None でなく空 tuple)."""
+        err = ValidationError("msg", unknown_keys={"foo": []})
+        assert err.unknown_keys == {"foo": ()}
+
+    def test_non_unknown_key_error_has_empty_unknown_keys(self) -> None:
+        """他 error_code の ValidationError は unknown_keys が常に空."""
+        err = ValidationError("bad op", error_code="VALIDATION_ERROR")
+        assert err.unknown_keys == {}


### PR DESCRIPTION
## Summary

- `parse_metadata_filter` が first-fail-only で 1 キーしか報告しなかったため、
  LLM agent が `{"typo1": "a", "typo2": "b"}` のように複数キーを同時に hallucinate
  した場合 N round-trip が必要だった
- 全 unknown key を 1 pass で収集し、1 個の `ValidationError` として一括報告
- `ValidationError` に `unknown_keys: dict[str, tuple[str, ...]]` 属性を追加し、
  各 unknown key → did_you_mean 候補を構造化保持 (単一 key 時は従来の
  `did_you_mean` / `allowed` も populated のまま — backward compat)

## 変更点

- `src/vault_search/validation.py`
  - `ValidationError.__init__` に `unknown_keys: Mapping[str, Sequence[str]] | None` 追加
  - `format_unknown_key_message(name, kind, suggestions, allowed_sorted)` を新規公開
    (validate_known_key / filter の単一 key message を共通化)
  - `validate_known_key` は helper 経由 + `unknown_keys={name: suggestions}` populated
- `src/vault_search/filter.py`
  - `parse_metadata_filter` を 3-pass 化 (identifier → unknown 収集 → entry parse)
  - `_raise_unknown_keys` で batch 報告 (単一 key / 複数 key で message 形式を分岐)
- `tests/test_filter.py`
  - `TestParseMetadataFilterMultipleUnknownKeys` 6 件追加
    - 2 key 同時報告 / 構造化 unknown_keys / 3 key regression guard /
      known+unknown 混在 / 単一 key backward compat / allowed 全集合

## Test plan

- [x] `uv run pytest` — 425 件 green (新規 6 件含む)
- [x] `uv run ruff check src/ tests/` — all passed
- [x] `uv run ruff format --check src/` — all formatted
- [x] 単一 key 時の既存 `did_you_mean` / `allowed` 挙動 backward compat
- [x] メッセージ bit-identical (単一 key 分岐は validate_known_key と共通 helper 経由)

Closes #123

https://claude.ai/code/session_019o8Q3oindKb3LtmwTtsWoP