### PR TITLE
Fix: list_frontmatter_keys に nested dotted key を含める (#136)

### DIFF
--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -26,6 +26,21 @@ from .parser import ParsedNote, parse_note
 logger = logging.getLogger(__name__)
 
 
+def _collect_nested_keys(obj: Any, prefix: str, out: set[str]) -> None:
+    """frontmatter dict を再帰 walk して dotted key を ``out`` に収集する.
+
+    array 要素の dict (``tags: [{a: 1}]``) は走査しない — SQL の
+    ``$.tags.a`` パスは不成立で意味がないため、known_keys に含めない。
+    """
+    if not isinstance(obj, dict):
+        return
+    for k, v in obj.items():
+        key = f"{prefix}.{k}" if prefix else k
+        out.add(key)
+        if isinstance(v, dict):
+            _collect_nested_keys(v, key, out)
+
+
 # ---------------------------------------------------------------------------
 # VaultIndex — SQLite + FTS5
 # ---------------------------------------------------------------------------
@@ -595,7 +610,12 @@ class VaultIndex:
             return [{"folder": r["folder"], "count": r["count"]} for r in rows]
 
     def list_frontmatter_keys(self) -> list[str]:
-        """Vault 内 frontmatter のトップレベルキーをソート済みで返す.
+        """Vault 内 frontmatter のキーをソート済みで返す.
+
+        トップレベルキーに加え、ネスト dict 値は dotted key (``meta.author``)
+        としても含まれる (Issue #136)。validate_identifier / SQL が dotted 形式を
+        受理するので、known_keys 側も一貫して dotted を公開し
+        ``metadata_filter={"meta.author": ...}`` の false positive UNKNOWN を防ぐ。
 
         初回呼出時に DB をスキャンしてキャッシュし、以降は書込み経路で
         invalidate されるまでキャッシュを返す (Issue #118 / #10)。
@@ -605,13 +625,17 @@ class VaultIndex:
         return list(self._frontmatter_keys_cache)
 
     def _query_frontmatter_keys_from_db(self) -> list[str]:
-        """Frontmatter のトップレベルキー集合を DB から取得する (キャッシュ無視)."""
+        """Frontmatter のキー集合 (トップレベル + nested dotted) を DB から取得する."""
         with self.connection() as conn:
             rows = conn.execute(
-                "SELECT DISTINCT key FROM notes, json_each(notes.frontmatter) "
-                "WHERE json_valid(notes.frontmatter) ORDER BY key"
+                "SELECT frontmatter FROM notes WHERE json_valid(frontmatter)"
             ).fetchall()
-            return [r["key"] for r in rows]
+        keys: set[str] = set()
+        for row in rows:
+            fm = json.loads(row["frontmatter"])
+            if isinstance(fm, dict):
+                _collect_nested_keys(fm, "", keys)
+        return sorted(keys)
 
     def stats(self) -> dict[str, Any]:
         """インデックスの統計情報."""

--- a/tests/test_nested_frontmatter_keys.py
+++ b/tests/test_nested_frontmatter_keys.py
@@ -1,0 +1,86 @@
+"""Issue #136: ネスト frontmatter のキーが dotted 形式で known_keys に現れること.
+
+``validate_identifier`` は ``a.b`` 形式を許可し、SQL (``$.meta.author``) も
+正しく辿れるのに、``list_frontmatter_keys`` がトップレベルキーしか返さないため
+``metadata_filter={"meta.author": ...}`` が UNKNOWN_FRONTMATTER_KEY で拒否される
+false positive を pin する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vault_search.indexer import VaultIndex
+from vault_search.validation import ValidationError
+
+
+@pytest.fixture
+def nested_vault(tmp_path: Path) -> Path:
+    """ネスト frontmatter を持つ最小 vault."""
+    root = tmp_path / "vault"
+    root.mkdir()
+    (root / "nested.md").write_text(
+        "---\nmeta:\n  author: foo\n  tag: bar\nsimple: scalar-value\n---\nbody\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+@pytest.fixture
+def nested_index(nested_vault: Path, tmp_path: Path) -> VaultIndex:
+    db_path = tmp_path / "nested.db"
+    idx = VaultIndex(nested_vault, db_path=db_path)
+    idx.build_index()
+    return idx
+
+
+def test_list_frontmatter_keys_includes_nested_dotted_keys(
+    nested_index: VaultIndex,
+) -> None:
+    """ネスト dict 値は dotted key として known_keys に現れる."""
+    keys = set(nested_index.list_frontmatter_keys())
+    assert "meta" in keys, "トップレベルキーも従来通り含まれる"
+    assert "meta.author" in keys, "ネスト子キーも dotted で含まれる必要がある (#136)"
+    assert "meta.tag" in keys
+    assert "simple" in keys
+
+
+def test_vault_search_accepts_nested_metadata_filter_key(
+    nested_index: VaultIndex,
+) -> None:
+    """nested frontmatter のキーが metadata_filter で false positive UNKNOWN されない.
+
+    ``meta.author`` は validate_identifier で許容され SQL も辿れるので、
+    unknown エラーにならず 1 件 hit するべき。
+    """
+    res = nested_index.search(
+        query="",
+        folder=None,
+        metadata_filter={"meta.author": "foo"},
+        limit=20,
+        offset=0,
+    )
+    assert res["total"] == 1
+    assert res["results"][0]["path"] == "nested.md"
+
+
+def test_vault_search_rejects_truly_unknown_dotted_key(
+    nested_index: VaultIndex,
+) -> None:
+    """存在しない親キーを使った dotted key は引き続き UNKNOWN として拒否される.
+
+    #136 修正で「ドット以降を無条件に pass させる」弱い修正を選ばないことを pin。
+    (Option A: 再帰展開で known_keys に実在する dotted のみ追加する方針)
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        nested_index.search(
+            query="",
+            folder=None,
+            metadata_filter={"nonexistent.child": "value"},
+            limit=20,
+            offset=0,
+        )
+    err = exc_info.value
+    assert err.error_code == "UNKNOWN_FRONTMATTER_KEY"


### PR DESCRIPTION
## Summary

- ネスト frontmatter (``meta: {author: foo}``) のキーが ``list_frontmatter_keys`` でトップレベル (``meta``) のみ返され、``metadata_filter={\"meta.author\": ...}`` が UNKNOWN_FRONTMATTER_KEY で false positive 拒否されていた
- ``_query_frontmatter_keys_from_db`` を Python 側 walk に差し替え、ネスト dict を再帰展開して dotted key (``meta.author`` / ``meta.tag``) も known_keys に含めるように変更
- validate_identifier は dotted 形式を既に許容しており、SQL (``$.meta.author``) も正しく辿れるため、validation 層と SQL 層と known_keys の整合性が取れていなかった不整合を解消

## Test plan

- [x] ``test_list_frontmatter_keys_includes_nested_dotted_keys``: トップレベル + dotted 両方が含まれる
- [x] ``test_vault_search_accepts_nested_metadata_filter_key``: search 経路で ValidationError にならず 1 件 hit
- [x] ``test_vault_search_rejects_truly_unknown_dotted_key``: 存在しない親キーの dotted は従来通り拒否 (修正の幅を制限する regression guard)
- [x] ``pytest``: 447 全通過 (Red 3 件追加)
- [x] ``ruff check`` / ``ruff format``: clean

## Refactor 省略理由

tdd-workflow.md の「Refactor 省略の判断基準」に照らし、Green diff に:
- repetition なし (単一関数の差替えのみ)
- 応急回避なし (validation 側に dotted pass-through のようなハックを入れていない)
- stale comment なし (``list_frontmatter_keys`` docstring に #136 の意図と「nested dotted key を含む」を明記済)

``build_schema_payload`` の docstring は ``list_frontmatter_keys()`` の戻り値をそのまま公開すると既に書かれており、dotted 包含の追記は重複となるため省略。

## 設計ノート (Option A 採用の根拠)

Issue #136 の Option A (list_frontmatter_keys 再帰展開) を採用。

- **Option A (採用)**: known_keys 側で dotted を実在する nested パスに限定して公開。schema://tools の frontmatter_keys にも反映されるため agent DX も一貫
- **Option B (不採用)**: validator で ``key.split(\".\")[0]`` が known_keys にあれば pass → 「存在しない nested パス (``meta.xxx``)」が UNKNOWN にならず SQL で empty match するだけになり UX 劣化
- array 要素の dict (``tags: [{a: 1}]``) は意図的に走査しない (``$.tags.a`` パスは SQL で不成立で意味がないため)

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)