### PR TITLE
Refactor: unknown key 検出の層越え解消 + message 構築統合 + orphan 解消 (#138/#140/#141)

### DIFF
--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -19,15 +19,14 @@ frontmatter の任意プロパティを AND 条件で絞り込む dict 構文を
 
 from __future__ import annotations
 
-import difflib
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Literal, NoReturn, get_args
+from typing import Any, Literal, get_args
 
 from .validation import (
     ValidationError,
-    format_unknown_key_message,
     validate_identifier,
+    validate_known_keys,
     validate_value,
 )
 
@@ -129,16 +128,14 @@ def parse_metadata_filter(
             raise ValidationError(f"metadata_filter key must be a string, got {type(key).__name__}")
         validate_identifier(key, kind="frontmatter key")
 
-    # Second pass: collect ALL unknown keys and raise once if any (#123).
-    # LLM agent は複数キーを同時に hallucinate しやすいため、first-fail では
-    # self-correction に N round-trip かかる。1 回の batch 報告に統合する。
+    # Second pass: batch-validate all keys against ``known_keys`` and raise
+    # a single ValidationError if any are unknown (#123). LLM agents tend to
+    # hallucinate multiple keys at once, so reporting all unknowns in one
+    # round-trip beats first-fail. The batch logic (dedupe, sort, message
+    # building) lives in ``validate_known_keys`` so filter.py and validation.py
+    # share one code path (#140/#141).
     if known_keys is not None:
-        unknowns: dict[str, tuple[str, ...]] = {}
-        for key in raw:
-            if key not in known_keys:
-                unknowns[key] = tuple(difflib.get_close_matches(key, known_keys, n=3, cutoff=0.6))
-        if unknowns:
-            _raise_unknown_keys(unknowns, known_keys)
+        validate_known_keys(list(raw.keys()), known_keys, kind="frontmatter key")
 
     # Third pass: parse individual entries. op / value 検証は fail-first。
     conditions: list[MetadataCondition] = []
@@ -146,68 +143,6 @@ def parse_metadata_filter(
         conditions.append(_parse_entry(key, value))
 
     return conditions
-
-
-def _raise_unknown_keys(
-    unknowns: dict[str, tuple[str, ...]],
-    known_keys: Sequence[str],
-) -> NoReturn:
-    """収集済み unknown key を 1 個の ValidationError にまとめて raise (#123).
-
-    単一 key 時は既存の ``validate_known_key`` と同形式のメッセージを返し、
-    ``did_you_mean`` / ``allowed`` 属性も populated (backward compat)。
-    複数 key 時は ``Unknown frontmatter keys: ...`` 形式で各 key ごとの候補を
-    列挙し、候補なしキーは明示的に ``(no close match)`` と注釈する。
-    構造化情報は ``unknown_keys`` 属性に格納し、``did_you_mean`` にも全候補を
-    flatten populate することで agent の旧分岐ロジックと対称性を保つ。
-    """
-    allowed_sorted = sorted(known_keys)
-
-    if len(unknowns) == 1:
-        ((key, suggestions),) = unknowns.items()
-        raise ValidationError(
-            format_unknown_key_message(key, "frontmatter key", suggestions, known_keys),
-            error_code="UNKNOWN_FRONTMATTER_KEY",
-            did_you_mean=suggestions,
-            allowed=allowed_sorted,
-            unknown_keys=unknowns,
-        )
-
-    # Multi-key path: 各キーに候補/なしを明示注釈して混在ケースの曖昧さを解消。
-    # unknown key 名でソートして、入力挿入順に依存しない決定的 message / did_you_mean
-    # を生成する (R2-3)。log 検索性と snapshot 再現性のため。
-    sorted_unknowns = dict(sorted(unknowns.items()))
-    parts = [
-        f"{k!r} (did you mean: {', '.join(s)})" if s else f"{k!r} (no close match)"
-        for k, s in sorted_unknowns.items()
-    ]
-    keys_str = ", ".join(parts)
-    if any(not s for s in sorted_unknowns.values()):
-        # 少なくとも 1 キーに候補なし → 全 allowed preview を message に添える
-        preview = ", ".join(allowed_sorted[:5])
-        suffix = ", ..." if len(allowed_sorted) > 5 else ""
-        msg = (
-            f"Unknown frontmatter keys: {keys_str}. "
-            f"Valid keys include: {preview}{suffix}. "
-            f"See schema://tools for the frontmatter_keys list"
-        )
-    else:
-        msg = (
-            f"Unknown frontmatter keys: {keys_str}. "
-            f"See schema://tools for the frontmatter_keys list"
-        )
-    # did_you_mean は単一/複数で非対称にならないよう全候補を flatten populate。
-    # 旧 agent が ``if err.did_you_mean:`` で分岐した場合でも候補ゼロ扱いにならない。
-    # ``dict.fromkeys`` で挿入順を保持しつつ重複候補を排除 (R2-2)。
-    # 2 つの unknown key が同じ candidate を提示した場合の二重提示を回避する。
-    all_candidates = tuple(dict.fromkeys(c for s in sorted_unknowns.values() for c in s))
-    raise ValidationError(
-        msg,
-        error_code="UNKNOWN_FRONTMATTER_KEY",
-        did_you_mean=all_candidates,
-        allowed=allowed_sorted,
-        unknown_keys=sorted_unknowns,
-    )
 
 
 def _parse_entry(key: str, value: Any) -> MetadataCondition:

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import difflib
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 
 from .exceptions import ErrorCode, VaultSearchError
 
@@ -34,8 +34,10 @@ __all__ = [
     "LIMIT_MAX",
     "ValidationError",
     "format_unknown_key_message",
+    "format_unknown_keys_message",
     "validate_identifier",
     "validate_known_key",
+    "validate_known_keys",
     "validate_pagination",
     "validate_value",
 ]
@@ -191,36 +193,140 @@ def validate_identifier(
     return name
 
 
+def format_unknown_keys_message(
+    unknowns: Mapping[str, Sequence[str]],
+    kind: str,
+    known_keys: Sequence[str],
+    *,
+    schema_ref: str = "schema://tools",
+    registry_label: str = "frontmatter_keys list",
+) -> str:
+    """Build a unified unknown-key error message covering 1 and N unknown keys.
+
+    Consolidates the single-key (``validate_known_key``) and multi-key
+    (``filter._raise_unknown_keys``) paths into one builder so preview length
+    and schema-reference wording live in one place (#140).
+
+    MCP / frontmatter-specific wording is injected via ``schema_ref`` and
+    ``registry_label`` instead of hardcoded strings; defaults match the
+    legacy callsites so existing messages remain bit-identical (#138).
+
+    ``known_keys`` は順不同で渡してよい — 関数内で ``sorted()`` してから preview
+    を組み立てる。callsite に「ソート済みで渡す」暗黙契約を強いず、drift
+    リスクを低減する (Round 1 review D4)。
+    """
+    allowed_sorted = sorted(known_keys)
+
+    if len(unknowns) == 1:
+        ((name, suggestions),) = unknowns.items()
+        if suggestions:
+            return (
+                f"Unknown {kind} {name!r}; "
+                f"did you mean: {', '.join(suggestions)}? "
+                f"See {schema_ref} for the {registry_label}"
+            )
+        preview = ", ".join(allowed_sorted[:5])
+        suffix = ", ..." if len(allowed_sorted) > 5 else ""
+        # Single-key no-match keeps the legacy "full list" wording (kind-agnostic)
+        # for bit-identicalness with pre-#138 messages. registry_label is reserved
+        # for did-you-mean / multi-key branches where agents need a navigation
+        # target inside schema://tools.
+        return (
+            f"Unknown {kind} {name!r}; "
+            f"valid keys include: {preview}{suffix}. "
+            f"See {schema_ref} for the full list"
+        )
+
+    # Multi-key path. Sort by unknown key name so the message is deterministic
+    # under input reordering (R2-3) and matches ``err.unknown_keys`` iteration
+    # order (R3 D-1).
+    sorted_unknowns = dict(sorted(unknowns.items()))
+    parts = [
+        f"{k!r} (did you mean: {', '.join(s)})" if s else f"{k!r} (no close match)"
+        for k, s in sorted_unknowns.items()
+    ]
+    keys_str = ", ".join(parts)
+    if any(not s for s in sorted_unknowns.values()):
+        preview = ", ".join(allowed_sorted[:5])
+        suffix = ", ..." if len(allowed_sorted) > 5 else ""
+        return (
+            f"Unknown {kind}s: {keys_str}. "
+            f"Valid keys include: {preview}{suffix}. "
+            f"See {schema_ref} for the {registry_label}"
+        )
+    return f"Unknown {kind}s: {keys_str}. See {schema_ref} for the {registry_label}"
+
+
 def format_unknown_key_message(
     name: str,
     kind: str,
     suggestions: Sequence[str],
     known_keys: Sequence[str],
 ) -> str:
-    """Build the single-unknown-key error message shared across validators.
+    """Deprecated: single-key message builder. Delegates to :func:`format_unknown_keys_message`.
 
-    Used by :func:`validate_known_key` (single-key path) and
-    :func:`~vault_search.filter.parse_metadata_filter` (single-unknown batch
-    path) so both produce identical text for the 1-key case and agents can
-    rely on one canonical error shape (#123).
-
-    ``known_keys`` は順不同で渡してよい — 関数内で ``sorted()`` してから preview
-    を組み立てる。callsite に「ソート済みで渡す」暗黙契約を強いず、drift
-    リスクを低減する (Round 1 review D4)。
+    Retained temporarily to keep ``filter.py`` imports working; call sites
+    should migrate to :func:`format_unknown_keys_message` directly.
     """
-    if suggestions:
-        return (
-            f"Unknown {kind} {name!r}; "
-            f"did you mean: {', '.join(suggestions)}? "
-            f"See schema://tools for the frontmatter_keys list"
-        )
-    allowed_sorted = sorted(known_keys)
-    preview = ", ".join(allowed_sorted[:5])
-    suffix = ", ..." if len(allowed_sorted) > 5 else ""
-    return (
-        f"Unknown {kind} {name!r}; "
-        f"valid keys include: {preview}{suffix}. "
-        f"See schema://tools for the full list"
+    return format_unknown_keys_message({name: tuple(suggestions)}, kind, known_keys)
+
+
+def validate_known_keys(
+    names: Iterable[str],
+    known_keys: Sequence[str],
+    *,
+    kind: str,
+    schema_ref: str = "schema://tools",
+    registry_label: str = "frontmatter_keys list",
+) -> None:
+    """Validate that every name in ``names`` appears in ``known_keys`` (batch).
+
+    Supersedes :func:`validate_known_key` for callers that need to check
+    multiple names at once (filter.py's ``parse_metadata_filter``). Single-
+    and multi-unknown cases produce the same :class:`ValidationError` shape
+    (``error_code="UNKNOWN_FRONTMATTER_KEY"``) so agents can self-correct
+    uniformly (#141 Option A).
+
+    Parameters
+    ----------
+    names:
+        Candidate names, iterated once. Callers should pass each name through
+        :func:`validate_identifier` first.
+    known_keys:
+        Authoritative allow-list (from the index). Empty is permitted; every
+        name is then unknown.
+    kind:
+        Human-readable singular label (e.g. ``"frontmatter key"``) used in the
+        error message. Multi-key messages append ``"s"`` to pluralize.
+    schema_ref, registry_label:
+        Inject the resource reference and registry label so validation stays
+        kind-agnostic (#138). Defaults match the frontmatter_keys use case.
+    """
+    unknowns: dict[str, tuple[str, ...]] = {}
+    for name in names:
+        if name in known_keys:
+            continue
+        if name in unknowns:  # dedupe repeated hits in the iterable
+            continue
+        unknowns[name] = tuple(difflib.get_close_matches(name, known_keys, n=3, cutoff=0.6))
+
+    if not unknowns:
+        return
+
+    sorted_unknowns = dict(sorted(unknowns.items()))
+    all_candidates = tuple(dict.fromkeys(c for s in sorted_unknowns.values() for c in s))
+    raise ValidationError(
+        format_unknown_keys_message(
+            sorted_unknowns,
+            kind,
+            known_keys,
+            schema_ref=schema_ref,
+            registry_label=registry_label,
+        ),
+        error_code="UNKNOWN_FRONTMATTER_KEY",
+        did_you_mean=all_candidates,
+        allowed=sorted(known_keys),
+        unknown_keys=sorted_unknowns,
     )
 
 
@@ -232,36 +338,11 @@ def validate_known_key(
 ) -> str:
     """Validate that ``name`` appears in ``known_keys`` and return it unchanged.
 
-    Intended for frontmatter keys (and, later, known tags / folders) where the
-    index contains an authoritative allow-list and an agent may hallucinate a
-    near-miss. Unknown keys raise :class:`ValidationError` with
-    ``error_code="UNKNOWN_FRONTMATTER_KEY"`` and the full ``known_keys`` sorted
-    list in ``allowed``; close matches (``difflib.get_close_matches``,
-    ``cutoff=0.6``) appear in ``did_you_mean``.
-
-    Parameters
-    ----------
-    name:
-        Candidate key. Callers should pass the value through
-        :func:`validate_identifier` first so SQL / path-traversal shapes are
-        rejected before similarity matching.
-    known_keys:
-        Authoritative allow-list (from the index). Empty sequence is
-        permitted; every ``name`` is unknown in that case.
-    kind:
-        Human-readable label (e.g. ``"frontmatter key"``) interpolated into
-        the error message so the agent knows which input to fix.
+    Thin wrapper over :func:`validate_known_keys`; kept for callers that
+    handle a single name at a time. New code should prefer the batch API.
     """
-    if name in known_keys:
-        return name
-    suggestions = tuple(difflib.get_close_matches(name, known_keys, n=3, cutoff=0.6))
-    raise ValidationError(
-        format_unknown_key_message(name, kind, suggestions, known_keys),
-        error_code="UNKNOWN_FRONTMATTER_KEY",
-        did_you_mean=suggestions,
-        allowed=sorted(known_keys),
-        unknown_keys={name: suggestions},
-    )
+    validate_known_keys([name], known_keys, kind=kind)
+    return name
 
 
 def _validate_strict_int(value: object, name: str) -> None:

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -33,7 +33,6 @@ __all__ = [
     "IDENTIFIER_MAX_LEN",
     "LIMIT_MAX",
     "ValidationError",
-    "format_unknown_key_message",
     "format_unknown_keys_message",
     "validate_identifier",
     "validate_known_key",
@@ -255,20 +254,6 @@ def format_unknown_keys_message(
             f"See {schema_ref} for the {registry_label}"
         )
     return f"Unknown {kind}s: {keys_str}. See {schema_ref} for the {registry_label}"
-
-
-def format_unknown_key_message(
-    name: str,
-    kind: str,
-    suggestions: Sequence[str],
-    known_keys: Sequence[str],
-) -> str:
-    """Deprecated: single-key message builder. Delegates to :func:`format_unknown_keys_message`.
-
-    Retained temporarily to keep ``filter.py`` imports working; call sites
-    should migrate to :func:`format_unknown_keys_message` directly.
-    """
-    return format_unknown_keys_message({name: tuple(suggestions)}, kind, known_keys)
 
 
 def validate_known_keys(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -400,3 +400,207 @@ class TestValidationErrorUnknownKeysAttribute:
         """他 error_code の ValidationError は unknown_keys が常に空."""
         err = ValidationError("bad op", error_code="VALIDATION_ERROR")
         assert err.unknown_keys == {}
+
+
+# ---------------------------------------------------------------------------
+# validate_known_keys (batch) + format_unknown_keys_message — Issues #138/#140/#141
+#
+# - #141: validate_known_key が filter.py production から orphan 化 → batch API に
+#   統合し filter.py から直接呼べるようにする
+# - #140: message 構築が validation.format_unknown_key_message と
+#   filter._raise_unknown_keys に 2 箇所分散 → 統一 builder に集約
+# - #138: validation.py に「schema://tools」「frontmatter_keys list」等の MCP /
+#   frontmatter 固有文言が hardcode → schema_ref / registry_label 引数で注入
+# ---------------------------------------------------------------------------
+
+
+class TestValidateKnownKeysBatch:
+    """validate_known_keys (batch API) の契約テスト (#141 Option A)."""
+
+    def test_all_known_names_no_op(self) -> None:
+        """全 name が known_keys に含まれる場合、例外は送出されない."""
+        from vault_search.validation import validate_known_keys
+
+        validate_known_keys(
+            ["priority", "status"], ["priority", "status", "tags"], kind="frontmatter key"
+        )
+
+    def test_empty_names_no_op_even_with_empty_known_keys(self) -> None:
+        """names が空なら known_keys も空でも no-op (空 dict frontmatter への配慮)."""
+        from vault_search.validation import validate_known_keys
+
+        validate_known_keys([], [], kind="frontmatter key")
+
+    def test_single_unknown_raises_with_single_key_shape(self) -> None:
+        """単一 unknown は従来の validate_known_key と同形で error を返す (backward compat)."""
+        from vault_search.validation import validate_known_keys
+
+        with pytest.raises(ValidationError) as exc:
+            validate_known_keys(["priorty"], ["priority", "status"], kind="frontmatter key")
+        err = exc.value
+        assert err.error_code == "UNKNOWN_FRONTMATTER_KEY"
+        assert err.did_you_mean == ("priority",)
+        assert tuple(sorted(err.allowed)) == ("priority", "status")
+        assert err.unknown_keys == {"priorty": ("priority",)}
+
+    def test_multiple_unknown_batched_and_sorted(self) -> None:
+        """複数 unknown は 1 回の error にまとめられ alphabetical に整列される."""
+        from vault_search.validation import validate_known_keys
+
+        with pytest.raises(ValidationError) as exc:
+            validate_known_keys(["zapple", "aapple"], ["banana"], kind="frontmatter key")
+        err = exc.value
+        assert err.error_code == "UNKNOWN_FRONTMATTER_KEY"
+        # insertion order に依存せず alphabetical で固定
+        assert list(err.unknown_keys.keys()) == ["aapple", "zapple"]
+
+    def test_mixed_known_unknown_only_unknown_reported(self) -> None:
+        """known と unknown の混在で unknown のみ報告される."""
+        from vault_search.validation import validate_known_keys
+
+        with pytest.raises(ValidationError) as exc:
+            validate_known_keys(
+                ["priority", "typo", "status"],
+                ["priority", "status", "tags"],
+                kind="frontmatter key",
+            )
+        err = exc.value
+        assert set(err.unknown_keys.keys()) == {"typo"}
+
+    def test_no_close_match_yields_empty_suggestions(self) -> None:
+        """close match が無いキーは空 tuple suggestion を持つ."""
+        from vault_search.validation import validate_known_keys
+
+        with pytest.raises(ValidationError) as exc:
+            validate_known_keys(["xyzqqq"], ["priority", "status"], kind="frontmatter key")
+        err = exc.value
+        assert err.unknown_keys == {"xyzqqq": ()}
+        assert err.did_you_mean == ()
+
+    def test_schema_ref_and_registry_label_injected_into_message(self) -> None:
+        """MCP/frontmatter 固有文言が引数で注入される (#138)."""
+        from vault_search.validation import validate_known_keys
+
+        with pytest.raises(ValidationError) as exc:
+            validate_known_keys(
+                ["foo"],
+                ["bar"],
+                kind="custom kind",
+                schema_ref="config://alt",
+                registry_label="custom_list",
+            )
+        msg = str(exc.value)
+        # param が message に到達する
+        assert "config://alt" in msg, f"schema_ref must be injected; got {msg!r}"
+        assert "custom_list" in msg, f"registry_label must be injected; got {msg!r}"
+        # デフォルト値がリークしない
+        assert "schema://tools" not in msg
+        assert "frontmatter_keys" not in msg
+
+    def test_default_schema_ref_and_registry_label_match_legacy_messages(self) -> None:
+        """デフォルト値で従来 message が bit-identical で生成される (#138/#140)."""
+        from vault_search.validation import validate_known_keys
+
+        with pytest.raises(ValidationError) as exc:
+            validate_known_keys(["priorty"], ["priority", "status"], kind="frontmatter key")
+        expected = (
+            "Unknown frontmatter key 'priorty'; "
+            "did you mean: priority? "
+            "See schema://tools for the frontmatter_keys list"
+        )
+        assert str(exc.value) == expected
+
+
+class TestFormatUnknownKeysMessage:
+    """統一 message builder (format_unknown_keys_message) の契約 (#140)."""
+
+    def test_single_key_with_suggestions_bit_identical(self) -> None:
+        """1 key with suggestions は従来 format_unknown_key_message と bit-identical."""
+        from vault_search.validation import format_unknown_keys_message
+
+        msg = format_unknown_keys_message(
+            {"priorty": ("priority",)},
+            "frontmatter key",
+            ["priority", "status"],
+        )
+        assert msg == (
+            "Unknown frontmatter key 'priorty'; "
+            "did you mean: priority? "
+            "See schema://tools for the frontmatter_keys list"
+        )
+
+    def test_single_key_no_suggestions_bit_identical(self) -> None:
+        """1 key without suggestions は従来 "full list" 文言を維持 (bit-identical)."""
+        from vault_search.validation import format_unknown_keys_message
+
+        msg = format_unknown_keys_message(
+            {"xyz": ()},
+            "frontmatter key",
+            ["a", "b", "c"],
+        )
+        assert msg == (
+            "Unknown frontmatter key 'xyz'; "
+            "valid keys include: a, b, c. "
+            "See schema://tools for the full list"
+        )
+
+    def test_multi_key_all_suggestions_bit_identical(self) -> None:
+        """複数 key 全候補ありは従来 _raise_unknown_keys と bit-identical."""
+        from vault_search.validation import format_unknown_keys_message
+
+        msg = format_unknown_keys_message(
+            {"priorty": ("priority",), "statu": ("status",)},
+            "frontmatter key",
+            ["priority", "status"],
+        )
+        assert msg == (
+            "Unknown frontmatter keys: "
+            "'priorty' (did you mean: priority), "
+            "'statu' (did you mean: status). "
+            "See schema://tools for the frontmatter_keys list"
+        )
+
+    def test_multi_key_mixed_suggestions_bit_identical(self) -> None:
+        """複数 key 混在 (候補あり + なし) は valid keys preview 付き."""
+        from vault_search.validation import format_unknown_keys_message
+
+        msg = format_unknown_keys_message(
+            {"priorty": ("priority",), "foo": ()},
+            "frontmatter key",
+            ["priority", "status"],
+        )
+        assert msg == (
+            "Unknown frontmatter keys: "
+            "'foo' (no close match), "
+            "'priorty' (did you mean: priority). "
+            "Valid keys include: priority, status. "
+            "See schema://tools for the frontmatter_keys list"
+        )
+
+    def test_multi_key_all_no_suggestions_bit_identical(self) -> None:
+        """複数 key 全候補なしは valid keys preview 付き."""
+        from vault_search.validation import format_unknown_keys_message
+
+        msg = format_unknown_keys_message(
+            {"foo": (), "bar": ()},
+            "frontmatter key",
+            ["priority", "status"],
+        )
+        assert msg == (
+            "Unknown frontmatter keys: "
+            "'bar' (no close match), "
+            "'foo' (no close match). "
+            "Valid keys include: priority, status. "
+            "See schema://tools for the frontmatter_keys list"
+        )
+
+    def test_preview_truncates_to_five_entries(self) -> None:
+        """6 件以上の known_keys は 5 件 preview + ', ...' 末尾で truncate される."""
+        from vault_search.validation import format_unknown_keys_message
+
+        msg = format_unknown_keys_message(
+            {"xyz": ()},
+            "frontmatter key",
+            ["a", "b", "c", "d", "e", "f", "g"],
+        )
+        assert "a, b, c, d, e, ..." in msg

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -478,19 +478,23 @@ class TestValidateKnownKeysBatch:
         assert err.did_you_mean == ()
 
     def test_schema_ref_and_registry_label_injected_into_message(self) -> None:
-        """MCP/frontmatter 固有文言が引数で注入される (#138)."""
+        """MCP/frontmatter 固有文言が引数で注入される (#138).
+
+        近似マッチがある入力 (did-you-mean 経路) を使うのは、候補なし経路だと
+        "for the full list" という kind-agnostic fallback 文言が挟まり
+        ``registry_label`` が使われないため (bit-identical 維持の副作用)。
+        """
         from vault_search.validation import validate_known_keys
 
         with pytest.raises(ValidationError) as exc:
             validate_known_keys(
-                ["foo"],
-                ["bar"],
+                ["priorty"],
+                ["priority"],
                 kind="custom kind",
                 schema_ref="config://alt",
                 registry_label="custom_list",
             )
         msg = str(exc.value)
-        # param が message に到達する
         assert "config://alt" in msg, f"schema_ref must be injected; got {msg!r}"
         assert "custom_list" in msg, f"registry_label must be injected; got {msg!r}"
         # デフォルト値がリークしない


### PR DESCRIPTION
## Summary

PR #135 (#123) 導入以降、unknown frontmatter key の検出ロジックが次のように散在していた:

- `validation.format_unknown_key_message` に `"schema://tools"` / `"frontmatter_keys list"` 等の MCP/frontmatter 固有文言が hardcode (**#138** 層越え)
- message 構築が `validation.format_unknown_key_message` (単一) と `filter._raise_unknown_keys` (複数) の 2 箇所に分散 (**#140** drift リスク)
- `validate_known_key` が filter.py の 3-pass 化以降 production から orphan 化、`difflib.get_close_matches` が filter.py と validation.py で重複 (**#141**)

これを 3 コミットで統合解消:

- validation.py に batch API `validate_known_keys` と統一 message builder `format_unknown_keys_message` を追加
- `schema_ref` / `registry_label` 引数で MCP/frontmatter 固有文言を inject 化
- filter.py の `_raise_unknown_keys` と重複 difflib を削除、batch API 1 呼びに集約
- `validate_known_key` は batch API への thin wrapper として存続 (後方互換)

## 完了条件の対応

**#138**:
- [x] `validation.py` から MCP / frontmatter 固有文言が排除された (`schema_ref` / `registry_label` のデフォルト値として退避)
- [x] 文言変更は caller 側の default override で完結、`validation.py` は touch 不要
- [x] 既存 single-key / multi-key message は bit-identical (14 新規テストで pin)
- [x] `validate_known_key` / filter の callsite 両方が更新された

**#140**:
- [x] message 構築が `format_unknown_keys_message` 1 箇所に統一 (単一/複数両対応)
- [x] 既存 message は bit-identical
- [x] `filter._raise_unknown_keys` を削除 (`~60` 行、10 行以下どころかゼロ)
- [x] preview 件数 / schema URI 変更時のテスト影響範囲が 1 関数で済む

**#141**:
- [x] filter.py の `difflib.get_close_matches` 直呼び削除 (validation 層経由に統一)
- [x] `validate_known_key` tests は既存のまま pass (後方互換)
- [x] 新 batch API のテストを `test_validation.py` に追加 (`TestValidateKnownKeysBatch` / `TestFormatUnknownKeysMessage`)
- [x] `format_unknown_keys_message` の `registry_label` / `schema_ref` 分離済み

## Commits (Red / Green / Refactor)

1. **Red**: `validate_known_keys` batch API と `format_unknown_keys_message` 統一 builder を pin (失敗テスト 14 件追加)
2. **Green**: validation.py に batch API + 統一 builder を実装。`validate_known_key` を wrapper 化。旧 `format_unknown_key_message` は delegation wrapper として一時残置 (filter.py 側のため)
3. **Refactor**: filter.py を batch API 呼出に置換、`_raise_unknown_keys` / 重複 `difflib` / 旧 `format_unknown_key_message` を削除

## Test plan

- [ ] `uv run pytest` で 461 テスト全通過
- [ ] `ruff check src/ tests/` clean
- [ ] `ruff format` clean
- [ ] 既存 #123 の multi-key DX テスト (`test_filter.py::TestMultiKeyMessageRefinements`) が壊れていない
- [ ] `test_validation.py::TestValidateKnownKey` (旧 single-key API) が壊れていない

## 関連

- Depends on: PR #135 (#123) で導入された構造
- Closes: #138, #140, #141
- E1 衝突注意: #46 + #29 (filter.py 分割) と同時進行不可。E1 は別 PR 待ち

🤖 Generated with [Claude Code](https://claude.com/claude-code)