### PR TITLE
Simplify: 後方互換のためだけに残した validate_known_key wrapper を削除

### DIFF
--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -35,7 +35,6 @@ __all__ = [
     "ValidationError",
     "format_unknown_keys_message",
     "validate_identifier",
-    "validate_known_key",
     "validate_known_keys",
     "validate_pagination",
     "validate_value",
@@ -202,13 +201,8 @@ def format_unknown_keys_message(
 ) -> str:
     """Build a unified unknown-key error message covering 1 and N unknown keys.
 
-    Consolidates the single-key (``validate_known_key``) and multi-key
-    (``filter._raise_unknown_keys``) paths into one builder so preview length
-    and schema-reference wording live in one place (#140).
-
     MCP / frontmatter-specific wording is injected via ``schema_ref`` and
-    ``registry_label`` instead of hardcoded strings; defaults match the
-    legacy callsites so existing messages remain bit-identical (#138).
+    ``registry_label`` instead of hardcoded strings (#138).
 
     ``known_keys`` は順不同で渡してよい — 関数内で ``sorted()`` してから preview
     を組み立てる。callsite に「ソート済みで渡す」暗黙契約を強いず、drift
@@ -266,11 +260,9 @@ def validate_known_keys(
 ) -> None:
     """Validate that every name in ``names`` appears in ``known_keys`` (batch).
 
-    Supersedes :func:`validate_known_key` for callers that need to check
-    multiple names at once (filter.py's ``parse_metadata_filter``). Single-
-    and multi-unknown cases produce the same :class:`ValidationError` shape
-    (``error_code="UNKNOWN_FRONTMATTER_KEY"``) so agents can self-correct
-    uniformly (#141 Option A).
+    Used by filter.py's ``parse_metadata_filter`` to report all unknown keys
+    in one :class:`ValidationError` (``error_code="UNKNOWN_FRONTMATTER_KEY"``)
+    so agents can self-correct in a single round-trip (#123/#141).
 
     Parameters
     ----------
@@ -313,21 +305,6 @@ def validate_known_keys(
         allowed=sorted(known_keys),
         unknown_keys=sorted_unknowns,
     )
-
-
-def validate_known_key(
-    name: str,
-    known_keys: Sequence[str],
-    *,
-    kind: str,
-) -> str:
-    """Validate that ``name`` appears in ``known_keys`` and return it unchanged.
-
-    Thin wrapper over :func:`validate_known_keys`; kept for callers that
-    handle a single name at a time. New code should prefer the batch API.
-    """
-    validate_known_keys([name], known_keys, kind=kind)
-    return name
 
 
 def _validate_strict_int(value: object, name: str) -> None:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -12,7 +12,6 @@ import pytest
 from vault_search.validation import (
     ValidationError,
     validate_identifier,
-    validate_known_key,
     validate_value,
 )
 
@@ -314,57 +313,6 @@ def test_validate_value_error_message_includes_custom_kind() -> None:
 
 
 # ---------------------------------------------------------------------------
-# validate_known_key — Issue #117
-#
-# filter.py の parse_metadata_filter から抽出した unknown key 検出ヘルパ。
-# known_keys に含まれる場合は入力を素通し、未知キーは
-# ValidationError(error_code="UNKNOWN_FRONTMATTER_KEY") を
-# did_you_mean (difflib) + allowed (sorted) 付きで送出する。
-# ---------------------------------------------------------------------------
-
-
-class TestValidateKnownKey:
-    """validate_known_key の直接テスト (Issue #117)."""
-
-    def test_known_key_returns_unchanged(self) -> None:
-        assert (
-            validate_known_key("priority", ["priority", "status"], kind="frontmatter key")
-            == "priority"
-        )
-
-    def test_unknown_key_raises_with_error_code(self) -> None:
-        with pytest.raises(ValidationError) as exc:
-            validate_known_key("priorty", ["priority", "status"], kind="frontmatter key")
-        err = exc.value
-        assert err.error_code == "UNKNOWN_FRONTMATTER_KEY"
-        assert "priority" in err.did_you_mean
-        assert tuple(sorted(err.allowed)) == ("priority", "status")
-        assert "schema://tools" in str(err)
-
-    def test_no_close_match_still_raises_with_allowed(self) -> None:
-        with pytest.raises(ValidationError) as exc:
-            validate_known_key(
-                "nonexistent",
-                ["status", "priority", "tags"],
-                kind="frontmatter key",
-            )
-        err = exc.value
-        assert err.error_code == "UNKNOWN_FRONTMATTER_KEY"
-        assert err.did_you_mean == ()
-        assert set(err.allowed) == {"status", "priority", "tags"}
-
-    def test_empty_known_keys_rejects_any_key(self) -> None:
-        with pytest.raises(ValidationError) as exc:
-            validate_known_key("xyz", [], kind="frontmatter key")
-        assert exc.value.error_code == "UNKNOWN_FRONTMATTER_KEY"
-
-    def test_kind_label_appears_in_message(self) -> None:
-        with pytest.raises(ValidationError) as exc:
-            validate_known_key("xyz", ["a"], kind="frontmatter key")
-        assert "frontmatter key" in str(exc.value)
-
-
-# ---------------------------------------------------------------------------
 # ValidationError.unknown_keys 契約 (Issue #123 round 1 review D5)
 #
 # ``unknown_keys`` 属性は ``parse_metadata_filter`` の batch 経路専用だが、
@@ -405,17 +353,15 @@ class TestValidationErrorUnknownKeysAttribute:
 # ---------------------------------------------------------------------------
 # validate_known_keys (batch) + format_unknown_keys_message — Issues #138/#140/#141
 #
-# - #141: validate_known_key が filter.py production から orphan 化 → batch API に
-#   統合し filter.py から直接呼べるようにする
-# - #140: message 構築が validation.format_unknown_key_message と
-#   filter._raise_unknown_keys に 2 箇所分散 → 統一 builder に集約
-# - #138: validation.py に「schema://tools」「frontmatter_keys list」等の MCP /
-#   frontmatter 固有文言が hardcode → schema_ref / registry_label 引数で注入
+# filter.py の parse_metadata_filter から unknown key 検出を抽出した batch
+# validator。ValidationError(error_code="UNKNOWN_FRONTMATTER_KEY") を
+# did_you_mean (difflib) + allowed (sorted) + unknown_keys (per-key 候補) 付きで
+# 送出する。schema_ref / registry_label 引数で MCP/frontmatter 固有文言を inject。
 # ---------------------------------------------------------------------------
 
 
 class TestValidateKnownKeysBatch:
-    """validate_known_keys (batch API) の契約テスト (#141 Option A)."""
+    """validate_known_keys (batch API) の契約テスト (#141)."""
 
     def test_all_known_names_no_op(self) -> None:
         """全 name が known_keys に含まれる場合、例外は送出されない."""
@@ -432,7 +378,10 @@ class TestValidateKnownKeysBatch:
         validate_known_keys([], [], kind="frontmatter key")
 
     def test_single_unknown_raises_with_single_key_shape(self) -> None:
-        """単一 unknown は従来の validate_known_key と同形で error を返す (backward compat)."""
+        """単一 unknown でも batch と同じ ValidationError shape で返る.
+
+        error_code / did_you_mean / allowed / unknown_keys 属性を検証する。
+        """
         from vault_search.validation import validate_known_keys
 
         with pytest.raises(ValidationError) as exc:


### PR DESCRIPTION
## Summary

PR #149 で batch API (`validate_known_keys`) に統合した後、`validate_known_key`
は「tests からのみ呼ばれる thin wrapper」として残存していた。vault-search-mcp
は本番未運用 (外部利用者なし) のため、後方互換性のためだけに残す実装は
YAGNI として削除する。

- `validation.py` から `validate_known_key` 関数と `__all__` エントリを削除
- `test_validation.py` から `TestValidateKnownKey` クラス (5 テスト) と
  `validate_known_key` import を削除
- 関連 docstring / コメントから `validate_known_key` への言及を整理

batch API の `test_single_unknown_raises_with_single_key_shape` が単一 unknown の
ValidationError shape (error_code / did_you_mean / allowed / unknown_keys) を
pin しているため coverage は維持される。

## Test plan

- [x] 456 テスト全通過 (旧 5 テスト削除で 461 → 456)
- [x] `ruff check` / `ruff format` clean
- [x] `parse_metadata_filter` の unknown key 検出経路が壊れていない
      (単一/複数両方のテスト通過)

🤖 Generated with [Claude Code](https://claude.com/claude-code)