### PR TITLE
Refactor: folder 入力正規化を validation 層に抽出 (#73)

### DIFF
--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -22,6 +22,7 @@ from typing import Any
 from .cache import TieredCache
 from .filter import MetadataCondition, build_sql_fragment, parse_metadata_filter
 from .parser import ParsedNote, parse_note
+from .validation import normalize_folder
 
 logger = logging.getLogger(__name__)
 
@@ -109,15 +110,12 @@ def _folder_filter_clause(folder: str, column: str = "folder") -> tuple[str, lis
     `folder == 'Projects'` が `'Projects Hermes'` 等の兄弟を拾わないよう、
     LIKE パターンを ``escaped + '/%'`` にし、等号比較と OR で結合する。
 
-    入力は `\\` → `/` 置換、末尾 `/` の rstrip で正規化する。正規化後が空
-    文字列 (e.g. `folder='/'`, `'//'`, `'\\'`) の場合は「フィルタなし」を意味
-    する no-op 断片 ``"1=1"`` と空 params を返す。
-
     Parameters
     ----------
     folder:
-        フォルダパス。空文字はフィルタを掛けないので呼び出し側で分岐する前提
-        だが、正規化後に空となるケース (スラッシュのみ) は本関数が no-op で吸収する。
+        canonical 形式の非空フォルダパス。呼び出し側 (``server.py``) が
+        :func:`~vault_search.validation.normalize_folder` で正規化済みであること
+        を前提とする。先頭 ``/`` や連続 ``/`` は含まない。
     column:
         SQL 上のカラム名。`n.folder` のようにテーブルエイリアス付きも可。
 
@@ -126,14 +124,7 @@ def _folder_filter_clause(folder: str, column: str = "folder") -> tuple[str, lis
     tuple[str, list[Any]]
         ``(clause, params)``。clause は前置詞を含まない WHERE 断片
         ``"(col = ? OR col LIKE ? ESCAPE '\\')"``、params は ``[folder, folder/%]``。
-        正規化後空の場合は ``("1=1", [])``。
     """
-    folder = folder.replace("\\", "/").rstrip("/")
-    if not folder:
-        # `/`, `//`, `\\` 等のスラッシュのみ入力は rstrip 後 '' となり、
-        # 呼び出し側の `if folder:` ガードは素通りしている。ここで no-op
-        # 断片 ("1=1") を返し「フィルタなし」扱いに揃える (Issue #34)。
-        return "1=1", []
     escaped = folder.replace("%", "\\%").replace("_", "\\_")
     clause = f"({column} = ? OR {column} LIKE ? ESCAPE '\\')"
     return clause, [folder, escaped + "/%"]
@@ -386,6 +377,10 @@ class VaultIndex:
         いずれかが指定されていれば、DB 全体を対象に構造化フィルタだけで
         絞り込む。全引数が空の場合は空結果を返す。
         """
+        # folder を canonical 形式に正規化する。先頭 '/' や '\\' 区切りの
+        # 入力を吸収し、スラッシュのみの場合は None (フィルタなし) にする。
+        folder = normalize_folder(folder) if folder is not None else None
+
         # Validate (raises ValidationError on malformed input).
         # metadata_filter が指定された場合のみ known_keys を取得する
         # (filter なしでは不要なので呼ばない)。list_frontmatter_keys() は
@@ -560,6 +555,7 @@ class VaultIndex:
         folder: str | None = None,
     ) -> list[dict[str, Any]]:
         """最近更新されたノート. offset スキップ後 limit 件を返す."""
+        folder = normalize_folder(folder) if folder is not None else None
         with self.connection() as conn:
             if folder:
                 clause, folder_params = _folder_filter_clause(folder, column="folder")

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -41,7 +41,7 @@ from .schemas import (
     TagCount,
     VaultStats,
 )
-from .validation import validate_pagination
+from .validation import normalize_folder, validate_pagination
 from .watcher import VaultWatcher
 
 logger = logging.getLogger(__name__)
@@ -121,7 +121,7 @@ def vault_search(
     raw = _get_index().search(
         query,
         tags=tags,
-        folder=folder,
+        folder=normalize_folder(folder) if folder is not None else None,
         metadata_filter=metadata_filter,
         limit=limit,
         offset=offset,
@@ -183,7 +183,11 @@ def vault_recent(
         してしまうため dict envelope に統一している。
     """
     validate_pagination(limit, offset)
-    rows = _get_index().recent_notes(limit=limit, offset=offset, folder=folder)
+    rows = _get_index().recent_notes(
+        limit=limit,
+        offset=offset,
+        folder=normalize_folder(folder) if folder is not None else None,
+    )
     notes = [RecentNote(**note).model_dump(mode="json") for note in rows]
     return {"notes": notes}
 

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -34,6 +34,7 @@ __all__ = [
     "LIMIT_MAX",
     "ValidationError",
     "format_unknown_keys_message",
+    "normalize_folder",
     "validate_identifier",
     "validate_known_keys",
     "validate_pagination",
@@ -305,6 +306,28 @@ def validate_known_keys(
         allowed=sorted(known_keys),
         unknown_keys=sorted_unknowns,
     )
+
+
+def normalize_folder(folder: str) -> str | None:
+    """入力 folder を canonical 形式に正規化する。
+
+    - ``\\`` → ``/``
+    - 連続 ``/`` を単一化
+    - 先頭 ``/`` を strip
+    - 末尾 ``/`` を strip
+    - 結果が空なら ``None`` を返す (フィルタなし — ``'/'`` や ``''`` も吸収)
+
+    Returns
+    -------
+    str | None
+        正規化済みフォルダパス。空になった場合は ``None``。
+
+    Notes
+    -----
+    path traversal (``..`` 等) の検出はこの関数の scope 外。
+    """
+    normalized = re.sub(r"/+", "/", folder.replace("\\", "/")).strip("/")
+    return normalized if normalized else None
 
 
 def _validate_strict_int(value: object, name: str) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -514,3 +514,34 @@ def test_mcp_tool_vault_search_no_metadata_filter_does_not_raise(
     res = fn("obsidian", None, None, 20, 0, None)
     assert isinstance(res, dict)
     assert "results" in res
+
+
+# ---------------------------------------------------------------------------
+# Issue #73: folder 入力正規化の integration regression guard
+# server.py 入口で normalize_folder を呼ぶことで、先頭 '/' や '\\' 区切りの
+# folder 引数が silent-miss にならないことを pin する。
+# ---------------------------------------------------------------------------
+
+
+def test_vault_search_leading_slash_folder_same_as_bare(vault_index: VaultIndex) -> None:
+    """`folder='/Projects'` が `folder='Projects'` と同件数を返すこと (silent-miss 防止)."""
+    fn = _fn(server_mod.vault_search)
+    bare = fn("日本語", None, "Projects", 50)
+    leading = fn("日本語", None, "/Projects", 50)
+    assert bare["total"] > 0, "fixture regression: bare folder returned 0 results"
+    assert leading["total"] == bare["total"], (
+        f"leading-slash folder '/Projects' returned {leading['total']} hits, "
+        f"expected {bare['total']} (same as 'Projects')"
+    )
+
+
+def test_vault_recent_leading_slash_folder_same_as_bare(vault_index: VaultIndex) -> None:
+    """`folder='/Projects'` が `vault_recent` でも silent-miss にならないこと."""
+    fn = _fn(server_mod.vault_recent)
+    bare = fn(limit=50, folder="Projects")
+    leading = fn(limit=50, folder="/Projects")
+    assert len(bare["notes"]) > 0, "fixture regression: bare folder returned 0 notes"
+    assert len(leading["notes"]) == len(bare["notes"]), (
+        f"leading-slash folder '/Projects' returned {len(leading['notes'])} notes, "
+        f"expected {len(bare['notes'])} (same as 'Projects')"
+    )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -557,3 +557,35 @@ class TestFormatUnknownKeysMessage:
             ["a", "b", "c", "d", "e", "f", "g"],
         )
         assert "a, b, c, d, e, ..." in msg
+
+
+# ---------------------------------------------------------------------------
+# normalize_folder — Issue #73 folder 入力正規化
+#
+# 先頭 `/`、末尾 `/`、連続 `/`、`\\` 区切りを canonical 形式に正規化する。
+# 正規化後が空なら None を返す (フィルタなし = 全件)。
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeFolder:
+    """normalize_folder の境界値テスト (#73)."""
+
+    @pytest.mark.parametrize(
+        "folder,expected",
+        [
+            ("", None),
+            ("/", None),
+            ("//", None),
+            ("\\", None),
+            ("Projects", "Projects"),
+            ("/Projects", "Projects"),
+            ("Projects/", "Projects"),
+            ("Projects//Hermes", "Projects/Hermes"),
+            ("Projects\\Hermes", "Projects/Hermes"),
+            ("Projects/Hermes/", "Projects/Hermes"),
+        ],
+    )
+    def test_normalize_folder_boundaries(self, folder: str, expected: str | None) -> None:
+        from vault_search.validation import normalize_folder
+
+        assert normalize_folder(folder) == expected


### PR DESCRIPTION
## Summary

`_folder_filter_clause` (indexer.py) に埋まっていた folder 正規化を `validation.py` の `normalize_folder` に抽出。これにより:

- 先頭 `/` (`folder="/Projects"`) と内部二重 `/` (`folder="Projects//Hermes"`) の silent-miss を解消
- server 入口で 1 度だけ正規化を実行、`_folder_filter_clause` は正規化済み非空 str のみ受け取る契約に縮退
- `filter.py` (metadata_filter) の validate-first + SQL-only パターンと対称化

## Commits (Red / Green / Refactor)

1. **Red**: `normalize_folder` のテスト追加 (#73) — 境界値 parametrize + silent-miss 検出用 integration regression guard
2. **Green**: `normalize_folder` 実装 + 呼び出し側統合 (`vault_search` / `vault_recent` 入口)
3. **Refactor**: `_folder_filter_clause` から正規化ロジックを撤去、正規化済み前提の純粋 SQL に縮退

## Test plan

- [x] pytest 全 pass (+追加テスト)
- [x] `ruff check` / `ruff format` clean
- [x] 既存 `_folder_filter_clause` のテストが継続 pass
- [x] `folder="/Projects"` が `folder="Projects"` と同件数を返す integration guard

## 関連

- Closes #73
- 非対称性の片側を解消。もう一方 `_folder_filter_clause` の indexer.py 孤立 (#46) は別 PR

## 注記

PR 作成時にタイトルが別 issue (#83) のものになっていたためタイトル・本文を修正 (contents は #73 の作業のまま)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)