### PR TITLE
Docs: vault_reindex の force 副作用差分を docstring で明示 (#83)

### DIFF
--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -222,7 +222,9 @@ class VaultIndex:
     def build_index(self, *, force: bool = False) -> dict[str, int]:
         """Vault 全体をスキャンしてインデックスを構築.
 
-        force=True で全件リビルド。False なら mtime ベースの差分更新。
+        force=False (デフォルト): mtime 差分更新。変更ファイルのみ UPSERT、消失ファイルを DELETE。
+        force=True: 全件リビルド。既存 DB レコードを無視して全ファイルを再パース・UPSERT する。
+        どちらも vault (.md) は読み取りのみ。更新対象は .vault-search.db のみ。
         """
         stats = {"added": 0, "updated": 0, "deleted": 0, "skipped": 0, "errors": 0}
         with self.connection() as conn:

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -225,17 +225,31 @@ def vault_folders() -> dict[str, Any]:
 def vault_reindex(force: bool = False) -> dict[str, Any]:
     """インデックスを再構築する。
 
-    通常はファイル監視が差分更新するため手動実行は不要。
-    Vault の大規模変更後やインデックス破損時に使う。
+    通常はファイル監視 (VaultWatcher) が差分更新するため手動実行は不要。
+    インデックス破損の疑いがある場合や、Vault の大規模変更後に用いる。
 
     Args:
-        force: True なら全件リビルド。False なら mtime ベースの差分更新。
+        force: 再構築の範囲を制御する。
 
-    副作用: `.vault-search.db` (派生インデックス) のみを更新。
-        vault 本体 (.md ファイル) は一切 touch しない。
+            ``force=False`` (デフォルト — 差分更新):
+                既存 DB を保持したまま、各ファイルの mtime を DB 内レコードと比較し、
+                変更があったファイルのみ UPSERT、消失ファイルを DELETE する。
+                変更がなければ skip カウントが増えるだけで副作用は最小。
+                idempotent であり通常はこちらで十分。
+
+            ``force=True`` (全件リビルド):
+                DB の既存レコードを無視して全 .md ファイルを再パースし直す。
+                notes テーブルが実質全件 UPSERT で置換される。
+                インデックス破損の疑いがある場合や大規模な Vault 再編成後に使う。
+
+    副作用:
+        どちらの場合も ``vault 本体の .md ファイルは一切 touch しない``。
+        更新されるのは ``.vault-search.db`` (派生インデックス DB) のみ。
+        ``destructiveHint=False`` を明示しているのはこの理由による。
 
     Returns:
-        dict: ReindexStats に相当する flat JSON (added / updated / deleted / skipped / errors)。
+        dict: ReindexStats に相当する flat JSON
+            (``added`` / ``updated`` / ``deleted`` / ``skipped`` / ``errors``)。
     """
     return ReindexStats(**_get_index().build_index(force=force)).model_dump(mode="json")
 

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -306,6 +306,28 @@ def test_tool_annotations_exclude_none_wire_omits_null_hints(
             )
 
 
+def test_vault_reindex_docstring_explains_force_behavior() -> None:
+    """vault_reindex docstring に force=True/False の挙動差分を説明するキーワードが含まれる.
+
+    Issue #83: docstring が force パラメータの内部挙動差分を agent に伝えていることを
+    regression guard する。docstring drift があればここが失敗するので気づける。
+    """
+    import inspect
+
+    doc = inspect.getdoc(server_mod.vault_reindex)
+    assert doc is not None, "vault_reindex has no docstring"
+
+    # force パラメータの両変種を説明する
+    assert "force=False" in doc, "docstring must explain force=False (incremental) behavior"
+    assert "force=True" in doc, "docstring must explain force=True (full rebuild) behavior"
+    # mtime ベースの差分更新について言及する
+    assert "mtime" in doc, "docstring must mention mtime-based incremental update"
+    # 更新対象は .vault-search.db のみ (vault .md は touch しない)
+    assert ".vault-search.db" in doc, (
+        "docstring must name .vault-search.db as the only modified artifact"
+    )
+
+
 def test_schema_tools_resource_exposes_annotations(vault_index: VaultIndex) -> None:
     """``schema://tools`` リソースも各 tool の annotations を公開する.
 


### PR DESCRIPTION
## Summary

`vault_reindex(force: bool = False)` は 2 挙動 (`force=False`: mtime 差分更新、`force=True`: 全件再構築) を持つが、MCP tool annotations は 1 set に固定されているため docstring で挙動差分を明示する (採用案: A 案)。

- `server.py::vault_reindex` docstring に以下を明記:
  - `force=False` (default): mtime 差分更新。既存 DB 保持、変更分のみ UPSERT、消失ファイル DELETE (idempotent)
  - `force=True`: 全件再構築。DB 内の notes テーブルを実質置換
  - いずれも vault 本体 (`.md`) は一切 touch しない (`.vault-search.db` のみ更新 — `destructiveHint=False` の根拠)
- `indexer.py::build_index` docstring も同様に補強
- `test_tool_annotations.py` に docstring キーワード regression guard を追加 (drift 防止)

挙動変更は**一切なし**。docstring + 1 regression test のみ。

## Commits

1. **Docs**: `vault_reindex` の force 副作用差分を docstring で明示 (#83)
2. **Test**: `vault_reindex` docstring キーワード regression guard を追加 (#83)

## Test plan

- [x] pytest 全 pass (+1 件 regression test)
- [x] `ruff check` / `ruff format` clean
- [x] annotations / 挙動は無変更

## 関連

- Closes #83
- B 案 (tool 2 分割) と C 案 (argument-conditional annotations) は trade-off 議論を経て不採用 (issue 本文参照)

🤖 Generated with [Claude Code](https://claude.com/claude-code)