### PR TITLE
Refactor: SQL fragment builders を filter.py に集約し alias 引数化 (#46/#29)

### DIFF
--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -30,7 +30,13 @@ from .validation import (
     validate_value,
 )
 
-__all__ = ["MetadataCondition", "Operator", "build_sql_fragment", "parse_metadata_filter"]
+__all__ = [
+    "MetadataCondition",
+    "Operator",
+    "build_folder_filter_clause",
+    "build_sql_fragment",
+    "parse_metadata_filter",
+]
 
 # 演算子の単一 source of truth。``eq`` / ``ne`` / ``in`` の 3 演算子。
 # ``MetadataCondition.op`` と ``_EXPLICIT_OPS`` はここから派生させる。
@@ -258,12 +264,25 @@ def _parse_ne(key: str, op_value: Any) -> MetadataCondition:
 # ---------------------------------------------------------------------------
 
 
-def build_sql_fragment(cond: MetadataCondition) -> tuple[str, list[Any]]:
+def build_sql_fragment(
+    cond: MetadataCondition,
+    *,
+    table_alias: str = "n",
+    frontmatter_column: str = "frontmatter",
+) -> tuple[str, list[Any]]:
     """単一 :class:`MetadataCondition` を SQLite WHERE 断片とパラメータに変換.
 
     返り値は ``(sql_fragment, params)``。``sql_fragment`` は先頭に ``AND`` を
     含む文字列で、indexer 側の既存 SQL (``WHERE ...``) に連結する前提。
-    参照するテーブル別名は ``n`` (``notes`` テーブル) を仮定する。
+
+    Parameters
+    ----------
+    cond:
+        検証済みの単一 frontmatter 条件。
+    table_alias:
+        生成 SQL 内で参照する ``notes`` テーブル別名。default は ``"n"``。
+    frontmatter_column:
+        JSON1 が走査する frontmatter カラム名。default は ``"frontmatter"``。
 
     ``cond.key`` は :func:`validate_identifier` 済みの安全な識別子
     (各セグメント ``A-Za-z0-9_-``、空セグメント不可) なので、JSON パス
@@ -292,16 +311,17 @@ def build_sql_fragment(cond: MetadataCondition) -> tuple[str, list[Any]]:
       配列でリスト要素のいずれかを含む場合。
     """
     json_path = f"$.{cond.key}"
+    fm_col = f"{table_alias}.{frontmatter_column}"
 
     if cond.op == "eq":
         assert isinstance(cond.value, str)
         fragment = (
             "AND ("
-            "json_extract(n.frontmatter, ?) = ? "
+            f"json_extract({fm_col}, ?) = ? "
             "OR ("
-            "  json_type(n.frontmatter, ?) = 'array' "
+            f"  json_type({fm_col}, ?) = 'array' "
             "  AND EXISTS ("
-            "    SELECT 1 FROM json_each(json_extract(n.frontmatter, ?)) "
+            f"    SELECT 1 FROM json_each(json_extract({fm_col}, ?)) "
             "    WHERE value = ?"
             "  )"
             ")"
@@ -313,14 +333,14 @@ def build_sql_fragment(cond: MetadataCondition) -> tuple[str, list[Any]]:
     if cond.op == "ne":
         assert isinstance(cond.value, str)
         fragment = (
-            "AND json_extract(n.frontmatter, ?) IS NOT NULL "
+            f"AND json_extract({fm_col}, ?) IS NOT NULL "
             "AND ("
-            "(json_type(n.frontmatter, ?) != 'array' "
-            " AND json_extract(n.frontmatter, ?) != ?) "
+            f"(json_type({fm_col}, ?) != 'array' "
+            f" AND json_extract({fm_col}, ?) != ?) "
             "OR ("
-            "  json_type(n.frontmatter, ?) = 'array' "
+            f"  json_type({fm_col}, ?) = 'array' "
             "  AND NOT EXISTS ("
-            "    SELECT 1 FROM json_each(json_extract(n.frontmatter, ?)) "
+            f"    SELECT 1 FROM json_each(json_extract({fm_col}, ?)) "
             "    WHERE value = ?"
             "  )"
             ")"
@@ -343,11 +363,11 @@ def build_sql_fragment(cond: MetadataCondition) -> tuple[str, list[Any]]:
     placeholders = ",".join("?" * len(values))
     fragment = (
         "AND ("
-        f"json_extract(n.frontmatter, ?) IN ({placeholders}) "
+        f"json_extract({fm_col}, ?) IN ({placeholders}) "
         "OR ("
-        "  json_type(n.frontmatter, ?) = 'array' "
+        f"  json_type({fm_col}, ?) = 'array' "
         "  AND EXISTS ("
-        "    SELECT 1 FROM json_each(json_extract(n.frontmatter, ?)) "
+        f"    SELECT 1 FROM json_each(json_extract({fm_col}, ?)) "
         f"    WHERE value IN ({placeholders})"
         "  )"
         ")"
@@ -355,3 +375,35 @@ def build_sql_fragment(cond: MetadataCondition) -> tuple[str, list[Any]]:
     )
     params = [json_path, *values, json_path, json_path, *values]
     return fragment, params
+
+
+# ---------------------------------------------------------------------------
+# Folder filter clause (moved from indexer.py — #46)
+# ---------------------------------------------------------------------------
+
+
+def build_folder_filter_clause(folder: str, column: str = "folder") -> tuple[str, list[Any]]:
+    """folder プレフィックスフィルタを「folder 自身 OR その配下」に厳密化する.
+
+    ``folder == 'Projects'`` が ``'Projects Hermes'`` 等の兄弟を拾わないよう、
+    LIKE パターンを ``escaped + '/%'`` にし、等号比較と OR で結合する。
+
+    Parameters
+    ----------
+    folder:
+        canonical 形式の非空フォルダパス。呼び出し側 (``server.py``) が
+        :func:`~vault_search.validation.normalize_folder` で正規化済みであること
+        を前提とする。先頭 ``/`` や連続 ``/`` は含まない。
+    column:
+        SQL 上のカラム名。``n.folder`` のようにテーブルエイリアス付きも可。
+
+    Returns
+    -------
+    tuple[str, list[Any]]
+        ``(clause, params)``。clause は前置詞を含まない WHERE 断片
+        ``"(col = ? OR col LIKE ? ESCAPE '\\')"``、params は
+        ``[folder, folder/%]``。
+    """
+    escaped = folder.replace("%", "\\%").replace("_", "\\_")
+    clause = f"({column} = ? OR {column} LIKE ? ESCAPE '\\')"
+    return clause, [folder, escaped + "/%"]

--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -1,20 +1,34 @@
-"""metadata_filter parser/validator and SQL fragment builder (Issue #5).
+"""SQL fragment builders for ``notes`` search queries (Issues #5 / #29 / #46).
 
-frontmatter の任意プロパティを AND 条件で絞り込む dict 構文を
-バリデーション済みの :class:`MetadataCondition` リストへ変換し、
-さらに SQLite 用の WHERE 断片に変換する。
+本モジュールは 2 系統の SQL 断片 builder を集約する:
 
-構文:
-    {
-        "status": "active",                       # 暗黙 eq
-        "priority": {"in": ["high", "critical"]}, # in 演算
-        "archived": {"ne": "true"},               # ne 演算
-    }
+1. **metadata_filter** (``parse_metadata_filter`` + ``build_sql_fragment``):
+   frontmatter の任意プロパティを AND 条件で絞り込む dict 構文を
+   バリデーション済みの :class:`MetadataCondition` リストへ変換し、
+   さらに SQLite 用の WHERE 断片に変換する。
 
-不正演算子・不正キー名・不正値はすべて
-:class:`~vault_search.validation.ValidationError` を送出する。
-エラーメッセージは、エージェントがどのキー・どの演算子を
-どう直せばよいかを自己修正できるよう具体的に構成する。
+   構文::
+
+       {
+           "status": "active",                       # 暗黙 eq
+           "priority": {"in": ["high", "critical"]}, # in 演算
+           "archived": {"ne": "true"},               # ne 演算
+       }
+
+   不正演算子・不正キー名・不正値はすべて
+   :class:`~vault_search.validation.ValidationError` を送出する。
+   エラーメッセージは、エージェントがどのキー・どの演算子を
+   どう直せばよいかを自己修正できるよう具体的に構成する。
+
+2. **folder filter** (``build_folder_filter_clause``):
+   正規化済み folder パスを「folder 自身 OR その配下」の厳密プレフィックス
+   WHERE 断片に変換する (Issue #46)。folder 正規化自体は
+   :func:`vault_search.validation.normalize_folder` が担う
+   (責務分離、PR #151)。
+
+``build_sql_fragment`` / ``build_folder_filter_clause`` の両方が
+テーブル別名・カラム名を引数で受け取るため、indexer 側のクエリ構造
+(別名 ``n``、frontmatter カラム名) に依存しない (Issue #29)。
 """
 
 from __future__ import annotations

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -20,7 +20,12 @@ from pathlib import Path
 from typing import Any
 
 from .cache import TieredCache
-from .filter import MetadataCondition, build_sql_fragment, parse_metadata_filter
+from .filter import (
+    MetadataCondition,
+    build_folder_filter_clause,
+    build_sql_fragment,
+    parse_metadata_filter,
+)
 from .parser import ParsedNote, parse_note
 from .validation import normalize_folder
 
@@ -102,32 +107,6 @@ CREATE TABLE IF NOT EXISTS meta (
     value TEXT
 );
 """
-
-
-def _folder_filter_clause(folder: str, column: str = "folder") -> tuple[str, list[Any]]:
-    """folder プレフィックスフィルタを「folder 自身 OR その配下」に厳密化する.
-
-    `folder == 'Projects'` が `'Projects Hermes'` 等の兄弟を拾わないよう、
-    LIKE パターンを ``escaped + '/%'`` にし、等号比較と OR で結合する。
-
-    Parameters
-    ----------
-    folder:
-        canonical 形式の非空フォルダパス。呼び出し側 (``server.py``) が
-        :func:`~vault_search.validation.normalize_folder` で正規化済みであること
-        を前提とする。先頭 ``/`` や連続 ``/`` は含まない。
-    column:
-        SQL 上のカラム名。`n.folder` のようにテーブルエイリアス付きも可。
-
-    Returns
-    -------
-    tuple[str, list[Any]]
-        ``(clause, params)``。clause は前置詞を含まない WHERE 断片
-        ``"(col = ? OR col LIKE ? ESCAPE '\\')"``、params は ``[folder, folder/%]``。
-    """
-    escaped = folder.replace("%", "\\%").replace("_", "\\_")
-    clause = f"({column} = ? OR {column} LIKE ? ESCAPE '\\')"
-    return clause, [folder, escaped + "/%"]
 
 
 class VaultIndex:
@@ -485,7 +464,7 @@ class VaultIndex:
 
             # メタデータフィルタ — folder は同プレフィックス兄弟の誤マッチを避ける
             if folder:
-                clause, folder_params = _folder_filter_clause(folder, column="n.folder")
+                clause, folder_params = build_folder_filter_clause(folder, column="n.folder")
                 sql_parts.append(f"AND {clause}")
                 params.extend(folder_params)
 
@@ -560,7 +539,7 @@ class VaultIndex:
         folder = normalize_folder(folder) if folder is not None else None
         with self.connection() as conn:
             if folder:
-                clause, folder_params = _folder_filter_clause(folder, column="folder")
+                clause, folder_params = build_folder_filter_clause(folder, column="folder")
                 rows = conn.execute(
                     "SELECT path, title, folder, tags, created_at, modified_at FROM notes "
                     f"WHERE {clause} "

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -940,3 +940,104 @@ class TestRangeOperatorAliasDetection:
         result = parse_metadata_filter({"priority": {"ne": "a"}})
         assert len(result) == 1
         assert result[0].op == "ne"
+
+
+# ---------------------------------------------------------------------------
+# Table alias / frontmatter column parameterization (#29)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSqlFragmentAliasArgs:
+    """``build_sql_fragment`` のテーブル別名・JSON カラム名引数化 (#29).
+
+    従来は ``n.frontmatter`` alias がハードコードされており、filter モジュールが
+    indexer 側のテーブル別名を前提にしていた (layering 違反)。
+    caller が明示的に ``table_alias`` / ``frontmatter_column`` を渡せることを
+    pin する。default 値は後方互換のため ``"n"`` / ``"frontmatter"``。
+    """
+
+    @pytest.mark.parametrize("op,value", [("eq", "5"), ("ne", "5"), ("in", ("5",))])
+    def test_custom_table_alias_appears_in_sql(self, op: str, value: object) -> None:
+        cond = MetadataCondition(key="priority", op=op, value=value)  # type: ignore[arg-type]
+        fragment, _ = build_sql_fragment(cond, table_alias="notes")
+        assert "notes.frontmatter" in fragment, (
+            f"custom table_alias must appear in generated SQL: {fragment!r}"
+        )
+        assert "n.frontmatter" not in fragment, (
+            f"default alias must not leak when custom provided: {fragment!r}"
+        )
+
+    @pytest.mark.parametrize("op,value", [("eq", "5"), ("ne", "5"), ("in", ("5",))])
+    def test_custom_frontmatter_column_appears_in_sql(self, op: str, value: object) -> None:
+        cond = MetadataCondition(key="priority", op=op, value=value)  # type: ignore[arg-type]
+        fragment, _ = build_sql_fragment(cond, frontmatter_column="fm")
+        assert "n.fm" in fragment, f"custom column must appear in SQL: {fragment!r}"
+        assert "n.frontmatter" not in fragment, (
+            f"default column must not leak when custom provided: {fragment!r}"
+        )
+
+    @pytest.mark.parametrize("op,value", [("eq", "5"), ("ne", "5"), ("in", ("5",))])
+    def test_default_args_match_previous_contract(self, op: str, value: object) -> None:
+        """default 引数なし呼出は従来通り ``n.frontmatter`` を生成 (後方互換)."""
+        cond = MetadataCondition(key="priority", op=op, value=value)  # type: ignore[arg-type]
+        fragment, _ = build_sql_fragment(cond)
+        assert "n.frontmatter" in fragment, (
+            f"default behavior must remain n.frontmatter: {fragment!r}"
+        )
+
+    def test_both_args_combined(self) -> None:
+        """table_alias と frontmatter_column の両方を同時に変更できる."""
+        cond = MetadataCondition(key="priority", op="eq", value="5")
+        fragment, _ = build_sql_fragment(cond, table_alias="notes", frontmatter_column="fm")
+        assert "notes.fm" in fragment, f"combined alias/column must appear: {fragment!r}"
+        assert "n.frontmatter" not in fragment
+        assert "n.fm" not in fragment
+        assert "notes.frontmatter" not in fragment
+
+
+# ---------------------------------------------------------------------------
+# build_folder_filter_clause (moved from indexer.py — #46)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFolderFilterClause:
+    """``build_folder_filter_clause`` が filter.py の public API であること (#46).
+
+    PR #151 で folder 正規化が ``validation.normalize_folder`` に抽出された結果、
+    indexer.py の ``_folder_filter_clause`` は「正規化済み folder → WHERE 断片」の
+    純粋 SQL builder に縮退した。metadata_filter の builder と責務が揃ったので、
+    filter モジュールに移動して SQL fragment builder を集約する。
+    """
+
+    def test_importable_from_filter_module(self) -> None:
+        """filter モジュール直下から import できる (public API)."""
+        from vault_search.filter import build_folder_filter_clause
+
+        assert callable(build_folder_filter_clause)
+
+    def test_basic_folder_clause(self) -> None:
+        from vault_search.filter import build_folder_filter_clause
+
+        clause, params = build_folder_filter_clause("Projects")
+        assert "folder = ?" in clause
+        assert "folder LIKE ?" in clause
+        assert "ESCAPE '\\'" in clause
+        assert params == ["Projects", "Projects/%"]
+
+    def test_custom_column_with_table_alias(self) -> None:
+        """column 引数でテーブル別名付き column (``n.folder`` 等) を指定可能."""
+        from vault_search.filter import build_folder_filter_clause
+
+        clause, params = build_folder_filter_clause("Projects", column="n.folder")
+        assert "n.folder = ?" in clause
+        assert "n.folder LIKE ?" in clause
+        assert params == ["Projects", "Projects/%"]
+
+    def test_wildcard_chars_escaped_in_like_param(self) -> None:
+        """folder 名に含まれる '%' '_' は LIKE param で ESCAPE される."""
+        from vault_search.filter import build_folder_filter_clause
+
+        _, params = build_folder_filter_clause("10%OFF_notes")
+        # 等号比較は生 folder、LIKE param 側だけエスケープされる
+        assert params[0] == "10%OFF_notes"
+        assert params[1] == r"10\%OFF\_notes/%"


### PR DESCRIPTION
Phase E1。filter.py の layer 越え (#29) と folder filter の層不整合 (#46) を 1 PR で解消。

## Summary

- **#29**: `build_sql_fragment` に keyword-only 引数 `table_alias` (default `"n"`) / `frontmatter_column` (default `"frontmatter"`) を追加。内部 11 箇所の `n.frontmatter` ハードコードを f-string 化。filter モジュールが indexer 側のテーブル別名を前提にしていた layer 越えを解消。
- **#46**: `indexer._folder_filter_clause` を `filter.build_folder_filter_clause` として filter.py に移動 + public 化。PR #151 で folder 正規化が `validation.normalize_folder` に抽出された結果、この関数は「正規化済み folder → WHERE 断片」の純粋 SQL builder に縮退していたので、metadata_filter builder と責務を揃えて集約。

## 変更範囲

- `src/vault_search/filter.py` — 引数追加、`build_folder_filter_clause` 新設、`__all__` 更新、module docstring で 2 系統 builder 集約の責務を明示
- `src/vault_search/indexer.py` — `_folder_filter_clause` 定義削除、import を filter から、呼出 2 箇所 (`_fts5_search` / `recent_notes`) を差替
- `tests/test_filter.py` — 新規 11 test (alias 引数化 3 演算子 × 3 + 両引数 + folder helper 4 件)

## 完了条件

- [x] `#29` — filter.py の SQL alias ハードコード解消、テーブル別名を引数化
- [x] `#46` — `_folder_filter_clause` を filter.py に移動 + public API 化
- [x] 全テスト通過 (483 passed、+14 new)
- [x] ruff check / format clean
- [x] 挙動変更ゼロ (既存 caller は default 引数で完全後方互換)

## Test plan

- [x] `.venv/bin/pytest tests/test_filter.py -v` — 133 passed (122 既存 + 11 新規)
- [x] `.venv/bin/pytest tests/` — 483 passed
- [x] `.venv/bin/ruff check src/ tests/` — clean
- [x] `.venv/bin/ruff format src/ tests/` — clean

## Commits

1. `Red`: 新 signature と filter.build_folder_filter_clause の期待を pin する failing test 追加
2. `Green`: alias 引数化 + folder helper を filter.py に追加 (indexer.py の定義は未変更)
3. `Refactor`: indexer.py から `_folder_filter_clause` 削除、filter からの import に差替、module docstring 更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)