### PR TITLE
Refactor: _FOLDER_INPUT_SCHEMA を Pydantic Annotated に統合 (#47)

### DIFF
--- a/src/vault_search/mcp_contract.py
+++ b/src/vault_search/mcp_contract.py
@@ -69,21 +69,21 @@ class _ToolSchemaSpec:
 # ---------------------------------------------------------------------------
 
 
-_FOLDER_INPUT_SCHEMA: dict[str, Any] = {
-    "type": ["string", "null"],
-    "description": (
-        "フォルダパス (Vault ルートからの相対)。指定したフォルダ自身と"
-        "その配下のみを対象とし、同プレフィックス兄弟 ('Projects' 指定で "
-        "'Projects Hermes/...' など) は除外される。"
-        "vault_folders の結果 (FolderCount.folder) をそのまま渡せる。"
-        "root 直下に限定したい場合は現状未サポート (null で全件)。"
-        "末尾 '/' および '\\\\' 区切りは自動で正規化される "
-        "(例: 'Projects/' → 'Projects')。"
-        "スラッシュのみの入力 ('/', '//', '\\\\\\\\') はフィルタなし "
-        "(= folder 指定なしと同等) として扱う。"
-        '例: "Projects"、"Projects/Hermes Agent"、"Projects/"。'
-    ),
-}
+# folder パラメータの description 文字列 — 単一ソース。
+# server.py の Annotated[str | None, Field(description=_FOLDER_DESCRIPTION)] と
+# TOOL_SPECS の input_schema 両方から参照することで drift を防ぐ (Issue #47)。
+_FOLDER_DESCRIPTION: str = (
+    "フォルダパス (Vault ルートからの相対)。指定したフォルダ自身と"
+    "その配下のみを対象とし、同プレフィックス兄弟 ('Projects' 指定で "
+    "'Projects Hermes/...' など) は除外される。"
+    "vault_folders の結果 (FolderCount.folder) をそのまま渡せる。"
+    "root 直下に限定したい場合は現状未サポート (null で全件)。"
+    "末尾 '/' および '\\\\' 区切りは自動で正規化される "
+    "(例: 'Projects/' → 'Projects')。"
+    "スラッシュのみの入力 ('/', '//', '\\\\\\\\') はフィルタなし "
+    "(= folder 指定なしと同等) として扱う。"
+    '例: "Projects"、"Projects/Hermes Agent"、"Projects/"。'
+)
 
 
 # Shared pagination input schemas. ``minimum`` / ``maximum`` are the single
@@ -149,7 +149,7 @@ TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
             "properties": {
                 "query": {"type": "string", "description": "検索クエリ"},
                 "tags": {"type": ["array", "null"], "items": {"type": "string"}},
-                "folder": _FOLDER_INPUT_SCHEMA,
+                "folder": {"type": ["string", "null"], "description": _FOLDER_DESCRIPTION},
                 "limit": _LIMIT_INPUT_SCHEMA,
                 "offset": _OFFSET_INPUT_SCHEMA,
                 "metadata_filter": {
@@ -240,7 +240,7 @@ TOOL_SPECS: dict[str, _ToolSchemaSpec] = {
             "properties": {
                 "limit": _LIMIT_INPUT_SCHEMA,
                 "offset": _OFFSET_INPUT_SCHEMA,
-                "folder": _FOLDER_INPUT_SCHEMA,
+                "folder": {"type": ["string", "null"], "description": _FOLDER_DESCRIPTION},
             },
         },
         output_model=RecentNote,

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -20,13 +20,15 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field
 
 from .exceptions import NoteNotFoundError
 from .indexer import VaultIndex
 from .mcp_contract import (
+    _FOLDER_DESCRIPTION,
     TOOL_SPECS,
     build_schema_payload,
     inject_rich_output_schemas,
@@ -76,7 +78,7 @@ mcp = FastMCP("vault-search")
 def vault_search(
     query: str,
     tags: list[str] | None = None,
-    folder: str | None = None,
+    folder: Annotated[str | None, Field(description=_FOLDER_DESCRIPTION)] = None,
     limit: int = 20,
     offset: int = 0,
     metadata_filter: dict[str, Any] | None = None,
@@ -160,7 +162,7 @@ def vault_get_note(path: str) -> dict[str, Any]:
 def vault_recent(
     limit: int = 20,
     offset: int = 0,
-    folder: str | None = None,
+    folder: Annotated[str | None, Field(description=_FOLDER_DESCRIPTION)] = None,
 ) -> dict[str, Any]:
     """最近更新されたノート一覧を取得する。
 

--- a/tests/test_mcp_contract.py
+++ b/tests/test_mcp_contract.py
@@ -58,9 +58,7 @@ def test_property_names_pattern_matches_validation() -> None:
     from vault_search.validation import IDENTIFIER_JSON_PATTERN
 
     mf = TOOL_SPECS["vault_search"].input_schema["properties"]
-    assert mf["metadata_filter"]["propertyNames"]["pattern"] == (
-        IDENTIFIER_JSON_PATTERN
-    )
+    assert mf["metadata_filter"]["propertyNames"]["pattern"] == (IDENTIFIER_JSON_PATTERN)
 
 
 def test_property_names_max_length_matches_validation() -> None:
@@ -69,9 +67,7 @@ def test_property_names_max_length_matches_validation() -> None:
     from vault_search.validation import IDENTIFIER_MAX_LEN
 
     mf = TOOL_SPECS["vault_search"].input_schema["properties"]
-    assert mf["metadata_filter"]["propertyNames"]["maxLength"] == (
-        IDENTIFIER_MAX_LEN
-    )
+    assert mf["metadata_filter"]["propertyNames"]["maxLength"] == (IDENTIFIER_MAX_LEN)
 
 
 # ---------------------------------------------------------------------------
@@ -88,10 +84,5 @@ def test_metadata_filter_description_mentions_single_operator() -> None:
     # "1 operator", "one operator", "exactly one" のいずれかを含む
     desc_lower = desc.lower()
     assert (
-        "1 operator" in desc_lower
-        or "one operator" in desc_lower
-        or "exactly one" in desc_lower
-    ), (
-        "metadata_filter description does not mention "
-        f"single-operator-per-key constraint: {desc!r}"
-    )
+        "1 operator" in desc_lower or "one operator" in desc_lower or "exactly one" in desc_lower
+    ), f"metadata_filter description does not mention single-operator-per-key constraint: {desc!r}"

--- a/tests/test_mcp_input_schema_drift.py
+++ b/tests/test_mcp_input_schema_drift.py
@@ -63,6 +63,4 @@ def test_folder_description_matches_tool_specs() -> None:
             f"  FastMCP (tools/list): {fastmcp_desc!r}\n"
             f"  TOOL_SPECS (schema://tools): {contract_desc!r}"
         )
-        assert contract_desc, (
-            f"{tool_name}: TOOL_SPECS folder description must be non-empty"
-        )
+        assert contract_desc, f"{tool_name}: TOOL_SPECS folder description must be non-empty"

--- a/tests/test_mcp_input_schema_drift.py
+++ b/tests/test_mcp_input_schema_drift.py
@@ -1,0 +1,68 @@
+"""folder パラメータ input schema の drift 検知テスト (Issue #47).
+
+MCP tools/list が公開する folder input schema の description と
+TOOL_SPECS (schema://tools 経路) の description が一致することを assert する。
+
+Red: FastMCP の生成 schema に folder description がない (str | None の plain annotation)
+     ため TOOL_SPECS の description と不一致 → テスト失敗。
+Green: server.py で Annotated[str | None, Field(description=_FOLDER_DESCRIPTION)] を使い
+       mcp_contract.py の _FOLDER_INPUT_SCHEMA を廃止すると両者が一致 → テスト通過。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from vault_search import server as server_mod
+from vault_search.mcp_contract import TOOL_SPECS
+
+# folder パラメータを持つツール
+_FOLDER_TOOLS = ["vault_search", "vault_recent"]
+
+
+def _get_fastmcp_input_props() -> dict[str, dict]:
+    """FastMCP が tools/list で公開する input schema の properties を全 tool 分返す."""
+    tools = asyncio.run(server_mod.mcp.list_tools())
+    return {t.name: t.inputSchema.get("properties", {}) for t in tools}
+
+
+def test_folder_description_present_in_fastmcp_schema() -> None:
+    """FastMCP が tools/list で公開する input schema に folder の description が存在すること.
+
+    ``folder: str | None = None`` の plain annotation では description が生成されないため、
+    ``Annotated[str | None, Field(description=...)]`` への変更後に pass する (Green)。
+    """
+    all_props = _get_fastmcp_input_props()
+    for tool_name in _FOLDER_TOOLS:
+        props = all_props[tool_name]
+        assert "folder" in props, f"{tool_name}: folder not in FastMCP input schema"
+        desc = props["folder"].get("description", "")
+        assert isinstance(desc, str) and desc.strip(), (
+            f"{tool_name}: folder description absent in FastMCP input schema. "
+            f"folder schema: {props['folder']!r}"
+        )
+
+
+def test_folder_description_matches_tool_specs() -> None:
+    """FastMCP input schema の folder description が TOOL_SPECS と一致すること (drift 検知).
+
+    _FOLDER_INPUT_SCHEMA (TOOL_SPECS 側) と server.py の Annotated annotation が
+    別々に管理されていると description が drift する。単一ソース化後は両者が
+    同一定数を参照するため不一致が起きない。
+    """
+    all_props = _get_fastmcp_input_props()
+    for tool_name in _FOLDER_TOOLS:
+        fastmcp_props = all_props[tool_name]
+        fastmcp_desc = fastmcp_props.get("folder", {}).get("description", "")
+
+        contract_props = TOOL_SPECS[tool_name].input_schema.get("properties", {})
+        contract_desc = contract_props.get("folder", {}).get("description", "")
+
+        assert fastmcp_desc == contract_desc, (
+            f"{tool_name}: folder description drift detected\n"
+            f"  FastMCP (tools/list): {fastmcp_desc!r}\n"
+            f"  TOOL_SPECS (schema://tools): {contract_desc!r}"
+        )
+        assert contract_desc, (
+            f"{tool_name}: TOOL_SPECS folder description must be non-empty"
+        )


### PR DESCRIPTION
## 採用案

`_FOLDER_INPUT_SCHEMA` (手書き JSON Schema dict) を廃止し、`_FOLDER_DESCRIPTION` 文字列定数を単一ソースとして
`server.py` の `Annotated[str | None, Field(description=...)]` と `TOOL_SPECS.input_schema` の両方から参照する設計に変更。

## 変更内容

- **`mcp_contract.py`**:
  - `_FOLDER_INPUT_SCHEMA: dict` を廃止
  - `_FOLDER_DESCRIPTION: str` 定数を新設 (description 文言を 1 箇所に集約)
  - `TOOL_SPECS["vault_search"]` / `["vault_recent"]` の `folder` エントリをインライン dict `{"type": ["string", "null"], "description": _FOLDER_DESCRIPTION}` に変更
- **`server.py`**:
  - `_FOLDER_DESCRIPTION` をインポート
  - `vault_search` / `vault_recent` の `folder` パラメータを `Annotated[str | None, Field(description=_FOLDER_DESCRIPTION)]` に変更

## drift 検知テスト

`tests/test_mcp_input_schema_drift.py` を新設:
- `test_folder_description_present_in_fastmcp_schema`: FastMCP が `tools/list` で公開する input schema に `folder.description` が存在することを assert
- `test_folder_description_matches_tool_specs`: FastMCP と `TOOL_SPECS` の description が一致することを assert (drift 検知)

## 完了条件対応

- [x] `.venv/bin/pytest tests/` 471 tests passed
- [x] `.venv/bin/ruff check src/ tests/` clean
- [x] `.venv/bin/ruff format src/ tests/` clean
- [x] Red/Green TDD 2 commit

## Refactor 省略理由

Green diff: 応急措置・重複ロジック・local import なし。変更は `_FOLDER_INPUT_SCHEMA` → `_FOLDER_DESCRIPTION` の単純な置き換えのみ。housekeeping ゼロのため省略。

## Test plan

- [ ] CI 全 pass 確認
- [ ] `gh pr diff` でスコープ外ファイルが混入していないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)