### PR TITLE
Fix: _IDENTIFIER_PATTERN を Unicode-aware に変更 (#33)

### DIFF
--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -8,9 +8,11 @@ surfaces the ``kind`` of input in error messages so the agent can self-correct.
 Design notes
 ------------
 
-* Identifiers (``field`` names, frontmatter keys) use a conservative ASCII
-  allow-list: ``A-Z a-z 0-9 _ - .``. The dot is kept because Obsidian users
-  conventionally express nested frontmatter keys as ``nested.key``.
+* Identifiers (``field`` names, frontmatter keys) accept Unicode word
+  characters (``\\w``), hyphens, and dots as segment separators. This allows
+  non-ASCII frontmatter keys such as ``タイトル`` that Obsidian users author
+  natively (#33). Control characters, path separators, and other punctuation
+  are still rejected. The dot is kept for nested-key notation (``nested.key``).
 * Values (``metadata_filter`` right-hand side) accept any Unicode text
   except C0/C1-adjacent control characters. Empty string is valid because
   ``key == ""`` is a meaningful filter ("frontmatter key present but
@@ -162,8 +164,8 @@ def validate_identifier(
         If ``name`` is empty, exceeds ``max_len``, contains control
         characters (including NUL), attempts path traversal, has an
         empty dot-separated segment (leading/trailing/consecutive ``.``),
-        or contains any character outside ``A-Z a-z 0-9 _ -`` within a
-        segment.
+        or contains a character outside Unicode word characters (``\\w``) and
+        hyphen within a segment (e.g. spaces, punctuation, path separators).
     """
     if not isinstance(name, str):
         raise ValidationError(f"{kind} must be a string, got {type(name).__name__}")

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -55,10 +55,10 @@ LIMIT_MAX = 500
 # between non-empty segments: leading, trailing, and consecutive dots would
 # expand to malformed SQLite JSON paths (e.g. ``$..foo``) and surface as
 # ``sqlite3.OperationalError`` instead of ``ValidationError`` (issue #14).
-_IDENTIFIER_SEGMENT = r"[A-Za-z0-9_\-]+"
+_IDENTIFIER_SEGMENT = r"[\w\-]+"
 _IDENTIFIER_PATTERN = rf"{_IDENTIFIER_SEGMENT}(?:\.{_IDENTIFIER_SEGMENT})*"
 _IDENTIFIER_RE = re.compile(rf"^{_IDENTIFIER_PATTERN}$")
-_IDENTIFIER_ALLOWED_DESC = "A-Z a-z 0-9 _ -, with . as separator between non-empty segments"
+_IDENTIFIER_ALLOWED_DESC = "Unicode word chars (\\w) and hyphen, with . as segment separator"
 
 # C0 controls (0x00-0x1F) + DEL (0x7F). Tabs/newlines are rejected because
 # they are never meaningful inside a field name or filter value and are a

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -195,14 +195,25 @@ def test_validate_identifier_malformed_dot_message_names_the_cause(name: str) ->
     )
 
 
-def test_validate_identifier_rejects_non_ascii_japanese() -> None:
-    with pytest.raises(ValidationError):
-        validate_identifier("重要")
+@pytest.mark.parametrize(
+    "name",
+    [
+        "タイトル",
+        "カテゴリ",
+        "日本語_キー",
+        "重要",
+        "café",
+    ],
+)
+def test_validate_identifier_accepts_unicode_keys(name: str) -> None:
+    """Unicode frontmatter keys (Japanese, accented Latin) must be accepted.
 
-
-def test_validate_identifier_rejects_non_ascii_latin() -> None:
-    with pytest.raises(ValidationError):
-        validate_identifier("café")
+    Issue #33: schema://tools exposes non-ASCII keys from vault frontmatter,
+    but validate_identifier used an ASCII-only pattern, causing every
+    Japanese / accented key to raise ValidationError even when passed
+    verbatim from the schema resource.
+    """
+    assert validate_identifier(name) == name
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
noascii-teammate (`phase-e1-sideline-parallel`) が 3 commit push 済み、PR 作成時に 529 overloaded error で中断したため team-lead が代理で PR 作成。

## Summary

- `_IDENTIFIER_SEGMENT` を `[A-Za-z0-9_\-]+` → `[\w\-]+` に変更 (Python 3 `\w` は default で Unicode-aware)
- 日本語・CJK・アクセント付きラテン文字等の frontmatter キー (`タイトル` / `カテゴリ` 等) が `validate_identifier` に受理される
- `schemas.list_frontmatter_keys` が露出するキーと validator 受理キーの乖離解消 (#33)
- SQL / JSON path injection vectors (空白 / `;` / `/` / `\` / `$` 等) の reject は維持

## 採用案

**Option A**: `_IDENTIFIER_PATTERN` を Unicode-aware `\w` に変更 (validation.py 1 ファイル)。

**Option B** (schema 側で filter、不採用): schemas.py / indexer.py を触ると並行進行中の Phase E1 (filter.py + indexer.py) と衝突するため。Option A は validation.py に閉じて衝突ゼロ。

## 完了条件

- [x] `validate_identifier("タイトル")` / `"カテゴリ")` / `"日本語_キー"` が pass
- [x] injection vectors は引き続き reject
- [x] 既存 valid / invalid テスト全通
- [x] `re.ASCII` flag は立てない (Unicode-aware 挙動を default で使用)
- [x] CI pass

## Test plan

- [x] `.venv/bin/pytest tests/test_validation.py -v`
- [x] `.venv/bin/pytest tests/` — full regression
- [x] `.venv/bin/ruff check src/ tests/` / `ruff format src/ tests/`

## Commits

1. `Red`: 非ASCII frontmatter キー受理の失敗テスト追加 (13aac11)
2. `Green`: `_IDENTIFIER_PATTERN` を Unicode-aware に変更 (5137ade)
3. `Refactor`: docstring を Unicode-aware に更新 (ac7f87c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)