### PR TITLE
Refactor: is_indexable_path + on_moved dispatch で watcher Handler 構造負債を解消 (#76, #77)

### DIFF
--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -155,10 +155,35 @@ class VaultIndex:
     # 除外するフォルダ名（先頭一致）
     _EXCLUDED_PREFIXES = (".", "_")
 
+    def is_indexable_path(self, raw_path: str | Path) -> str | None:
+        """Vault 内のインデックス対象パスかを判定し、該当すれば rel path を返す.
+
+        フィルタ条件:
+
+        - ``.md`` 拡張子
+        - ``vault_root`` 配下
+        - パス構成要素に ``.`` / ``_`` プレフィックスを含まない
+
+        walker (``_iter_markdown_files``) と watcher Handler
+        (``VaultEventHandler``) 双方の単一ソースとし、将来の除外ルール拡張で
+        drift しないようにする (#76)。
+        """
+        s = str(raw_path)
+        if not s.endswith(".md"):
+            return None
+        try:
+            rel = str(Path(s).relative_to(self.vault_root)).replace("\\", "/")
+        except ValueError:
+            return None
+        if any(p.startswith(self._EXCLUDED_PREFIXES) for p in Path(rel).parts):
+            return None
+        return rel
+
     def _iter_markdown_files(self) -> list[Path]:
         """Vault 内の .md ファイルを安全にイテレーション.
 
         隠しフォルダ・システムフォルダをスキップし、I/O エラーを吸収する。
+        leaf 判定は ``is_indexable_path`` に委譲して Handler 側とロジックを共有する。
         """
         results: list[Path] = []
 
@@ -170,14 +195,14 @@ class VaultIndex:
 
             for entry in entries:
                 name = entry.name
-                # 隠しフォルダ / _ プレフィックスをスキップ
+                # 隠しフォルダ / _ プレフィックスをスキップ (traversal 最適化)
                 if any(name.startswith(p) for p in self._EXCLUDED_PREFIXES):
                     continue
 
                 try:
                     if entry.is_dir():
                         _walk(entry)
-                    elif entry.is_file() and name.endswith(".md"):
+                    elif entry.is_file() and self.is_indexable_path(entry) is not None:
                         results.append(entry)
                 except OSError:
                     continue

--- a/src/vault_search/watcher.py
+++ b/src/vault_search/watcher.py
@@ -11,7 +11,6 @@ import logging
 import threading
 import time
 from collections.abc import Callable
-from pathlib import Path
 from typing import Any
 
 from .indexer import VaultIndex
@@ -21,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 try:
     from watchdog.events import (
-        FileMovedEvent,
         FileSystemEvent,
         FileSystemEventHandler,
     )
@@ -35,43 +33,61 @@ except ImportError:  # pragma: no cover - watchdog is a hard dep but keep guard 
 class VaultEventHandler(FileSystemEventHandler):  # type: ignore[misc]
     """watchdog FileSystemEventHandler を vault 専用フィルタ + callback に閉じ込める.
 
-    Observer / filesystem を介さず、テストから直接 ``on_any_event`` に合成
+    Observer / filesystem を介さず、テストから直接各 handler メソッドに合成
     イベントを流せるよう module-level に切り出している (#79)。
+
+    Dispatch 構造 (#77): watchdog 慣例に合わせて ``on_created`` / ``on_modified``
+    / ``on_deleted`` / ``on_moved`` を個別 override する。汎用 ``on_any_event``
+    フォールバックは使わないことで:
+
+    - ``isinstance(event, FileMovedEvent)`` 分岐を排除
+    - 将来 watchdog に追加される ``FileClosedEvent`` 等による意図しない
+      再インデックスを避ける
+    - ``on_moved`` を他所から差し替えた際の src/dest 二重 schedule を構造的に防ぐ
+
+    パス判定は ``VaultIndex.is_indexable_path`` に委譲する (#76)。``.md`` 拡張子
+    / ``vault_root`` 配下 / 除外プレフィックスの判定が walker (`_iter_markdown_files`)
+    と単一ソース化される。
     """
 
-    def __init__(self, vault_root: Path, schedule_callback: Callable[[str], None]) -> None:
-        self._vault_root = vault_root
+    def __init__(self, index: VaultIndex, schedule_callback: Callable[[str], None]) -> None:
+        self._index = index
         self._schedule = schedule_callback
 
     def _schedule_if_valid(self, raw_path: str) -> None:
-        if not raw_path.endswith(".md"):
-            logger.debug("skipped non-.md path: %s", raw_path)
-            return
-        try:
-            rel = str(Path(raw_path).relative_to(self._vault_root)).replace("\\", "/")
-        except ValueError:
-            logger.debug("skipped path outside vault: %s", raw_path)
-            return
-        if any(p.startswith(".") or p.startswith("_") for p in Path(rel).parts):
-            logger.debug("skipped excluded path: %s", rel)
+        rel = self._index.is_indexable_path(raw_path)
+        if rel is None:
+            logger.debug("skipped non-indexable path: %s", raw_path)
             return
         self._schedule(rel)
 
-    def on_any_event(self, event: FileSystemEvent) -> None:  # type: ignore[override]
+    def on_created(self, event: FileSystemEvent) -> None:  # type: ignore[override]
         if event.is_directory:
             return
-        # FileMovedEvent はリネーム/移動。src_path (旧) と
-        # dest_path (新) の両方をインデックス更新対象にする (#58)。
-        if isinstance(event, FileMovedEvent):
-            logger.info(
-                "rename detected: %s -> %s",
-                event.src_path,
-                event.dest_path,
-            )
-            self._schedule_if_valid(event.src_path)
-            self._schedule_if_valid(event.dest_path)
+        self._schedule_if_valid(event.src_path)
+
+    def on_modified(self, event: FileSystemEvent) -> None:  # type: ignore[override]
+        if event.is_directory:
             return
         self._schedule_if_valid(event.src_path)
+
+    def on_deleted(self, event: FileSystemEvent) -> None:  # type: ignore[override]
+        if event.is_directory:
+            return
+        self._schedule_if_valid(event.src_path)
+
+    def on_moved(self, event: FileSystemEvent) -> None:  # type: ignore[override]
+        if event.is_directory:
+            return
+        # FileMovedEvent はリネーム/移動。src_path (旧) と dest_path (新)
+        # の両方をインデックス更新対象にする (#58)。
+        logger.info(
+            "rename detected: %s -> %s",
+            event.src_path,
+            event.dest_path,
+        )
+        self._schedule_if_valid(event.src_path)
+        self._schedule_if_valid(event.dest_path)
 
 
 class VaultWatcher:
@@ -96,7 +112,7 @@ class VaultWatcher:
 
         from watchdog.observers import Observer
 
-        handler = VaultEventHandler(self._index.vault_root, self._schedule_update)
+        handler = VaultEventHandler(self._index, self._schedule_update)
         self._observer = Observer()
         self._observer.schedule(handler, str(self._index.vault_root), recursive=True)
         self._observer.daemon = True

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -131,6 +131,58 @@ def test_excluded_prefix_folders(vault_index: VaultIndex) -> None:
     assert not any(f.startswith(".") for f in folders)
 
 
+# ---------------------------------------------------------------------------
+# is_indexable_path — walker と watcher Handler の単一ソース (#76)
+# ---------------------------------------------------------------------------
+
+
+class TestIsIndexablePath:
+    """``VaultIndex.is_indexable_path`` の除外ルール (#76)."""
+
+    def test_accepts_flat_md(self, tmp_path: Path) -> None:
+        idx = VaultIndex(tmp_path, db_path=tmp_path / "x.db")
+        assert idx.is_indexable_path(tmp_path / "note.md") == "note.md"
+
+    def test_accepts_nested_md(self, tmp_path: Path) -> None:
+        idx = VaultIndex(tmp_path, db_path=tmp_path / "x.db")
+        assert idx.is_indexable_path(tmp_path / "sub" / "deep" / "n.md") == "sub/deep/n.md"
+
+    def test_rejects_non_md_extension(self, tmp_path: Path) -> None:
+        idx = VaultIndex(tmp_path, db_path=tmp_path / "x.db")
+        assert idx.is_indexable_path(tmp_path / "notes.txt") is None
+        assert idx.is_indexable_path(tmp_path / "image.png") is None
+        assert idx.is_indexable_path(tmp_path / "README.MD") is None  # case-sensitive
+
+    def test_rejects_outside_vault(self, tmp_path: Path) -> None:
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        idx = VaultIndex(vault, db_path=tmp_path / "x.db")
+        outside = tmp_path / "elsewhere" / "x.md"
+        assert idx.is_indexable_path(outside) is None
+
+    @pytest.mark.parametrize(
+        "rel,expect",
+        [
+            (".archive/n.md", None),
+            ("_drafts/n.md", None),
+            ("sub/.hidden/n.md", None),
+            ("sub/_internal/n.md", None),
+            (".archive.md", None),  # ファイル名自体も除外
+            ("_private.md", None),
+        ],
+    )
+    def test_rejects_excluded_prefix_segments(
+        self, tmp_path: Path, rel: str, expect: str | None
+    ) -> None:
+        idx = VaultIndex(tmp_path, db_path=tmp_path / "x.db")
+        assert idx.is_indexable_path(tmp_path / rel) is expect
+
+    def test_accepts_string_and_path_inputs(self, tmp_path: Path) -> None:
+        idx = VaultIndex(tmp_path, db_path=tmp_path / "x.db")
+        assert idx.is_indexable_path(str(tmp_path / "n.md")) == "n.md"
+        assert idx.is_indexable_path(tmp_path / "n.md") == "n.md"
+
+
 def test_get_note_roundtrip(vault_index: VaultIndex) -> None:
     note = vault_index.get_note("Welcome.md")
     assert note is not None

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -23,8 +23,10 @@ import pytest
 pytest.importorskip("watchdog")
 
 from watchdog.events import (  # noqa: E402
+    FileClosedEvent,
     FileCreatedEvent,
     FileDeletedEvent,
+    FileModifiedEvent,
     FileMovedEvent,
 )
 
@@ -73,10 +75,10 @@ def index(vault: Path, tmp_path: Path) -> VaultIndex:
 # ---------------------------------------------------------------------------
 
 
-def _make_handler(vault: Path) -> tuple[VaultEventHandler, list[str]]:
+def _make_handler(index: VaultIndex) -> tuple[VaultEventHandler, list[str]]:
     """``VaultEventHandler`` と schedule された rel_path を記録する list を返す."""
     scheduled: list[str] = []
-    handler = VaultEventHandler(vault.resolve(), scheduled.append)
+    handler = VaultEventHandler(index, scheduled.append)
     return handler, scheduled
 
 
@@ -99,75 +101,111 @@ RENAME_HANDLER_CASES = [
 
 @pytest.mark.parametrize("src_rel,dest_rel,expected", RENAME_HANDLER_CASES)
 def test_handler_schedules_rename_paths(
-    vault: Path, src_rel: str, dest_rel: str, expected: list[str]
+    vault: Path, index: VaultIndex, src_rel: str, dest_rel: str, expected: list[str]
 ) -> None:
     """合成 ``FileMovedEvent`` で src/dest が期待通り schedule されること.
 
     filesystem を経由しないため Observer 登録 race / inotify レイテンシに
     依存しない。RENAME のシナリオ網羅はこの経路で担保する (#79)。
     """
-    handler, scheduled = _make_handler(vault)
+    handler, scheduled = _make_handler(index)
     src_full = str(vault / src_rel)
     dest_full = str(vault / dest_rel)
-    handler.on_any_event(FileMovedEvent(src_full, dest_full))
+    handler.on_moved(FileMovedEvent(src_full, dest_full))
     assert scheduled == expected
 
 
-def test_handler_schedules_on_create(vault: Path) -> None:
+def test_handler_schedules_on_create(vault: Path, index: VaultIndex) -> None:
     """``FileCreatedEvent`` で対象 .md が schedule される."""
-    handler, scheduled = _make_handler(vault)
-    handler.on_any_event(FileCreatedEvent(str(vault / "fresh.md")))
+    handler, scheduled = _make_handler(index)
+    handler.on_created(FileCreatedEvent(str(vault / "fresh.md")))
     assert scheduled == ["fresh.md"]
 
 
-def test_handler_schedules_on_delete(vault: Path) -> None:
+def test_handler_schedules_on_modified(vault: Path, index: VaultIndex) -> None:
+    """``FileModifiedEvent`` で対象 .md が schedule される (#77 dispatch 分離)."""
+    handler, scheduled = _make_handler(index)
+    handler.on_modified(FileModifiedEvent(str(vault / "edit.md")))
+    assert scheduled == ["edit.md"]
+
+
+def test_handler_schedules_on_delete(vault: Path, index: VaultIndex) -> None:
     """``FileDeletedEvent`` で対象 .md が schedule される."""
-    handler, scheduled = _make_handler(vault)
-    handler.on_any_event(FileDeletedEvent(str(vault / "gone.md")))
+    handler, scheduled = _make_handler(index)
+    handler.on_deleted(FileDeletedEvent(str(vault / "gone.md")))
     assert scheduled == ["gone.md"]
 
 
-def test_handler_skips_non_md(vault: Path) -> None:
+def test_handler_ignores_unmapped_event_types(vault: Path, index: VaultIndex) -> None:
+    """``FileClosedEvent`` 等の未マップ event 型では schedule されない (#77).
+
+    旧 ``on_any_event`` 集約方式では FileClosedEvent でも再インデックスが走って
+    いたが、新方式は ``on_created`` / ``on_modified`` / ``on_deleted`` / ``on_moved``
+    のみ override するため、未マップ型は watchdog default の no-op になる。
+    """
+    handler, scheduled = _make_handler(index)
+    # dispatch() が watchdog の標準経路: on_any_event → type-specific 。
+    # 未 override の on_any_event と on_closed は no-op なので何も起こらない。
+    handler.dispatch(FileClosedEvent(str(vault / "note.md")))
+    assert scheduled == []
+
+
+def test_handler_skips_non_md(vault: Path, index: VaultIndex) -> None:
     """非 .md ファイルは schedule されない (拡張子フィルタ)."""
-    handler, scheduled = _make_handler(vault)
-    handler.on_any_event(FileCreatedEvent(str(vault / "notes.txt")))
-    handler.on_any_event(FileCreatedEvent(str(vault / "image.png")))
+    handler, scheduled = _make_handler(index)
+    handler.on_created(FileCreatedEvent(str(vault / "notes.txt")))
+    handler.on_created(FileCreatedEvent(str(vault / "image.png")))
     assert scheduled == []
 
 
-def test_handler_skips_path_outside_vault(vault: Path, tmp_path: Path) -> None:
+def test_handler_skips_path_outside_vault(vault: Path, index: VaultIndex, tmp_path: Path) -> None:
     """vault_root 外の .md は schedule されない (relative_to 失敗)."""
-    handler, scheduled = _make_handler(vault)
+    handler, scheduled = _make_handler(index)
     outside = tmp_path / "elsewhere" / "x.md"
-    handler.on_any_event(FileCreatedEvent(str(outside)))
+    handler.on_created(FileCreatedEvent(str(outside)))
     assert scheduled == []
 
 
-def test_handler_skips_directory_events(vault: Path) -> None:
+def test_handler_skips_directory_events(vault: Path, index: VaultIndex) -> None:
     """ディレクトリイベントは schedule されない (is_directory=True)."""
-    handler, scheduled = _make_handler(vault)
+    handler, scheduled = _make_handler(index)
     event = FileCreatedEvent(str(vault / "sub"))
     event.is_directory = True
-    handler.on_any_event(event)
+    handler.on_created(event)
     assert scheduled == []
 
 
-def test_handler_logs_rename_at_info(vault: Path, caplog: pytest.LogCaptureFixture) -> None:
-    """``FileMovedEvent`` で ``rename detected`` の INFO log が出る (#78)."""
-    handler, _ = _make_handler(vault)
+def test_handler_on_moved_dispatches_once_via_watchdog(vault: Path, index: VaultIndex) -> None:
+    """``dispatch(FileMovedEvent)`` が on_moved のみ経由で src/dest 各 1 回 schedule (#77).
+
+    watchdog ``dispatch`` は ``on_any_event`` → type-specific の順で呼ぶ。旧実装は
+    ``on_any_event`` で moved を処理 + watchdog default ``on_moved`` が no-op という
+    暗黙の依存があった。新実装は ``on_moved`` のみが処理するため、将来別経路で
+    ``on_any_event`` を触っても二重 schedule が起きないことを構造的に保証する。
+    """
+    handler, scheduled = _make_handler(index)
+    handler.dispatch(FileMovedEvent(str(vault / "A.md"), str(vault / "B.md")))
+    assert scheduled == ["A.md", "B.md"]
+
+
+def test_handler_logs_rename_at_info(
+    vault: Path, index: VaultIndex, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``on_moved`` で ``rename detected`` の INFO log が出る (#78)."""
+    handler, _ = _make_handler(index)
     with caplog.at_level(logging.INFO, logger="vault_search.watcher"):
-        handler.on_any_event(FileMovedEvent(str(vault / "A.md"), str(vault / "B.md")))
+        handler.on_moved(FileMovedEvent(str(vault / "A.md"), str(vault / "B.md")))
     info_msgs = [r.message for r in caplog.records if r.levelno == logging.INFO]
     assert any("rename detected" in m for m in info_msgs), info_msgs
 
 
 def test_handler_logs_debug_on_hidden_dest_exclusion(
-    vault: Path, caplog: pytest.LogCaptureFixture
+    vault: Path, index: VaultIndex, caplog: pytest.LogCaptureFixture
 ) -> None:
     """隠しフォルダ宛 rename で dest 除外時に DEBUG log が出る (#78)."""
-    handler, _ = _make_handler(vault)
+    handler, _ = _make_handler(index)
     with caplog.at_level(logging.DEBUG, logger="vault_search.watcher"):
-        handler.on_any_event(
+        handler.on_moved(
             FileMovedEvent(str(vault / "note.md"), str(vault / ".archive" / "note.md"))
         )
     debug_msgs = [r.message for r in caplog.records if r.levelno == logging.DEBUG]


### PR DESCRIPTION
## Summary

Issue #76 (Handler DI 不能 + パス判定重複) と #77 (on_any_event + isinstance 分岐が watchdog 慣例違反) を一括解消。PR #162 (#79) で実施した Handler module-level 抽出を土台に、残る構造負債を閉じる。

## Changes

### #76: `VaultIndex.is_indexable_path` で単一ソース化

- `VaultIndex.is_indexable_path(raw_path) -> str | None` を公開。`.md` 拡張子 / `vault_root` 配下 / 除外プレフィックス (`.` / `_`) を判定し、該当すれば rel path を返す
- `VaultEventHandler._schedule_if_valid` を `is_indexable_path` 委譲に変更 — closure 内の重複パス判定を削除
- `VaultIndex._iter_markdown_files` の leaf 判定にも `is_indexable_path` を使用 — walker (build_index 経路) と watcher Handler (差分更新経路) が同じ除外ルールを共有
- `VaultEventHandler.__init__` は `vault_root` ではなく `VaultIndex` を受け取る (API break、同一 commit 内で callers 更新済)

### #77: watchdog 慣例の per-type dispatch に統一

- `on_any_event` を廃止し `on_created` / `on_modified` / `on_deleted` / `on_moved` を個別 override
- `isinstance(event, FileMovedEvent)` 分岐を排除
- 副次効果: FileClosedEvent / FileOpenedEvent 等の未マップ型が無視される。旧実装は `on_any_event` 経由でこれらも再インデックスしていたが、コンテンツ変更ではないため過剰発火だった
- 将来 `on_moved` を別途差し替えた際の src/dest 二重 schedule リスクを構造的に排除 (`_schedule_update` の dict dedupe への暗黙依存を解消)

## Test coverage

- **#76 向け**: `TestIsIndexablePath` 7 cases (flat/nested accept / non-.md / outside vault / hidden prefix / underscore prefix / string+Path 入力)
- **#77 向け**: `test_handler_schedules_on_modified` / `test_handler_ignores_unmapped_event_types` / `test_handler_on_moved_dispatches_once_via_watchdog` を追加 (dispatch 経路の regression guard)
- **#79 から継承**: deterministic handler test 17 件 + integration smoke 3 件 は全て維持

## Test plan

- [x] `.venv/bin/pytest` → 490 passed
- [x] `.venv/bin/ruff check --fix && .venv/bin/ruff format` → All checks passed
- [x] `_iter_markdown_files` 経路の既存テスト (`test_excluded_prefix_folders` 等) が回帰なし
- [x] Handler 構造変更後も全 rename/create/delete シナリオが deterministic に pass

Closes #76
Closes #77

https://claude.ai/code/session_01DKrFUiXtTM5eaMu3jxFEai