### PR TITLE
watcher failure observability + main try/finally (#39)

### DIFF
--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -258,9 +258,16 @@ def vault_reindex(force: bool = False) -> dict[str, Any]:
 
     Returns:
         dict: ReindexStats に相当する flat JSON
-            (``added`` / ``updated`` / ``deleted`` / ``skipped`` / ``errors``)。
+            (``added`` / ``updated`` / ``deleted`` / ``skipped`` / ``errors`` /
+            ``watcher_failure_count`` / ``last_watcher_error_at``)。
+            末尾 2 つは VaultWatcher が差分更新で失敗した累計 (#39) を返す。
+            ``--no-watch`` で watcher 無効の場合と起動以降失敗ゼロの場合は
+            それぞれ ``0`` / ``null``。
     """
-    return ReindexStats(**_get_index().build_index(force=force)).model_dump(mode="json")
+    stats = _get_index().build_index(force=force)
+    if _watcher is not None:
+        stats.update(_watcher.failure_stats())
+    return ReindexStats(**stats).model_dump(mode="json")
 
 
 @mcp.tool(annotations=TOOL_SPECS["vault_stats"].annotations)
@@ -362,8 +369,14 @@ def main() -> None:
         _watcher.start()
 
     # MCP サーバー起動（stdio）
+    # shutdown / 例外どちらの経路でも watcher.stop() で Observer スレッドを
+    # 明示停止し、プロセス終了時のリソースリークを防ぐ (#39)。
     logger.info("Starting MCP server (stdio)")
-    mcp.run(transport="stdio")
+    try:
+        mcp.run(transport="stdio")
+    finally:
+        if _watcher is not None:
+            _watcher.stop()
 
 
 if __name__ == "__main__":

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -363,16 +363,16 @@ def main() -> None:
     stats = _index.build_index()
     logger.info("Initial index: %s", stats)
 
-    # ファイル監視開始
-    if not args.no_watch:
-        _watcher = VaultWatcher(_index)
-        _watcher.start()
-
     # MCP サーバー起動（stdio）
     # shutdown / 例外どちらの経路でも watcher.stop() で Observer スレッドを
     # 明示停止し、プロセス終了時のリソースリークを防ぐ (#39)。
+    # watcher.start() を try 内に置くことで、start() 自体が例外を投げた場合にも
+    # finally が実行され stop() が呼ばれることを保証する。
     logger.info("Starting MCP server (stdio)")
     try:
+        if not args.no_watch:
+            _watcher = VaultWatcher(_index)
+            _watcher.start()
         mcp.run(transport="stdio")
     finally:
         if _watcher is not None:

--- a/src/vault_search/stats.py
+++ b/src/vault_search/stats.py
@@ -6,8 +6,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -30,10 +28,11 @@ class ReindexStats(BaseModel):
             "--no-watch で watcher 無効の場合と、一度も失敗していない場合はいずれも 0"
         ),
     )
-    last_watcher_error_at: datetime | None = Field(
+    last_watcher_error_at: str | None = Field(
         default=None,
         description=(
-            "VaultWatcher 最新の失敗時刻 (UTC, ISO 8601)。"
+            "VaultWatcher 最新の失敗時刻 (UTC, isoformat '+00:00' 形式。"
+            "例: '2026-04-19T12:00:00+00:00')。"
             "一度も失敗していない / watcher 無効の場合は null。"
             "watcher_failure_count が 0 でない場合の最新エラーのみ指す"
         ),

--- a/src/vault_search/stats.py
+++ b/src/vault_search/stats.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -19,6 +21,23 @@ class ReindexStats(BaseModel):
     deleted: int = Field(description="削除されたノート数 (ファイル消失)")
     skipped: int = Field(description="mtime 変化なしでスキップされたノート数")
     errors: int = Field(description="パース失敗したノート数")
+    watcher_failure_count: int = Field(
+        default=0,
+        description=(
+            "VaultWatcher が差分更新で失敗した累計件数 (プロセス起動以降)。"
+            "0 より大きいとき、watcher が監視している Vault の一部が"
+            "インデックスと drift している可能性がある。"
+            "--no-watch で watcher 無効の場合と、一度も失敗していない場合はいずれも 0"
+        ),
+    )
+    last_watcher_error_at: datetime | None = Field(
+        default=None,
+        description=(
+            "VaultWatcher 最新の失敗時刻 (UTC, ISO 8601)。"
+            "一度も失敗していない / watcher 無効の場合は null。"
+            "watcher_failure_count が 0 でない場合の最新エラーのみ指す"
+        ),
+    )
 
 
 class VaultStats(BaseModel):

--- a/src/vault_search/watcher.py
+++ b/src/vault_search/watcher.py
@@ -126,7 +126,8 @@ class VaultWatcher:
     def stop(self) -> None:
         if self._observer:
             self._observer.stop()
-            self._observer.join(timeout=5)
+            if self._observer.is_alive():
+                self._observer.join(timeout=5)
             self._observer = None
 
     def _schedule_update(self, rel_path: str) -> None:

--- a/src/vault_search/watcher.py
+++ b/src/vault_search/watcher.py
@@ -11,6 +11,7 @@ import logging
 import threading
 import time
 from collections.abc import Callable
+from datetime import datetime, timezone
 from typing import Any
 
 from .indexer import VaultIndex
@@ -103,6 +104,8 @@ class VaultWatcher:
         self._pending: dict[str, float] = {}
         self._timer: threading.Timer | None = None
         self._lock = threading.Lock()
+        self._watcher_failure_count: int = 0
+        self._last_watcher_error_at: datetime | None = None
 
     def start(self) -> bool:
         """監視開始。watchdog が利用可能なら True."""
@@ -137,6 +140,18 @@ class VaultWatcher:
             self._timer.daemon = True
             self._timer.start()
 
+    def failure_stats(self) -> dict[str, Any]:
+        """差分更新の失敗累計を返す (#39).
+
+        agent が ``vault_reindex`` 経由で watcher の健全性を把握できるよう、
+        起動以降の _flush 失敗カウントと最新失敗時刻 (UTC) を公開する。
+        """
+        with self._lock:
+            return {
+                "watcher_failure_count": self._watcher_failure_count,
+                "last_watcher_error_at": self._last_watcher_error_at,
+            }
+
     def _flush(self) -> None:
         with self._lock:
             paths = list(self._pending.keys())
@@ -149,3 +164,6 @@ class VaultWatcher:
                 logger.info("indexed: %s (pending=%d)", rel_path, n - i - 1)
             except Exception:
                 logger.exception("Failed to update index for %s", rel_path)
+                with self._lock:
+                    self._watcher_failure_count += 1
+                    self._last_watcher_error_at = datetime.now(timezone.utc)

--- a/src/vault_search/watcher.py
+++ b/src/vault_search/watcher.py
@@ -105,7 +105,7 @@ class VaultWatcher:
         self._timer: threading.Timer | None = None
         self._lock = threading.Lock()
         self._watcher_failure_count: int = 0
-        self._last_watcher_error_at: datetime | None = None
+        self._last_watcher_error_at: str | None = None
 
     def start(self) -> bool:
         """監視開始。watchdog が利用可能なら True."""
@@ -166,4 +166,4 @@ class VaultWatcher:
                 logger.exception("Failed to update index for %s", rel_path)
                 with self._lock:
                     self._watcher_failure_count += 1
-                    self._last_watcher_error_at = datetime.now(timezone.utc)
+                    self._last_watcher_error_at = datetime.now(timezone.utc).isoformat()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +19,7 @@ from vault_search.schemas import (
     SearchResponse,
     TagCount,
 )
+from vault_search.watcher import VaultWatcher
 
 
 @pytest.fixture(autouse=True)
@@ -222,6 +224,74 @@ def test_mcp_tool_vault_reindex(vault_index: VaultIndex) -> None:
     # added/updated/deleted/skipped/errors を必須キーで持つ flat JSON
     for key in ("added", "updated", "deleted", "skipped", "errors"):
         assert res[key] >= 0
+
+
+# ---------------------------------------------------------------------------
+# Watcher observability (#39) — vault_reindex が watcher 健全性を返し、
+# main() が watcher.stop() を try/finally で保証する。
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_tool_vault_reindex_watcher_none_defaults(
+    vault_index: VaultIndex, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_watcher=None (--no-watch) でも watcher_failure_count / last_error はデフォルト (#39)."""
+    monkeypatch.setattr(server_mod, "_watcher", None)
+    fn = _fn(server_mod.vault_reindex)
+    res = fn(False)
+    assert res["watcher_failure_count"] == 0
+    assert res["last_watcher_error_at"] is None
+
+
+def test_mcp_tool_vault_reindex_includes_watcher_failures(
+    vault_index: VaultIndex, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_watcher に failure 履歴があれば vault_reindex の戻りに反映される (#39)."""
+    watcher = VaultWatcher(vault_index)
+    # 内部状態を直接設定 (実 flush を待つと flaky になるため)
+    with watcher._lock:
+        watcher._watcher_failure_count = 2
+        watcher._last_watcher_error_at = datetime(2026, 4, 19, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(server_mod, "_watcher", watcher)
+
+    fn = _fn(server_mod.vault_reindex)
+    res = fn(False)
+    assert res["watcher_failure_count"] == 2
+    # JSON 表現は Pydantic のデフォルト datetime 直列化 (ISO 8601)
+    assert res["last_watcher_error_at"] == "2026-04-19T12:00:00Z"
+
+
+def test_main_stops_watcher_on_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """mcp.run() が例外を起こしても _watcher.stop() が呼ばれる (#39 try/finally)."""
+    import sys as _sys
+
+    vault = tmp_path / "main_vault"
+    vault.mkdir()
+    monkeypatch.setattr(_sys, "argv", ["vault-search-mcp", "--vault", str(vault)])
+
+    stop_calls: list[int] = []
+
+    class _FakeWatcher:
+        def __init__(self, *_a: Any, **_kw: Any) -> None:
+            pass
+
+        def start(self) -> bool:
+            return True
+
+        def stop(self) -> None:
+            stop_calls.append(1)
+
+    monkeypatch.setattr(server_mod, "VaultWatcher", _FakeWatcher)
+
+    def _raise(*_a: Any, **_kw: Any) -> None:
+        raise RuntimeError("mcp dead")
+
+    monkeypatch.setattr(server_mod.mcp, "run", _raise)
+
+    with pytest.raises(RuntimeError, match="mcp dead"):
+        server_mod.main()
+
+    assert stop_calls == [1]
 
 
 def test_mcp_tool_vault_stats(vault_index: VaultIndex) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -249,16 +248,16 @@ def test_mcp_tool_vault_reindex_includes_watcher_failures(
     """_watcher に failure 履歴があれば vault_reindex の戻りに反映される (#39)."""
     watcher = VaultWatcher(vault_index)
     # 内部状態を直接設定 (実 flush を待つと flaky になるため)
+    # last_watcher_error_at は str (isoformat "+00:00" 形式) で格納される
     with watcher._lock:
         watcher._watcher_failure_count = 2
-        watcher._last_watcher_error_at = datetime(2026, 4, 19, 12, 0, 0, tzinfo=timezone.utc)
+        watcher._last_watcher_error_at = "2026-04-19T12:00:00+00:00"
     monkeypatch.setattr(server_mod, "_watcher", watcher)
 
     fn = _fn(server_mod.vault_reindex)
     res = fn(False)
     assert res["watcher_failure_count"] == 2
-    # JSON 表現は Pydantic のデフォルト datetime 直列化 (ISO 8601)
-    assert res["last_watcher_error_at"] == "2026-04-19T12:00:00Z"
+    assert res["last_watcher_error_at"] == "2026-04-19T12:00:00+00:00"
 
 
 def test_main_stops_watcher_on_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -289,6 +288,38 @@ def test_main_stops_watcher_on_exception(tmp_path: Path, monkeypatch: pytest.Mon
     monkeypatch.setattr(server_mod.mcp, "run", _raise)
 
     with pytest.raises(RuntimeError, match="mcp dead"):
+        server_mod.main()
+
+    assert stop_calls == [1]
+
+
+def test_main_stops_watcher_when_start_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_watcher.start() が例外を起こしても stop() が呼ばれる (start() が try 内にあるため) (#39)."""
+    import sys as _sys
+
+    vault = tmp_path / "main_vault2"
+    vault.mkdir()
+    monkeypatch.setattr(_sys, "argv", ["vault-search-mcp", "--vault", str(vault)])
+
+    stop_calls: list[int] = []
+
+    class _FakeWatcher:
+        def __init__(self, *_a: Any, **_kw: Any) -> None:
+            pass
+
+        def start(self) -> bool:
+            raise OSError("inotify limit reached")
+
+        def stop(self) -> None:
+            stop_calls.append(1)
+
+    monkeypatch.setattr(server_mod, "VaultWatcher", _FakeWatcher)
+    # mcp.run は呼ばれないはずだが念のため
+    monkeypatch.setattr(server_mod.mcp, "run", lambda *_a, **_kw: None)
+
+    with pytest.raises(OSError, match="inotify limit"):
         server_mod.main()
 
     assert stop_calls == [1]

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import time
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -266,3 +267,57 @@ def test_watcher_logs_indexed_at_info_on_flush(
 
     info_msgs = [r.message for r in caplog.records if r.levelno == logging.INFO]
     assert any("indexed:" in m for m in info_msgs), info_msgs
+
+
+# ---------------------------------------------------------------------------
+# Failure observability (#39) — agent が watcher の健全性を把握できるよう
+# ``VaultWatcher`` が failure_count と last_error_at を公開する。
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_failure_stats_initial(vault: Path, index: VaultIndex) -> None:
+    """新規 VaultWatcher は failure_count=0, last_error_at=None (#39)."""
+    watcher = VaultWatcher(index)
+    stats = watcher.failure_stats()
+    assert stats["watcher_failure_count"] == 0
+    assert stats["last_watcher_error_at"] is None
+
+
+def test_watcher_flush_records_failure(
+    vault: Path, index: VaultIndex, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_flush`` 中に update_single が raise すると failure_count インクリメント (#39)."""
+    watcher = VaultWatcher(index)
+
+    def _raise(_rel_path: str) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(index, "update_single", _raise)
+    watcher._pending["note.md"] = time.monotonic()
+
+    before = datetime.now(timezone.utc)
+    watcher._flush()
+    after = datetime.now(timezone.utc)
+
+    stats = watcher.failure_stats()
+    assert stats["watcher_failure_count"] == 1
+    ts = stats["last_watcher_error_at"]
+    assert ts is not None
+    assert before <= ts <= after
+
+
+def test_watcher_flush_accumulates_multiple_failures(
+    vault: Path, index: VaultIndex, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """複数ファイルの失敗が独立にカウントされる (#39)."""
+    watcher = VaultWatcher(index)
+
+    def _raise(_rel_path: str) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(index, "update_single", _raise)
+    watcher._pending = {"a.md": time.monotonic(), "b.md": time.monotonic()}
+    watcher._flush()
+
+    stats = watcher.failure_stats()
+    assert stats["watcher_failure_count"] == 2

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -323,3 +323,22 @@ def test_watcher_flush_accumulates_multiple_failures(
 
     stats = watcher.failure_stats()
     assert stats["watcher_failure_count"] == 2
+
+
+def test_watcher_stop_safe_when_observer_not_started(vault: Path, index: VaultIndex) -> None:
+    """``stop()`` が ``observer.start()`` 未呼び出し状態でも安全に完了する (#39).
+
+    ``start()`` 内で ``self._observer = Observer()`` を設定した直後に
+    ``observer.start()`` が失敗した場合 (inotify 上限・権限エラー等)、
+    ``_observer`` は設定済みだがスレッドは未起動。
+    このとき ``stop()`` → ``observer.join()`` は
+    ``RuntimeError: cannot join thread before it is started`` を投げる。
+    """
+    from watchdog.observers import Observer
+
+    watcher = VaultWatcher(index)
+    # observer を設定するが start() は呼ばない (start() が途中失敗する状況を模倣)
+    watcher._observer = Observer()
+    watcher._observer.daemon = True
+    # stop() が RuntimeError を投げないこと
+    watcher.stop()  # must not raise

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -301,8 +301,10 @@ def test_watcher_flush_records_failure(
 
     stats = watcher.failure_stats()
     assert stats["watcher_failure_count"] == 1
-    ts = stats["last_watcher_error_at"]
-    assert ts is not None
+    ts_str = stats["last_watcher_error_at"]
+    assert ts_str is not None
+    # str (isoformat "+00:00") を parse して時刻境界を確認
+    ts = datetime.fromisoformat(ts_str)
     assert before <= ts <= after
 
 


### PR DESCRIPTION
## Summary

Issue #39 の確定スコープ (2026-04-19 設計セッションコメント) を実装:

- `ReindexStats` (stats.py) に `watcher_failure_count: int` / `last_watcher_error_at: datetime | None` を追加
- `VaultWatcher._flush` の例外時にカウント + UTC timestamp を記録、`failure_stats()` で公開 (lock 下 atomic)
- `vault_reindex` が `_watcher.failure_stats()` を merge して返す (`_watcher=None` の場合は Pydantic デフォルト)
- `main()` で `mcp.run()` を try/finally で包み `_watcher.stop()` を保証 (shutdown leak 防止)
- `VaultWatcher.stop()` を `observer.is_alive()` ガードで idempotent 化 (start 失敗中の二重停止で `RuntimeError` を出さない)

スコープ外として明示された `schema://tools` の `errors` セクション (PR 1b へ移動) は本 PR に含めない。

## Commits (rebase 後)

1. `Red:` watcher failure observability / main try-finally — 失敗テスト 6 件追加
2. `Green:` watcher failure observability / main try-finally — 最小実装でテスト全通
3. `Refactor:` review-loop 指摘 A-1/A-2 を解消
4. `Red:` `stop()` raises `RuntimeError` if `observer.start()` failed mid-way
5. `Green:` guard `observer.join()` with `is_alive()` check in `stop()`

main rebase で merge 済 PR との衝突 (schemas.py / stats.py の `ReindexStats` 配置変更) を解消し force-push 済。

## Test plan

- [x] `.venv/bin/pytest -q` → 全件 pass
- [x] `.venv/bin/ruff check src/ tests/` → clean
- [x] `.venv/bin/ruff format src/ tests/` → 変更なし
- [x] CI: lint + test (3.10 / 3.12 / 3.13) 全て green
- [x] `test_mcp_wrapping` で vault_reindex の outputSchema drift 検知 pass
- [x] `test_tool_annotations` で annotations regression pass

https://claude.ai/code/session_01FyaVNRfbRyuWS5iDij7bkq