### PR TITLE
Refactor: stats.py 分離 (ReindexStats / VaultStats, PR 1a, #38 基盤)

### DIFF
--- a/src/vault_search/mcp_contract.py
+++ b/src/vault_search/mcp_contract.py
@@ -24,11 +24,10 @@ from .schemas import (
     FolderCount,
     NoteDetail,
     RecentNote,
-    ReindexStats,
     SearchResponse,
     TagCount,
-    VaultStats,
 )
+from .stats import ReindexStats, VaultStats
 from .validation import IDENTIFIER_JSON_PATTERN, IDENTIFIER_MAX_LEN, LIMIT_MAX
 
 __all__ = [

--- a/src/vault_search/schemas.py
+++ b/src/vault_search/schemas.py
@@ -146,31 +146,3 @@ class FolderCount(BaseModel):
         ),
     )
     count: int = Field(description="このフォルダ直下のノート数")
-
-
-# ---------------------------------------------------------------------------
-# Maintenance
-# ---------------------------------------------------------------------------
-
-
-class ReindexStats(BaseModel):
-    """`vault_reindex` ツールのレスポンス: 処理件数の内訳."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    added: int = Field(description="新規追加されたノート数")
-    updated: int = Field(description="更新されたノート数 (mtime 進行)")
-    deleted: int = Field(description="削除されたノート数 (ファイル消失)")
-    skipped: int = Field(description="mtime 変化なしでスキップされたノート数")
-    errors: int = Field(description="パース失敗したノート数")
-
-
-class VaultStats(BaseModel):
-    """`vault_stats` ツールのレスポンス: インデックス全体の統計."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    total_notes: int = Field(description="インデックス済みノート総数")
-    db_size_bytes: int = Field(description="SQLite DB ファイルのサイズ (バイト)")
-    db_size_mb: float = Field(description="SQLite DB ファイルのサイズ (MB, 小数2桁)")
-    vault_root: str = Field(description="Vault ルートの絶対パス")

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -37,12 +37,11 @@ from .schemas import (
     FolderCount,
     NoteDetail,
     RecentNote,
-    ReindexStats,
     SearchHit,
     SearchResponse,
     TagCount,
-    VaultStats,
 )
+from .stats import ReindexStats, VaultStats
 from .validation import normalize_folder, validate_pagination
 from .watcher import VaultWatcher
 

--- a/src/vault_search/stats.py
+++ b/src/vault_search/stats.py
@@ -1,0 +1,32 @@
+"""インデックスの集計状態 / スキーマメタを表す型を集約する.
+
+検索結果や個別ノートを表す型は schemas.py に残る。
+将来的に境界が揺らぐ可能性あり (PR 1b/1c で再評価)。
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ReindexStats(BaseModel):
+    """`vault_reindex` ツールのレスポンス: 処理件数の内訳."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    added: int = Field(description="新規追加されたノート数")
+    updated: int = Field(description="更新されたノート数 (mtime 進行)")
+    deleted: int = Field(description="削除されたノート数 (ファイル消失)")
+    skipped: int = Field(description="mtime 変化なしでスキップされたノート数")
+    errors: int = Field(description="パース失敗したノート数")
+
+
+class VaultStats(BaseModel):
+    """`vault_stats` ツールのレスポンス: インデックス全体の統計."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    total_notes: int = Field(description="インデックス済みノート総数")
+    db_size_bytes: int = Field(description="SQLite DB ファイルのサイズ (バイト)")
+    db_size_mb: float = Field(description="SQLite DB ファイルのサイズ (MB, 小数2桁)")
+    vault_root: str = Field(description="Vault ルートの絶対パス")


### PR DESCRIPTION
## Summary

- Agent DX cluster (β 5-PR: 1a / 1b / 1c / 2 / 3) の基盤 Refactor
- `src/vault_search/stats.py` を新設し、`ReindexStats` / `VaultStats` を
  `schemas.py` から移動
- observable change ゼロ (MCP wire 仕様・既存テスト全通過)
- 後続 PR (#38 / #20 / #80 / #39) が `schemas.py` を touch せずに
  `stats.py` を拡張できる基盤

## Scope (Opus 評価後の縮小版)

Opus 計画評価で以下を除外:

- **`FrontmatterKeyInfo` 事前定義は含めない** — PR 1c で全フィールド
  まとめて追加。PR 1a 時点で参照ゼロの dead code / half-definition
  を回避
- **`tests/test_stats.py` 追加しない** — module 構造を tests に pin する
  anti-pattern 回避。regression guard は既存 test_mcp_wrapping /
  test_server / test_tool_annotations で張られている

## 変更ファイル (4 files, +34 / -32)

- `src/vault_search/stats.py` — 新規作成 (ReindexStats + VaultStats)
- `src/vault_search/schemas.py` — 2 クラス + `# Maintenance` section
  header 削除
- `src/vault_search/mcp_contract.py` — import 元変更 (schemas → stats)
- `src/vault_search/server.py` — import 元変更 (schemas → stats)

## 境界の ambiguity (stats.py docstring に明記)

「集計状態 / スキーマメタ」と「検索結果 / 個別ノート」で境界を切ったが、
PR 1b (#38) の ErrorSpec 系や PR 1c (#20) の FrontmatterKeyInfo 追加時に
境界が揺らぐ可能性あり。docstring に「PR 1b/1c で再評価」を明記。

## Test plan

- [x] `.venv/bin/pytest` — 493 passed
- [x] `.venv/bin/ruff check` / `ruff format --check` クリーン
- [x] `git diff --stat` で変更が 4 ファイルのみ
- [x] 1 commit (e492a91)

## 関連

- Agent DX cluster: #38 (1b) / #20 (1c) / #80 (2) / #39 (3)
- TDD workflow: Refactor 単一 commit、observable change zero