### PR TITLE
feat: frontmatter_keys を FrontmatterKeyInfo 構造化 (PR 1c, #20)

### DIFF
--- a/src/vault_search/filter.py
+++ b/src/vault_search/filter.py
@@ -118,6 +118,7 @@ class MetadataCondition:
 def parse_metadata_filter(
     raw: dict[str, Any] | None,
     known_keys: Sequence[str] | None = None,
+    object_keys: Sequence[str] = (),
 ) -> list[MetadataCondition]:
     """``metadata_filter`` dict を :class:`MetadataCondition` リストへ変換する.
 
@@ -155,7 +156,12 @@ def parse_metadata_filter(
     # building) lives in ``validate_known_keys`` so filter.py and validation.py
     # share one code path (#140/#141).
     if known_keys is not None:
-        validate_known_keys(list(raw.keys()), known_keys, kind="frontmatter key")
+        validate_known_keys(
+            list(raw.keys()),
+            known_keys,
+            kind="frontmatter key",
+            object_keys=object_keys,
+        )
 
     # Third pass: parse individual entries. op / value 検証は fail-first。
     conditions: list[MetadataCondition] = []

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -35,7 +35,7 @@ from .validation import normalize_folder
 logger = logging.getLogger(__name__)
 
 
-_NUMBER_RE = re.compile(r"^-?\d+(\.\d+)?$")
+_NUMBER_RE = re.compile(r"^-?\d+(\.\d+)?([eE][+-]?\d+)?$")
 
 
 def _infer_value_type(value: Any) -> str:
@@ -465,8 +465,13 @@ class VaultIndex:
         # metadata_filter が指定された場合のみ known_keys を取得する
         # (filter なしでは不要なので呼ばない)。list_frontmatter_keys() は
         # 書込み経路で invalidate される in-memory cache 付き (#118)。
+        # value_type='object' の親 dict キーは filter 不可 (SQL 上は dict が返り
+        # 文字列比較で常に false → silent 0 件) なので known_keys から除外し、
+        # agent が誤って親キーで filter すると UNKNOWN_FRONTMATTER_KEY で通知する。
         known_keys: list[str] | None = (
-            [info.key for info in self.list_frontmatter_keys()] if metadata_filter else None
+            [info.key for info in self.list_frontmatter_keys() if info.value_type != "object"]
+            if metadata_filter
+            else None
         )
         conditions = parse_metadata_filter(metadata_filter, known_keys=known_keys)
 

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -408,9 +408,15 @@ class VaultIndex:
             return True
 
     def _invalidate_caches(self) -> None:
-        """書込み経路で tiered cache と frontmatter_keys cache を同時に落とす."""
+        """書込み経路で tiered cache と frontmatter_keys cache を同時に落とす.
+
+        ``_frontmatter_keys_cache`` の書込みは ``self._lock`` 下で行い、
+        ``list_frontmatter_keys()`` の snapshot pattern と対称化する
+        (Round 2 E1)。``_cache.invalidate()`` は自身で thread-safe。
+        """
         self._cache.invalidate()
-        self._frontmatter_keys_cache = None
+        with self._lock:
+            self._frontmatter_keys_cache = None
 
     # ------------------------------------------------------------------
     # Search — 3段パイプライン
@@ -791,15 +797,17 @@ class VaultIndex:
         初回呼出時に DB をスキャンしてキャッシュし、以降は書込み経路で
         invalidate されるまでキャッシュを返す (Issue #118 / #10)。
 
-        double-checked locking で並行初回呼出時の重複 DB scan を回避する
-        (本 PR で query コストが type 推論 + sample 集計に増大したため、
-        Reviewer A4 の指摘を踏まえ明示保護)。
+        並行処理対策 (A4 + Round 2 E1):
+        - double-checked locking で初回 DB scan の重複実行を防ぐ
+        - lock 下で snapshot 参照を取得してから return することで、read 後に
+          ``_invalidate_caches()`` が ``_frontmatter_keys_cache = None`` に
+          書き込んでも ``list(None)`` にならない
         """
-        if self._frontmatter_keys_cache is None:
-            with self._lock:
-                if self._frontmatter_keys_cache is None:
-                    self._frontmatter_keys_cache = self._query_frontmatter_keys_from_db()
-        return list(self._frontmatter_keys_cache)
+        with self._lock:
+            if self._frontmatter_keys_cache is None:
+                self._frontmatter_keys_cache = self._query_frontmatter_keys_from_db()
+            snapshot = self._frontmatter_keys_cache
+        return list(snapshot)
 
     def _query_frontmatter_keys_from_db(self) -> list[FrontmatterKeyInfo]:
         """Frontmatter のキー別メタ情報 (型推論 + sample_values + note_count) を DB から取得する."""

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import sqlite3
 import threading
+from collections import Counter
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -27,6 +29,7 @@ from .filter import (
     parse_metadata_filter,
 )
 from .parser import ParsedNote, parse_note
+from .stats import FrontmatterKeyInfo
 from .validation import normalize_folder
 
 logger = logging.getLogger(__name__)
@@ -45,6 +48,75 @@ def _collect_nested_keys(obj: Any, prefix: str, out: set[str]) -> None:
         out.add(key)
         if isinstance(v, dict):
             _collect_nested_keys(v, key, out)
+
+
+_NUMBER_RE = re.compile(r"^-?\d+(\.\d+)?$")
+
+
+def _infer_value_type(value: Any) -> str:
+    """value 1 つから value_type を推論する (None は呼び出し側で除外済み前提)."""
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, str) and value in ("true", "false"):
+        return "boolean"
+    if isinstance(value, str) and _NUMBER_RE.fullmatch(value):
+        return "number"
+    return "string"
+
+
+def _collect_key_info(
+    obj: Any,
+    prefix: str,
+    value_counters: dict[str, Counter[str]],
+    type_sets: dict[str, set[str]],
+    note_counts: dict[str, int],
+) -> None:
+    """frontmatter dict を再帰 walk し、各 key の value_counter / type_set / note_count を更新する.
+
+    - 親 dict キー (e.g. 'meta') も含める (value_type='object'、#136 既存契約)
+    - ネスト dict は dotted key として葉ノードを別に集計
+    - None は note_count から除外
+    - 空文字は sample_values (counter) からは除外するが note_count には含める
+    - list 要素の dict は走査しない (SQL の $.tags.x パス不成立のため)
+    """
+    if not isinstance(obj, dict):
+        return
+    for k, v in obj.items():
+        key = f"{prefix}.{k}" if prefix else k
+
+        # None は全集計から除外
+        if v is None:
+            continue
+
+        # note_count は常に +1 (空文字も含む)
+        note_counts[key] = note_counts.get(key, 0) + 1
+
+        # value_type 推論
+        vtype = _infer_value_type(v)
+        type_sets.setdefault(key, set()).add(vtype)
+
+        # sample_values への追加
+        # 親 dict (object) は sample_values を持たない → Counter エントリを作らないが
+        # value_counters に key が登録される必要はある (result イテレート用)
+        counter = value_counters.setdefault(key, Counter())
+
+        if isinstance(v, dict):
+            # 親キーとして登録後、子を再帰 walk
+            _collect_key_info(v, key, value_counters, type_sets, note_counts)
+        elif isinstance(v, list):
+            # 配列全体の JSON 文字列表現を sample に入れる (要素別展開はしない)
+            sample_repr = json.dumps(v, ensure_ascii=False)
+            counter[sample_repr] += 1
+        elif isinstance(v, str):
+            # 空文字 / whitespace-only は sample から除外 (note_count は +1 済)
+            if v.strip():
+                counter[v] += 1
+        else:
+            # _normalize_fm により scalar は str/list/dict/None に収束しているはず
+            # 念のため str 化
+            counter[str(v)] += 1
 
 
 # ---------------------------------------------------------------------------
@@ -126,7 +198,7 @@ class VaultIndex:
 
         self._cache = TieredCache()
         self._lock = threading.Lock()
-        self._frontmatter_keys_cache: list[str] | None = None
+        self._frontmatter_keys_cache: list[FrontmatterKeyInfo] | None = None
         self._init_db()
 
     def _init_db(self) -> None:
@@ -408,7 +480,9 @@ class VaultIndex:
         # metadata_filter が指定された場合のみ known_keys を取得する
         # (filter なしでは不要なので呼ばない)。list_frontmatter_keys() は
         # 書込み経路で invalidate される in-memory cache 付き (#118)。
-        known_keys = self.list_frontmatter_keys() if metadata_filter else None
+        known_keys: list[str] | None = (
+            [info.key for info in self.list_frontmatter_keys()] if metadata_filter else None
+        )
         conditions = parse_metadata_filter(metadata_filter, known_keys=known_keys)
 
         filters: dict[str, Any] | None = None
@@ -709,13 +783,16 @@ class VaultIndex:
             ).fetchall()
             return [{"folder": r["folder"], "count": r["count"]} for r in rows]
 
-    def list_frontmatter_keys(self) -> list[str]:
-        """Vault 内 frontmatter のキーをソート済みで返す.
+    def list_frontmatter_keys(self) -> list[FrontmatterKeyInfo]:
+        """Vault 内 frontmatter のキー別メタ情報をソート済みで返す (Issue #20).
 
         トップレベルキーに加え、ネスト dict 値は dotted key (``meta.author``)
         としても含まれる (Issue #136)。validate_identifier / SQL が dotted 形式を
         受理するので、known_keys 側も一貫して dotted を公開し
         ``metadata_filter={"meta.author": ...}`` の false positive UNKNOWN を防ぐ。
+
+        各要素は :class:`FrontmatterKeyInfo` で value_type / sample_values /
+        note_count を持つ。
 
         初回呼出時に DB をスキャンしてキャッシュし、以降は書込み経路で
         invalidate されるまでキャッシュを返す (Issue #118 / #10)。
@@ -724,18 +801,48 @@ class VaultIndex:
             self._frontmatter_keys_cache = self._query_frontmatter_keys_from_db()
         return list(self._frontmatter_keys_cache)
 
-    def _query_frontmatter_keys_from_db(self) -> list[str]:
-        """Frontmatter のキー集合 (トップレベル + nested dotted) を DB から取得する."""
+    def _query_frontmatter_keys_from_db(self) -> list[FrontmatterKeyInfo]:
+        """Frontmatter のキー別メタ情報 (型推論 + sample_values + note_count) を DB から取得する."""
+        value_counters: dict[str, Counter[str]] = {}
+        type_sets: dict[str, set[str]] = {}
+        note_counts: dict[str, int] = {}
+
         with self.connection() as conn:
             rows = conn.execute(
                 "SELECT frontmatter FROM notes WHERE json_valid(frontmatter)"
             ).fetchall()
-        keys: set[str] = set()
+
         for row in rows:
             fm = json.loads(row["frontmatter"])
-            if isinstance(fm, dict):
-                _collect_nested_keys(fm, "", keys)
-        return sorted(keys)
+            if not isinstance(fm, dict):
+                continue
+            _collect_key_info(fm, "", value_counters, type_sets, note_counts)
+
+        result: list[FrontmatterKeyInfo] = []
+        for key in sorted(value_counters.keys()):
+            types = type_sets[key]
+            if len(types) == 1:
+                vtype = next(iter(types))
+            else:
+                vtype = "mixed"
+
+            # top-5 頻度降順、同頻度は辞書順
+            counter = value_counters[key]
+            samples_sorted = sorted(
+                counter.items(),
+                key=lambda kv: (-kv[1], kv[0]),
+            )[:5]
+            samples = [v for v, _ in samples_sorted]
+
+            result.append(
+                FrontmatterKeyInfo(
+                    key=key,
+                    value_type=vtype,
+                    sample_values=samples,
+                    note_count=note_counts[key],
+                )
+            )
+        return result
 
     def stats(self) -> dict[str, Any]:
         """インデックスの統計情報."""

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -75,33 +75,32 @@ def _collect_key_info(
         if v is None:
             continue
 
-        # note_count は常に +1 (空文字も含む)
+        # note_count は常に +1 (空文字も含む)。
+        # note_counts.keys() を「この走査で観測された key 全集合」の正準 source of
+        # truth として扱い、呼び出し側はこれを iterate する (Reviewer D6)。
         note_counts[key] = note_counts.get(key, 0) + 1
 
         # value_type 推論
         vtype = _infer_value_type(v)
         type_sets.setdefault(key, set()).add(vtype)
 
-        # sample_values への追加
-        # 親 dict (object) は sample_values を持たない → Counter エントリを作らないが
-        # value_counters に key が登録される必要はある (result イテレート用)
-        counter = value_counters.setdefault(key, Counter())
-
+        # sample_values の追加 — 値を持つ経路のみ Counter エントリを作る。
+        # 親 dict (object) は sample を持たないので value_counters に登録しない。
         if isinstance(v, dict):
-            # 親キーとして登録後、子を再帰 walk
+            # 親キーのサンプルは空。子を再帰 walk する。
             _collect_key_info(v, key, value_counters, type_sets, note_counts)
         elif isinstance(v, list):
-            # 配列全体の JSON 文字列表現を sample に入れる (要素別展開はしない)
+            # 配列全体の JSON 文字列表現を sample に入れる (要素別展開はしない)。
             sample_repr = json.dumps(v, ensure_ascii=False)
-            counter[sample_repr] += 1
+            value_counters.setdefault(key, Counter())[sample_repr] += 1
         elif isinstance(v, str):
-            # 空文字 / whitespace-only は sample から除外 (note_count は +1 済)
+            # 空文字 / whitespace-only は sample から除外 (note_count は +1 済)。
             if v.strip():
-                counter[v] += 1
+                value_counters.setdefault(key, Counter())[v] += 1
         else:
-            # _normalize_fm により scalar は str/list/dict/None に収束しているはず
-            # 念のため str 化
-            counter[str(v)] += 1
+            # _normalize_fm により scalar は str/list/dict/None に収束しているはず。
+            # 念のため str 化。
+            value_counters.setdefault(key, Counter())[str(v)] += 1
 
 
 # ---------------------------------------------------------------------------
@@ -786,9 +785,15 @@ class VaultIndex:
 
         初回呼出時に DB をスキャンしてキャッシュし、以降は書込み経路で
         invalidate されるまでキャッシュを返す (Issue #118 / #10)。
+
+        double-checked locking で並行初回呼出時の重複 DB scan を回避する
+        (本 PR で query コストが type 推論 + sample 集計に増大したため、
+        Reviewer A4 の指摘を踏まえ明示保護)。
         """
         if self._frontmatter_keys_cache is None:
-            self._frontmatter_keys_cache = self._query_frontmatter_keys_from_db()
+            with self._lock:
+                if self._frontmatter_keys_cache is None:
+                    self._frontmatter_keys_cache = self._query_frontmatter_keys_from_db()
         return list(self._frontmatter_keys_cache)
 
     def _query_frontmatter_keys_from_db(self) -> list[FrontmatterKeyInfo]:
@@ -808,21 +813,27 @@ class VaultIndex:
                 continue
             _collect_key_info(fm, "", value_counters, type_sets, note_counts)
 
+        # note_counts を「観測された key 全集合」の正準とする (Reviewer D6)。
+        # value_counters は parent dict (object) key にはエントリを持たない。
         result: list[FrontmatterKeyInfo] = []
-        for key in sorted(value_counters.keys()):
+        for key in sorted(note_counts.keys()):
             types = type_sets[key]
             if len(types) == 1:
                 vtype = next(iter(types))
             else:
                 vtype = "mixed"
 
-            # top-5 頻度降順、同頻度は辞書順
-            counter = value_counters[key]
-            samples_sorted = sorted(
-                counter.items(),
-                key=lambda kv: (-kv[1], kv[0]),
-            )[:5]
-            samples = [v for v, _ in samples_sorted]
+            # top-5 頻度降順、同頻度は辞書順。
+            # parent dict (object) は value_counters に存在しないので samples=[]。
+            counter = value_counters.get(key)
+            if counter is None:
+                samples: list[str] = []
+            else:
+                samples_sorted = sorted(
+                    counter.items(),
+                    key=lambda kv: (-kv[1], kv[0]),
+                )[:5]
+                samples = [v for v, _ in samples_sorted]
 
             result.append(
                 FrontmatterKeyInfo(

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -35,21 +35,6 @@ from .validation import normalize_folder
 logger = logging.getLogger(__name__)
 
 
-def _collect_nested_keys(obj: Any, prefix: str, out: set[str]) -> None:
-    """frontmatter dict を再帰 walk して dotted key を ``out`` に収集する.
-
-    array 要素の dict (``tags: [{a: 1}]``) は走査しない — SQL の
-    ``$.tags.a`` パスは不成立で意味がないため、known_keys に含めない。
-    """
-    if not isinstance(obj, dict):
-        return
-    for k, v in obj.items():
-        key = f"{prefix}.{k}" if prefix else k
-        out.add(key)
-        if isinstance(v, dict):
-            _collect_nested_keys(v, key, out)
-
-
 _NUMBER_RE = re.compile(r"^-?\d+(\.\d+)?$")
 
 

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -467,12 +467,17 @@ class VaultIndex:
         # value_type='object' の親 dict キーは filter 不可 (SQL 上は dict が返り
         # 文字列比較で常に false → silent 0 件) なので known_keys から除外し、
         # agent が誤って親キーで filter すると UNKNOWN_FRONTMATTER_KEY で通知する。
-        known_keys: list[str] | None = (
-            [info.key for info in self.list_frontmatter_keys() if info.value_type != "object"]
-            if metadata_filter
-            else None
+        # object_keys を別途渡すことで、UNKNOWN エラーメッセージに
+        # 「親 dict なので dotted leaf key を使え」の hint を付与する (Round 2 E2)。
+        known_keys: list[str] | None = None
+        object_keys: list[str] = []
+        if metadata_filter:
+            _key_infos = self.list_frontmatter_keys()
+            known_keys = [info.key for info in _key_infos if info.value_type != "object"]
+            object_keys = [info.key for info in _key_infos if info.value_type == "object"]
+        conditions = parse_metadata_filter(
+            metadata_filter, known_keys=known_keys, object_keys=object_keys
         )
-        conditions = parse_metadata_filter(metadata_filter, known_keys=known_keys)
 
         filters: dict[str, Any] | None = None
         if tags or folder or metadata_filter:

--- a/src/vault_search/mcp_contract.py
+++ b/src/vault_search/mcp_contract.py
@@ -27,7 +27,7 @@ from .schemas import (
     SearchResponse,
     TagCount,
 )
-from .stats import ReindexStats, VaultStats
+from .stats import FrontmatterKeyInfo, ReindexStats, VaultStats
 from .validation import IDENTIFIER_JSON_PATTERN, IDENTIFIER_MAX_LEN, LIMIT_MAX
 
 __all__ = [
@@ -329,15 +329,17 @@ TOOL_ENTRIES: dict[str, dict[str, Any]] = {
 }
 
 
-def build_schema_payload(frontmatter_keys: Iterable[str]) -> dict[str, Any]:
-    """AI エージェント向けに全ツールの入出力スキーマと frontmatter キー一覧を集約.
+def build_schema_payload(
+    frontmatter_keys: Iterable[FrontmatterKeyInfo],
+) -> dict[str, Any]:
+    """schema://tools resource payload の frontmatter_keys エンベロープ.
 
     呼び出し側は ``VaultIndex.list_frontmatter_keys()`` 相当の反復可能オブジェクトを
-    渡す。mcp_contract モジュールが indexer に依存しないよう引数化している。
+    そのまま渡す。
     """
     return {
         "tools": TOOL_ENTRIES,
-        "frontmatter_keys": list(frontmatter_keys),
+        "frontmatter_keys": [item.model_dump(mode="json") for item in frontmatter_keys],
     }
 
 

--- a/src/vault_search/stats.py
+++ b/src/vault_search/stats.py
@@ -6,7 +6,46 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field
+
+
+class FrontmatterKeyInfo(BaseModel):
+    """frontmatter キー 1 件のメタ情報 (Issue #20)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str = Field(
+        description=(
+            "frontmatter のキー名。ネスト dict は dotted key (例: 'meta.author') を含む。"
+            "トップレベルの親 dict キー (例: 'meta') も value_type='object' として公開される "
+            "(ただし metadata_filter では filter 不可 — 葉キーを使うこと)"
+        )
+    )
+    value_type: Literal["string", "number", "boolean", "array", "object", "mixed"] = Field(
+        description=(
+            "観測された値型。index 時に全スカラーが文字列に正規化されるため、"
+            "boolean / number はヒューリスティック推論 ('true'/'false' 完全一致で boolean、"
+            "数値 regex で number、それ以外の文字列は string)。"
+            "配列値は 'array' (要素型は問わない)。親 dict キーは 'object' "
+            "(filter 不可、葉 dotted key を使うこと)。"
+            "複数 note で型が混在する場合は 'mixed'。"
+            "日付/日時は 'string' に丸まる (正規化で型情報喪失、既知の limitation)"
+        )
+    )
+    sample_values: list[str] = Field(
+        default_factory=list,
+        description=(
+            "出現頻度上位最大 5 件のサンプル値 (降順、重複なし、同頻度は辞書順で安定)。"
+            '配列フィールドは配列全体の JSON 文字列表現 (例: \'["a", "b"]\')。'
+            "配列要素別の頻度集計は vault_tags (tags 相当) を使うこと。"
+            "空文字・空白のみの値は sample_values から除外するが note_count には含める "
+            "(この差分から『空が多い key』が判る)。"
+            "親 dict キー (value_type='object') は sample_values が空リスト"
+        ),
+    )
+    note_count: int = Field(description="このキーを持つ note 数 (YAML null / 欠落は除外)")
 
 
 class ReindexStats(BaseModel):

--- a/src/vault_search/stats.py
+++ b/src/vault_search/stats.py
@@ -20,25 +20,33 @@ class FrontmatterKeyInfo(BaseModel):
         description=(
             "frontmatter のキー名。ネスト dict は dotted key (例: 'meta.author') を含む。"
             "トップレベルの親 dict キー (例: 'meta') も value_type='object' として公開される "
-            "(ただし metadata_filter では filter 不可 — 葉キーを使うこと)"
+            "(ただし metadata_filter では not filterable — 葉 dotted key を使うこと。"
+            "親キー名を metadata_filter に渡すと UNKNOWN_FRONTMATTER_KEY が返る)"
         )
     )
     value_type: Literal["string", "number", "boolean", "array", "object", "mixed"] = Field(
         description=(
             "観測された値型。index 時に全スカラーが文字列に正規化されるため、"
             "boolean / number はヒューリスティック推論 ('true'/'false' 完全一致で boolean、"
-            "数値 regex で number、それ以外の文字列は string)。"
+            "数値 regex (指数表記含む) で number、それ以外の文字列は string)。"
             "配列値は 'array' (要素型は問わない)。親 dict キーは 'object' "
-            "(filter 不可、葉 dotted key を使うこと)。"
-            "複数 note で型が混在する場合は 'mixed'。"
-            "日付/日時は 'string' に丸まる (正規化で型情報喪失、既知の limitation)"
+            "(not filterable、葉 dotted key を使うこと)。"
+            "複数 note で型が混在する場合は 'mixed' — filter は可能で、値は常に文字列表現 "
+            "(例: metadata_filter={'level': '5'} で int 5 の note もマッチ)。"
+            "日付/日時は 'string' に丸まる (正規化で型情報喪失、既知の limitation)。"
+            "YAML で引用符付きの数値文字列 (例: code: '007') も 'number' に分類される"
+            " (heuristic の限界)"
         )
     )
     sample_values: list[str] = Field(
         default_factory=list,
         description=(
             "出現頻度上位最大 5 件のサンプル値 (降順、重複なし、同頻度は辞書順で安定)。"
+            "これらは正規化済みの文字列表現で、そのまま metadata_filter の "
+            "eq / ne / in 値として使える (例: date は isoformat、int 5 は '5' として格納)。"
             '配列フィールドは配列全体の JSON 文字列表現 (例: \'["a", "b"]\')。'
+            "この文字列をそのまま eq に渡すと配列全体一致の filter になるが通常は意図しない — "
+            "array 要素で filter したい場合は要素値 (例: 'a') を渡すこと。"
             "配列要素別の頻度集計は vault_tags (tags 相当) を使うこと。"
             "空文字・空白のみの値は sample_values から除外するが note_count には含める "
             "(この差分から『空が多い key』が判る)。"

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -220,16 +220,22 @@ def format_unknown_keys_message(
     allowed_sorted = sorted(known_keys)
     object_keys_set = set(object_keys)
     # 各 unknown のうち object key にマッチするものだけをヒント対象にする。
+    # 単数 / 複数で plural 文法を切り分ける (Round 3)。
     unknown_object_keys = sorted(name for name in unknowns if name in object_keys_set)
-    object_hint = (
-        (
-            f" Note: {', '.join(repr(k) for k in unknown_object_keys)} "
-            "is a parent dict (value_type='object') and not filterable; "
-            "use a dotted leaf key (e.g. 'meta.author')."
+    if not unknown_object_keys:
+        object_hint = ""
+    elif len(unknown_object_keys) == 1:
+        object_hint = (
+            f" Note: {unknown_object_keys[0]!r} is a parent dict "
+            f"(value_type='object') and not filterable; "
+            f"use a dotted leaf key (e.g. 'meta.author')."
         )
-        if unknown_object_keys
-        else ""
-    )
+    else:
+        keys_str = ", ".join(repr(k) for k in unknown_object_keys)
+        object_hint = (
+            f" Note: {keys_str} are parent dicts (value_type='object') and "
+            f"not filterable; use dotted leaf keys (e.g. 'meta.author')."
+        )
 
     if len(unknowns) == 1:
         ((name, suggestions),) = unknowns.items()

--- a/src/vault_search/validation.py
+++ b/src/vault_search/validation.py
@@ -201,6 +201,7 @@ def format_unknown_keys_message(
     *,
     schema_ref: str = "schema://tools",
     registry_label: str = "frontmatter_keys list",
+    object_keys: Sequence[str] = (),
 ) -> str:
     """Build a unified unknown-key error message covering 1 and N unknown keys.
 
@@ -210,8 +211,25 @@ def format_unknown_keys_message(
     ``known_keys`` は順不同で渡してよい — 関数内で ``sorted()`` してから preview
     を組み立てる。callsite に「ソート済みで渡す」暗黙契約を強いず、drift
     リスクを低減する (Round 1 review D4)。
+
+    ``object_keys`` に含まれる unknown は「value_type='object' の親 dict キー」
+    として特別な hint 文言をメッセージに含める (#20 PR round 2): schema://tools
+    では公開されているが metadata_filter では使えないキーに対し、dotted leaf
+    key (e.g. ``meta.author``) への誘導を agent に通知する。
     """
     allowed_sorted = sorted(known_keys)
+    object_keys_set = set(object_keys)
+    # 各 unknown のうち object key にマッチするものだけをヒント対象にする。
+    unknown_object_keys = sorted(name for name in unknowns if name in object_keys_set)
+    object_hint = (
+        (
+            f" Note: {', '.join(repr(k) for k in unknown_object_keys)} "
+            "is a parent dict (value_type='object') and not filterable; "
+            "use a dotted leaf key (e.g. 'meta.author')."
+        )
+        if unknown_object_keys
+        else ""
+    )
 
     if len(unknowns) == 1:
         ((name, suggestions),) = unknowns.items()
@@ -219,7 +237,7 @@ def format_unknown_keys_message(
             return (
                 f"Unknown {kind} {name!r}; "
                 f"did you mean: {', '.join(suggestions)}? "
-                f"See {schema_ref} for the {registry_label}"
+                f"See {schema_ref} for the {registry_label}{object_hint}"
             )
         preview = ", ".join(allowed_sorted[:5])
         suffix = ", ..." if len(allowed_sorted) > 5 else ""
@@ -230,7 +248,7 @@ def format_unknown_keys_message(
         return (
             f"Unknown {kind} {name!r}; "
             f"valid keys include: {preview}{suffix}. "
-            f"See {schema_ref} for the full list"
+            f"See {schema_ref} for the full list{object_hint}"
         )
 
     # Multi-key path. Sort by unknown key name so the message is deterministic
@@ -248,9 +266,9 @@ def format_unknown_keys_message(
         return (
             f"Unknown {kind}s: {keys_str}. "
             f"Valid keys include: {preview}{suffix}. "
-            f"See {schema_ref} for the {registry_label}"
+            f"See {schema_ref} for the {registry_label}{object_hint}"
         )
-    return f"Unknown {kind}s: {keys_str}. See {schema_ref} for the {registry_label}"
+    return f"Unknown {kind}s: {keys_str}. See {schema_ref} for the {registry_label}{object_hint}"
 
 
 def validate_known_keys(
@@ -260,6 +278,7 @@ def validate_known_keys(
     kind: str,
     schema_ref: str = "schema://tools",
     registry_label: str = "frontmatter_keys list",
+    object_keys: Sequence[str] = (),
 ) -> None:
     """Validate that every name in ``names`` appears in ``known_keys`` (batch).
 
@@ -302,6 +321,7 @@ def validate_known_keys(
             known_keys,
             schema_ref=schema_ref,
             registry_label=registry_label,
+            object_keys=object_keys,
         ),
         error_code="UNKNOWN_FRONTMATTER_KEY",
         did_you_mean=all_candidates,

--- a/tests/test_frontmatter_key_info.py
+++ b/tests/test_frontmatter_key_info.py
@@ -296,7 +296,7 @@ def test_dotted_nested_key_returns_key_info(
         f"meta.author='foo' → value_type='string' (got {key_map['meta.author'].value_type!r})"
     )
 
-    # 親 dict キー "meta" は value_type='object' として保持される (#136 既存契約 + filter 不可を明示)
+    # 親 dict キー "meta" は value_type='object' として保持される (#136 既存契約 + filter 不可を明示)  # noqa: E501
     assert "meta" in key_map, (
         f"親 dict キー 'meta' も FrontmatterKeyInfo として含まれるべき (#136, keys={list(key_map)})"
     )

--- a/tests/test_frontmatter_key_info.py
+++ b/tests/test_frontmatter_key_info.py
@@ -433,3 +433,43 @@ def test_object_key_filter_error_message_has_dotted_leaf_hint(
         "エラーメッセージに dotted leaf / parent dict / object のいずれかの hint が"
         f" 必要 (got: {msg})"
     )
+
+
+def test_object_key_multi_error_message_uses_plural_grammar(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """複数の object 型キーを同時 filter 試行した時、plural 文法でメッセージが整う (Round 3).
+
+    Round 2 E2 の hint は単数前提で書かれており、複数 object key の同時 filter で
+    `'a', 'b' is a parent dict` という主語・動詞不一致 (plural subject + singular
+    verb) が生じる。agent の batch hallucination は MCP 運用で主要シナリオなので
+    文法整合性を pin する。
+    """
+    from vault_search.validation import ValidationError
+
+    _root, idx = vault_builder(
+        {
+            "nested.md": "---\nmeta:\n  author: foo\nconfig:\n  env: prod\n---\nbody\n",
+        }
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        idx.search(
+            query="",
+            folder=None,
+            metadata_filter={"meta": "x", "config": "y"},
+            limit=20,
+            offset=0,
+        )
+    msg = str(exc_info.value)
+    # 両 object key の言及
+    assert "meta" in msg and "config" in msg, (
+        f"エラーメッセージに両 object key が含まれる (got: {msg})"
+    )
+    # plural 形 ("are parent dicts" 等) で singular ("is a parent dict") を使わない
+    assert "are parent dicts" in msg.lower() or "parent dicts" in msg.lower(), (
+        f"複数 object key 時は plural 文法 ('are parent dicts' 等) であるべき (got: {msg})"
+    )
+    assert "is a parent dict" not in msg.lower(), (
+        f"複数 object key 時に singular 'is a parent dict' は誤文法 (got: {msg})"
+    )

--- a/tests/test_frontmatter_key_info.py
+++ b/tests/test_frontmatter_key_info.py
@@ -1,0 +1,324 @@
+"""Issue #20: FrontmatterKeyInfo モデルと list_frontmatter_keys 新仕様の失敗テスト.
+
+Red フェーズ: src/ は無変更。全テストが AssertionError / TypeError / ValidationError で
+明示的に失敗することを確認する (ImportError による collection error は回避済み)。
+
+テスト件数: 12 件
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+try:
+    from vault_search.stats import FrontmatterKeyInfo
+except ImportError:
+    FrontmatterKeyInfo = None  # Red では未定義、Green で実装される
+
+from vault_search.indexer import VaultIndex
+
+# ---------------------------------------------------------------------------
+# モデル系 (2 件)
+# ---------------------------------------------------------------------------
+
+
+def test_frontmatter_key_info_literal_and_forbid() -> None:
+    """FrontmatterKeyInfo の Literal 制約と extra=forbid を検証する."""
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+
+    # 正常構築
+    obj = FrontmatterKeyInfo(key="x", value_type="mixed", note_count=1)
+    assert obj.key == "x"
+    assert obj.value_type == "mixed"
+    assert obj.note_count == 1
+
+    # Literal 制約: "datetime" は不正値 → Pydantic ValidationError
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        FrontmatterKeyInfo(key="x", value_type="datetime", note_count=1)
+
+    # extra=forbid: 未知フィールドを渡すと ValidationError
+    with pytest.raises(pydantic.ValidationError):
+        FrontmatterKeyInfo(key="x", value_type="string", note_count=1, unknown_field="bad")
+
+
+def test_frontmatter_key_info_sample_values_default() -> None:
+    """sample_values は省略時に空リスト [] がデフォルト値になる."""
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+
+    obj = FrontmatterKeyInfo(key="y", value_type="string", note_count=2)
+    assert obj.sample_values == [], (
+        f"sample_values のデフォルトは [] であるべき (got {obj.sample_values!r})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 戻り型変更 / value_type 推論 (4 件)
+# ---------------------------------------------------------------------------
+
+
+def test_list_frontmatter_keys_returns_frontmatter_key_info(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """list_frontmatter_keys() が list[FrontmatterKeyInfo] を返す."""
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+
+    _root, idx = vault_builder({"note.md": "---\npriority: high\n---\nbody\n"})
+    result = idx.list_frontmatter_keys()
+
+    assert isinstance(result, list), f"戻り型は list であるべき (got {type(result)})"
+    assert len(result) > 0, "frontmatter を持つ note があるのに空リストが返った"
+
+    first = result[0]
+    assert isinstance(first, FrontmatterKeyInfo), (
+        f"各要素は FrontmatterKeyInfo であるべき (got {type(first)})"
+    )
+    assert isinstance(first.key, str), f".key は str であるべき (got {type(first.key)})"
+    assert first.note_count >= 1, f".note_count >= 1 であるべき (got {first.note_count})"
+
+
+def test_value_type_boolean_and_number_and_string(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """YAML bool/int/float は正規化後 value_type 推論で boolean/number に分類される."""
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+
+    _root, idx = vault_builder(
+        {
+            "bool_note.md": "---\ndone: true\n---\nbody\n",
+            "int_note.md": "---\npriority: 5\n---\nbody\n",
+            "float_note.md": "---\nscore: 4.5\n---\nbody\n",
+            "str_note.md": "---\nstatus: active\n---\nbody\n",
+        }
+    )
+    result = idx.list_frontmatter_keys()
+    key_map = {item.key: item for item in result}
+
+    assert "done" in key_map, "done キーが含まれるべき"
+    assert key_map["done"].value_type == "boolean", (
+        f"done: true → value_type='boolean' であるべき (got {key_map['done'].value_type!r})"
+    )
+
+    assert "priority" in key_map, "priority キーが含まれるべき"
+    assert key_map["priority"].value_type == "number", (
+        f"priority: 5 → value_type='number' であるべき (got {key_map['priority'].value_type!r})"
+    )
+
+    assert "score" in key_map, "score キーが含まれるべき"
+    assert key_map["score"].value_type == "number", (
+        f"score: 4.5 → value_type='number' であるべき (got {key_map['score'].value_type!r})"
+    )
+
+    assert "status" in key_map, "status キーが含まれるべき"
+    assert key_map["status"].value_type == "string", (
+        f"status: active → value_type='string' であるべき (got {key_map['status'].value_type!r})"
+    )
+
+
+def test_value_type_array(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """YAML list 値は value_type='array' に分類され、sample_values に JSON 文字列表現が入る."""
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+
+    _root, idx = vault_builder({"arr_note.md": "---\ntags:\n  - a\n  - b\n---\nbody\n"})
+    result = idx.list_frontmatter_keys()
+    key_map = {item.key: item for item in result}
+
+    assert "tags" in key_map, "tags キーが含まれるべき"
+    assert key_map["tags"].value_type == "array", (
+        f"tags: [a, b] → value_type='array' であるべき (got {key_map['tags'].value_type!r})"
+    )
+    # sample_values に配列全体の JSON 文字列表現が含まれる (例: '["a", "b"]')
+    assert len(key_map["tags"].sample_values) > 0, "sample_values に配列表現が含まれるべき"
+    # 少なくとも 1 件は JSON 配列文字列 ([ で始まる)
+    assert any(v.startswith("[") for v in key_map["tags"].sample_values), (
+        "sample_values に '[' で始まる JSON 配列文字列が含まれるべき"
+        f" (got {key_map['tags'].sample_values!r})"
+    )
+
+
+def test_value_type_mixed(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """同一キーに string と number が混在する場合 value_type='mixed' になる."""
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+
+    _root, idx = vault_builder(
+        {
+            "level_str.md": "---\nlevel: high\n---\nbody\n",
+            "level_num.md": "---\nlevel: 5\n---\nbody\n",
+        }
+    )
+    result = idx.list_frontmatter_keys()
+    key_map = {item.key: item for item in result}
+
+    assert "level" in key_map, "level キーが含まれるべき"
+    assert key_map["level"].value_type == "mixed", (
+        "level が string と number で混在 → value_type='mixed' であるべき"
+        f" (got {key_map['level'].value_type!r})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# sample_values / note_count 仕様 (3 件)
+# ---------------------------------------------------------------------------
+
+
+def test_sample_values_top5_frequency_and_tiebreak(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """sample_values は頻度降順 top-5、同頻度は辞書順で安定する."""
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+
+    # status の頻度: active=3, draft=2, wip=1, todo=1, done=1, cancel=1
+    _root, idx = vault_builder(
+        {
+            "a1.md": "---\nstatus: active\n---\nbody\n",
+            "a2.md": "---\nstatus: active\n---\nbody\n",
+            "a3.md": "---\nstatus: active\n---\nbody\n",
+            "d1.md": "---\nstatus: draft\n---\nbody\n",
+            "d2.md": "---\nstatus: draft\n---\nbody\n",
+            "w1.md": "---\nstatus: wip\n---\nbody\n",
+            "t1.md": "---\nstatus: todo\n---\nbody\n",
+            "do1.md": "---\nstatus: done\n---\nbody\n",
+            "c1.md": "---\nstatus: cancel\n---\nbody\n",
+        }
+    )
+    result = idx.list_frontmatter_keys()
+    key_map = {item.key: item for item in result}
+
+    assert "status" in key_map, "status キーが含まれるべき"
+    samples = key_map["status"].sample_values
+
+    # 最大 5 件
+    assert len(samples) <= 5, f"sample_values は最大 5 件 (got {len(samples)})"
+
+    # 1 位は "active" (頻度 3)
+    assert samples[0] == "active", f"頻度最大の 'active' が先頭であるべき (got {samples[0]!r})"
+
+    # 2 位は "draft" (頻度 2)
+    assert len(samples) >= 2, "sample_values に少なくとも 2 件あるべき"
+    assert samples[1] == "draft", f"2 位は 'draft' (頻度 2) であるべき (got {samples[1]!r})"
+
+    # 3 位以降は同頻度 (1) → 辞書順: cancel, done, todo, wip の先頭 2 件
+    if len(samples) >= 3:
+        assert samples[2] == "cancel", f"3 位は辞書順 'cancel' であるべき (got {samples[2]!r})"
+
+
+def test_sample_values_excludes_empty_but_note_count_includes(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """空文字は sample_values から除外されるが note_count には含まれる."""
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+
+    _root, idx = vault_builder(
+        {
+            "empty_note.md": "---\nnote: ''\n---\nbody\n",
+            "some_note.md": "---\nnote: something\n---\nbody\n",
+        }
+    )
+    result = idx.list_frontmatter_keys()
+    key_map = {item.key: item for item in result}
+
+    assert "note" in key_map, "note キーが含まれるべき"
+    info = key_map["note"]
+
+    assert info.note_count == 2, (
+        f"note_count は空文字ノートも含めて 2 であるべき (got {info.note_count})"
+    )
+    assert "" not in info.sample_values, (
+        f"空文字は sample_values に含まれないべき (got {info.sample_values!r})"
+    )
+    assert "something" in info.sample_values, (
+        f"'something' は sample_values に含まれるべき (got {info.sample_values!r})"
+    )
+
+
+def test_note_count_excludes_null(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """YAML null は note_count から除外される."""
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+
+    _root, idx = vault_builder(
+        {
+            "active_note.md": "---\nstatus: active\n---\nbody\n",
+            "null_note.md": "---\nstatus: ~\n---\nbody\n",
+        }
+    )
+    result = idx.list_frontmatter_keys()
+    key_map = {item.key: item for item in result}
+
+    assert "status" in key_map, "status キーが含まれるべき"
+    assert key_map["status"].note_count == 1, (
+        f"null は note_count に含まれないため 1 であるべき (got {key_map['status'].note_count})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 追加観点 (Opus 指摘) (3 件)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_vault_returns_empty_list(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """frontmatter を持つ note が 0 件の場合、空リストが返る."""
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+
+    _root, idx = vault_builder({"no_fm.md": "# Plain note\n\nNo frontmatter here.\n"})
+    result = idx.list_frontmatter_keys()
+
+    assert result == [], f"frontmatter なし vault では [] が返るべき (got {result!r})"
+
+
+def test_dotted_nested_key_returns_key_info(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """ネスト frontmatter は親 dict key + dotted leaf key 両方が返る (#136 の既存契約保持)."""
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+
+    _root, idx = vault_builder({"nested.md": "---\nmeta:\n  author: foo\n---\nbody\n"})
+    result = idx.list_frontmatter_keys()
+    key_map = {item.key: item for item in result}
+
+    # dotted leaf key は葉値の型で分類される
+    assert "meta.author" in key_map, (
+        f"ネスト key 'meta.author' が FrontmatterKeyInfo として含まれるべき (keys={list(key_map)})"
+    )
+    assert isinstance(key_map["meta.author"], FrontmatterKeyInfo)
+    assert key_map["meta.author"].value_type == "string", (
+        f"meta.author='foo' → value_type='string' (got {key_map['meta.author'].value_type!r})"
+    )
+
+    # 親 dict キー "meta" は value_type='object' として保持される (#136 既存契約 + filter 不可を明示)
+    assert "meta" in key_map, (
+        f"親 dict キー 'meta' も FrontmatterKeyInfo として含まれるべき (#136, keys={list(key_map)})"
+    )
+    assert key_map["meta"].value_type == "object", (
+        f"親 dict キーは value_type='object' であるべき (got {key_map['meta'].value_type!r})"
+    )
+
+
+def test_unicode_key_and_value_supported(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """Unicode キーと値が FrontmatterKeyInfo に正しく格納される."""
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+
+    _root, idx = vault_builder({"unicode_note.md": "---\n日本語キー: あいうえお\n---\nbody\n"})
+    result = idx.list_frontmatter_keys()
+    key_map = {item.key: item for item in result}
+
+    assert "日本語キー" in key_map, (
+        f"Unicode キー '日本語キー' が含まれるべき (keys={list(key_map)})"
+    )
+    assert "あいうえお" in key_map["日本語キー"].sample_values, (
+        "sample_values に 'あいうえお' が含まれるべき"
+        f" (got {key_map['日本語キー'].sample_values!r})"
+    )

--- a/tests/test_frontmatter_key_info.py
+++ b/tests/test_frontmatter_key_info.py
@@ -322,3 +322,74 @@ def test_unicode_key_and_value_supported(
         "sample_values に 'あいうえお' が含まれるべき"
         f" (got {key_map['日本語キー'].sample_values!r})"
     )
+
+
+# ---------------------------------------------------------------------------
+# Round 1 review 由来の追加 (A1 / B1)
+# ---------------------------------------------------------------------------
+
+
+def test_value_type_number_exponent_notation(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """YAML float の指数表記 (1e15 以上) が number と判定される (Reviewer A1).
+
+    Python float の str 変換は 1e16 以上を ``'1e+16'`` 形式で出す。既存 regex
+    ``^-?\\d+(\\.\\d+)?$`` はこれを string 扱いしていたため誤分類していた。
+    """
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義"
+
+    _root, idx = vault_builder(
+        {
+            "exp_note.md": "---\nlarge: 1.5e100\n---\nbody\n",
+            "neg_exp_note.md": "---\nsmall: 2e-10\n---\nbody\n",
+        }
+    )
+    result = idx.list_frontmatter_keys()
+    key_map = {item.key: item for item in result}
+
+    assert "large" in key_map and key_map["large"].value_type == "number", (
+        f"large: 1.5e100 → value_type='number' (got {key_map['large'].value_type!r})"
+    )
+    assert "small" in key_map and key_map["small"].value_type == "number", (
+        f"small: 2e-10 → value_type='number' (got {key_map['small'].value_type!r})"
+    )
+
+
+def test_object_key_rejected_from_metadata_filter(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """親 dict key は metadata_filter の known_keys から除外される (B1).
+
+    object 型は filter 不可なので、親キー名で filter を試みると silent 0 件ではなく
+    UNKNOWN_FRONTMATTER_KEY ValidationError で agent に誤用を通知する。
+    """
+    from vault_search.validation import ValidationError
+
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義"
+
+    _root, idx = vault_builder({"nested.md": "---\nmeta:\n  author: foo\n---\nbody\n"})
+    # 親キー 'meta' は value_type='object' として list_frontmatter_keys に含まれるが、
+    # metadata_filter の known_keys からは除外されている必要がある。
+    with pytest.raises(ValidationError) as exc_info:
+        idx.search(
+            query="",
+            folder=None,
+            metadata_filter={"meta": "any"},
+            limit=20,
+            offset=0,
+        )
+    assert exc_info.value.error_code == "UNKNOWN_FRONTMATTER_KEY", (
+        f"object 型キー 'meta' への filter は UNKNOWN_FRONTMATTER_KEY になるべき "
+        f"(got {exc_info.value.error_code!r})"
+    )
+
+    # dotted leaf key 'meta.author' は引き続き filter 可能 (既存契約 #136 保持)
+    res = idx.search(
+        query="",
+        folder=None,
+        metadata_filter={"meta.author": "foo"},
+        limit=20,
+        offset=0,
+    )
+    assert res["total"] == 1

--- a/tests/test_frontmatter_key_info.py
+++ b/tests/test_frontmatter_key_info.py
@@ -400,3 +400,38 @@ def test_object_key_rejected_from_metadata_filter(
         offset=0,
     )
     assert res["total"] == 1
+
+
+def test_object_key_filter_error_message_has_dotted_leaf_hint(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """object 型 filter エラーで dotted leaf key の hint が message にある (Round 2).
+
+    Round 1 B1 fix で `meta` は UNKNOWN_FRONTMATTER_KEY を返すようになったが、
+    schema://tools では `meta` が公開されているため、agent 視点では「schema と
+    error が不整合」に見える。MCP wire では structured error 属性が消える
+    (fastmcp-gotchas.md) ため、`str(err)` に agent が self-correct できるヒントを
+    埋める必要がある。
+    """
+    from vault_search.validation import ValidationError
+
+    _root, idx = vault_builder({"nested.md": "---\nmeta:\n  author: foo\n---\nbody\n"})
+
+    with pytest.raises(ValidationError) as exc_info:
+        idx.search(
+            query="",
+            folder=None,
+            metadata_filter={"meta": "any"},
+            limit=20,
+            offset=0,
+        )
+    msg = str(exc_info.value)
+    assert "meta" in msg, f"エラーメッセージに 'meta' が含まれるべき (got: {msg})"
+    # "parent dict" / "dotted" / "object" いずれかの hint が含まれる
+    hint_found = any(
+        token in msg.lower() for token in ("parent dict", "dotted", "object", "leaf")
+    )
+    assert hint_found, (
+        "エラーメッセージに dotted leaf / parent dict / object のいずれかの hint が"
+        f" 必要 (got: {msg})"
+    )

--- a/tests/test_frontmatter_key_info.py
+++ b/tests/test_frontmatter_key_info.py
@@ -133,12 +133,11 @@ def test_value_type_array(
     assert key_map["tags"].value_type == "array", (
         f"tags: [a, b] → value_type='array' であるべき (got {key_map['tags'].value_type!r})"
     )
-    # sample_values に配列全体の JSON 文字列表現が含まれる (例: '["a", "b"]')
-    assert len(key_map["tags"].sample_values) > 0, "sample_values に配列表現が含まれるべき"
-    # 少なくとも 1 件は JSON 配列文字列 ([ で始まる)
-    assert any(v.startswith("[") for v in key_map["tags"].sample_values), (
-        "sample_values に '[' で始まる JSON 配列文字列が含まれるべき"
-        f" (got {key_map['tags'].sample_values!r})"
+    # sample_values に配列全体の JSON 文字列表現が厳密に含まれる (Reviewer C5)。
+    # `str(list)` の Python repr (`"['a', 'b']"`) ではなく `json.dumps` 出力を pin。
+    assert '["a", "b"]' in key_map["tags"].sample_values, (
+        f'sample_values に JSON 配列文字列 \'["a", "b"]\' が含まれるべき '
+        f"(got {key_map['tags'].sample_values!r})"
     )
 
 
@@ -195,19 +194,18 @@ def test_sample_values_top5_frequency_and_tiebreak(
     assert "status" in key_map, "status キーが含まれるべき"
     samples = key_map["status"].sample_values
 
-    # 最大 5 件
-    assert len(samples) <= 5, f"sample_values は最大 5 件 (got {len(samples)})"
+    # 厳密に 5 件 (top-5 強制の regression guard: 全件返却バグや [:5] 削除バグを検知)
+    assert len(samples) == 5, f"sample_values は厳密に 5 件 (got {len(samples)})"
 
-    # 1 位は "active" (頻度 3)
-    assert samples[0] == "active", f"頻度最大の 'active' が先頭であるべき (got {samples[0]!r})"
+    # 1-2 位は頻度上位: active(3), draft(2)
+    assert samples[0] == "active", f"頻度 3 の 'active' が先頭 (got {samples[0]!r})"
+    assert samples[1] == "draft", f"頻度 2 の 'draft' が 2 位 (got {samples[1]!r})"
 
-    # 2 位は "draft" (頻度 2)
-    assert len(samples) >= 2, "sample_values に少なくとも 2 件あるべき"
-    assert samples[1] == "draft", f"2 位は 'draft' (頻度 2) であるべき (got {samples[1]!r})"
-
-    # 3 位以降は同頻度 (1) → 辞書順: cancel, done, todo, wip の先頭 2 件
-    if len(samples) >= 3:
-        assert samples[2] == "cancel", f"3 位は辞書順 'cancel' であるべき (got {samples[2]!r})"
+    # 3-5 位は同頻度 (1) → 辞書順: cancel, done, todo (wip は 6 番目で除外)
+    assert samples[2] == "cancel", f"3 位は辞書順 'cancel' (got {samples[2]!r})"
+    assert samples[3] == "done", f"4 位は辞書順 'done' (got {samples[3]!r})"
+    assert samples[4] == "todo", f"5 位は辞書順 'todo' (got {samples[4]!r})"
+    assert "wip" not in samples, f"6 番目 (辞書順で 'wip') は除外されるべき (got {samples!r})"
 
 
 def test_sample_values_excludes_empty_but_note_count_includes(
@@ -302,6 +300,15 @@ def test_dotted_nested_key_returns_key_info(
     )
     assert key_map["meta"].value_type == "object", (
         f"親 dict キーは value_type='object' であるべき (got {key_map['meta'].value_type!r})"
+    )
+    # object 型の sample_values と note_count contract (Reviewer C3):
+    # sample_values は空リスト (dict 値は filter 不可なのでサンプルを持たない)
+    assert key_map["meta"].sample_values == [], (
+        f"object 型キーの sample_values は空リスト (got {key_map['meta'].sample_values!r})"
+    )
+    # note_count は親キーが出現する note 数
+    assert key_map["meta"].note_count == 1, (
+        f"object 型キーの note_count は出現 note 数 (got {key_map['meta'].note_count})"
     )
 
 

--- a/tests/test_frontmatter_key_info.py
+++ b/tests/test_frontmatter_key_info.py
@@ -428,9 +428,7 @@ def test_object_key_filter_error_message_has_dotted_leaf_hint(
     msg = str(exc_info.value)
     assert "meta" in msg, f"エラーメッセージに 'meta' が含まれるべき (got: {msg})"
     # "parent dict" / "dotted" / "object" いずれかの hint が含まれる
-    hint_found = any(
-        token in msg.lower() for token in ("parent dict", "dotted", "object", "leaf")
-    )
+    hint_found = any(token in msg.lower() for token in ("parent dict", "dotted", "object", "leaf"))
     assert hint_found, (
         "エラーメッセージに dotted leaf / parent dict / object のいずれかの hint が"
         f" 必要 (got: {msg})"

--- a/tests/test_frontmatter_keys_cache.py
+++ b/tests/test_frontmatter_keys_cache.py
@@ -102,3 +102,50 @@ def test_list_frontmatter_keys_invalidated_after_build_index(
 
     keys = {info.key for info in idx.list_frontmatter_keys()}
     assert "extra_key_from_rebuild" in keys
+
+
+def test_list_frontmatter_keys_concurrent_read_during_invalidate(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """read と invalidate の並行実行で TypeError / 破損が発生しない (Round 2 E1).
+
+    `list_frontmatter_keys()` 読出し中に別スレッドが `_invalidate_caches()` で
+    キャッシュを None にしても、snapshot pattern + lock 対称化により
+    ``list(None)`` にならず、常に valid な list を返す。
+    """
+    import threading
+
+    _root, idx = vault_builder(
+        {
+            "a.md": "---\nalpha: 1\n---\nbody\n",
+            "b.md": "---\nbeta: 2\n---\nbody\n",
+        }
+    )
+    idx.list_frontmatter_keys()  # prime cache
+
+    errors: list[Exception] = []
+    barrier = threading.Barrier(2)
+
+    def reader() -> None:
+        barrier.wait()
+        for _ in range(200):
+            try:
+                result = idx.list_frontmatter_keys()
+                assert isinstance(result, list)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+                return
+
+    def invalidator() -> None:
+        barrier.wait()
+        for _ in range(200):
+            idx._invalidate_caches()
+
+    t1 = threading.Thread(target=reader)
+    t2 = threading.Thread(target=invalidator)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert not errors, f"concurrent read/invalidate should not raise: {errors!r}"

--- a/tests/test_frontmatter_keys_cache.py
+++ b/tests/test_frontmatter_keys_cache.py
@@ -46,7 +46,7 @@ def test_list_frontmatter_keys_invalidated_after_update_single_add(
 ) -> None:
     """update_single でキーが追加されたら次の呼出で反映される."""
     root, idx = vault_builder({"seed.md": "---\nexisting_key: seed\n---\nbody\n"})
-    before = set(idx.list_frontmatter_keys())
+    before = {info.key for info in idx.list_frontmatter_keys()}
     assert "brand_new_key_xyzzy" not in before
 
     (root / "new_with_key.md").write_text(
@@ -55,7 +55,7 @@ def test_list_frontmatter_keys_invalidated_after_update_single_add(
     )
     assert idx.update_single("new_with_key.md") is True
 
-    after = set(idx.list_frontmatter_keys())
+    after = {info.key for info in idx.list_frontmatter_keys()}
     assert "brand_new_key_xyzzy" in after
 
 
@@ -74,14 +74,14 @@ def test_list_frontmatter_keys_invalidated_after_update_single_delete(
         }
     )
     _ = idx.list_frontmatter_keys()  # populate cache
-    assert "shared_key" in set(idx.list_frontmatter_keys())
+    assert "shared_key" in {info.key for info in idx.list_frontmatter_keys()}
 
     (root / "alpha.md").unlink()
     (root / "beta.md").unlink()
     assert idx.update_single("alpha.md") is True
     assert idx.update_single("beta.md") is True
 
-    after = set(idx.list_frontmatter_keys())
+    after = {info.key for info in idx.list_frontmatter_keys()}
     assert "shared_key" not in after
     # 無関係キーは残る (部分削除 regression guard)
     assert "unrelated_key" in after
@@ -100,5 +100,5 @@ def test_list_frontmatter_keys_invalidated_after_build_index(
     )
     idx.build_index(force=True)
 
-    keys = set(idx.list_frontmatter_keys())
+    keys = {info.key for info in idx.list_frontmatter_keys()}
     assert "extra_key_from_rebuild" in keys

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -138,28 +138,47 @@ def test_frontmatter_keys_match_vault(
 
 
 def test_value_samples_subset(schema_payload: dict[str, Any], vault_index: VaultIndex) -> None:
-    """frontmatter_value_samples の各サンプル値が実 vault の実データの部分集合である."""
-    samples = schema_payload.get("frontmatter_value_samples") or {}
-    assert isinstance(samples, dict), "frontmatter_value_samples must be a dict"
-    for key, bucket in samples.items():
-        if not isinstance(bucket, list) or not bucket:
+    """frontmatter_keys[*].sample_values の各値が実 vault の frontmatter 値と整合する.
+
+    正規化 (parser._normalize_scalar) 後の文字列表現と sample_values 値を比較:
+      - scalar (bool/int/float/date) は isoformat / str() で文字列化されている
+      - 配列値は json.dumps(..., ensure_ascii=False) の文字列
+      - value_type='object' の親キーは sample_values=[] なので skip
+    """
+    fm_keys = schema_payload.get("frontmatter_keys") or []
+    assert isinstance(fm_keys, list), "frontmatter_keys must be a list"
+    assert len(fm_keys) > 0, "fixture vault should have frontmatter keys"
+
+    # vault から各 key の正規化済み値の集合を収集
+    expected_by_key: dict[str, set[str]] = {}
+    for note in vault_index.recent_notes(limit=100):
+        detail = vault_index.get_note(note["path"])
+        if detail is None:
             continue
-        vault_values: set[Any] = set()
-        for note in vault_index.recent_notes(limit=100):
-            detail = vault_index.get_note(note["path"])
-            if detail is None:
+        fm = detail.get("frontmatter") or {}
+        for k, v in fm.items():
+            if v is None or isinstance(v, dict):
                 continue
-            fm = detail.get("frontmatter") or {}
-            if key in fm:
-                v = fm[key]
-                if isinstance(v, list):
-                    vault_values.update(v)
-                else:
-                    vault_values.add(v)
-        for sample_val in bucket:
-            assert sample_val in vault_values, (
-                f"sample value {sample_val!r} for key {key!r} "
-                f"not found in vault (vault values: {sorted(str(x) for x in vault_values)})"
+            bucket = expected_by_key.setdefault(k, set())
+            if isinstance(v, list):
+                bucket.add(json.dumps(v, ensure_ascii=False))
+            elif isinstance(v, str):
+                if v.strip():
+                    bucket.add(v)
+            else:
+                bucket.add(str(v))
+
+    for info in fm_keys:
+        if info.get("value_type") == "object":
+            assert info["sample_values"] == [], (
+                f"object 型 '{info['key']}' の sample_values は [] でなければならない"
+            )
+            continue
+        expected = expected_by_key.get(info["key"], set())
+        for sample_val in info["sample_values"]:
+            assert sample_val in expected, (
+                f"sample value {sample_val!r} for key {info['key']!r} "
+                f"not found in vault (expected subset: {sorted(expected)})"
             )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -121,12 +121,17 @@ def test_frontmatter_keys_match_vault(
     assert isinstance(frontmatter_keys, list) and frontmatter_keys, (
         f"frontmatter_keys must be a non-empty list, got {frontmatter_keys!r}"
     )
+    # frontmatter_keys は list[dict] (FrontmatterKeyInfo の model_dump 結果)
+    assert all(isinstance(k, dict) for k in frontmatter_keys), (
+        "frontmatter_keys の各要素は dict (FrontmatterKeyInfo) であるべき"
+    )
     all_fm_keys: set[str] = set()
     for note in vault_index.recent_notes(limit=100):
         detail = vault_index.get_note(note["path"])
         if detail:
             all_fm_keys.update((detail.get("frontmatter") or {}).keys())
-    for key in frontmatter_keys:
+    for info in frontmatter_keys:
+        key = info["key"]
         assert key in all_fm_keys, (
             f"schema key {key!r} not found in any vault note (vault keys: {sorted(all_fm_keys)})"
         )

--- a/tests/test_nested_frontmatter_keys.py
+++ b/tests/test_nested_frontmatter_keys.py
@@ -40,7 +40,7 @@ def test_list_frontmatter_keys_includes_nested_dotted_keys(
     nested_index: VaultIndex,
 ) -> None:
     """ネスト dict 値は dotted key として known_keys に現れる."""
-    keys = set(nested_index.list_frontmatter_keys())
+    keys = {info.key for info in nested_index.list_frontmatter_keys()}
     assert "meta" in keys, "トップレベルキーも従来通り含まれる"
     assert "meta.author" in keys, "ネスト子キーも dotted で含まれる必要がある (#136)"
     assert "meta.tag" in keys

--- a/tests/test_schema_resource.py
+++ b/tests/test_schema_resource.py
@@ -116,7 +116,7 @@ def test_vault_search_output_schema_describes_search_hit_fields(
 
 
 def test_frontmatter_keys_listed(vault_index: VaultIndex) -> None:
-    """ルートに 'frontmatter_keys' が list[str] として存在し、
+    """ルートに 'frontmatter_keys' が list[dict] として存在し、
     tmp_vault の Welcome.md に含まれるキーを少なくとも含むこと。
     """
     from vault_search.mcp_contract import build_schema_payload
@@ -125,18 +125,26 @@ def test_frontmatter_keys_listed(vault_index: VaultIndex) -> None:
     assert "frontmatter_keys" in payload
     keys = payload["frontmatter_keys"]
     assert isinstance(keys, list)
-    assert all(isinstance(k, str) for k in keys)
+    assert all(isinstance(k, dict) for k in keys)
+
+    # 各 dict に必須フィールドが含まれること
+    for info in keys:
+        assert "key" in info, f"'key' フィールドが欠落: {info!r}"
+        assert "value_type" in info, f"'value_type' フィールドが欠落: {info!r}"
+        assert "note_count" in info, f"'note_count' フィールドが欠落: {info!r}"
+
+    key_names = {info["key"] for info in keys}
 
     expected_from_welcome = {"title", "tags", "aliases", "created_at", "modified_at"}
     # created_at / modified_at は conftest の Welcome.md で使われているキー名。
     # 実装側が created / modified へ正規化する可能性もあるので
     # 「少なくとも title / tags / aliases と 日付系 1つ以上」を要求。
-    assert {"title", "tags", "aliases"}.issubset(set(keys)), (
-        f"expected at least title/tags/aliases in frontmatter_keys, got {keys}"
+    assert {"title", "tags", "aliases"}.issubset(key_names), (
+        f"expected at least title/tags/aliases in frontmatter_keys, got {key_names}"
     )
     date_keys = {"created_at", "modified_at", "created", "modified"}
-    assert date_keys & set(keys), (
-        f"expected at least one date-like key in frontmatter_keys, got {keys}"
+    assert date_keys & key_names, (
+        f"expected at least one date-like key in frontmatter_keys, got {key_names}"
     )
     # 参照だけしておく (将来の拡張用)
     _ = expected_from_welcome


### PR DESCRIPTION
## Summary

- Agent DX cluster PR 1c: `schema://tools` の `frontmatter_keys` を
  `list[str]` → `list[FrontmatterKeyInfo]` に拡張
- 各 key に `value_type` (Literal enum) / `sample_values` (top-5) /
  `note_count` を付与し、agent が `metadata_filter` を組み立てる際の
  試行錯誤を削減
- Closes #20

## 設計決定

### value_type Literal (`"object"` を追加)

Issue 本文は `"string|number|boolean|list|mixed"` だが、**JSON Schema 用語に
統一**して `"string|number|boolean|array|object|mixed"` を採用。

- `"array"` ← Issue 本文の `"list"` を JSON Schema 用語に
- `"object"` ← 親 dict key (`meta`) 用に新設 (#136 既存契約 = 親 key も
  `list_frontmatter_keys()` に含まれる、を破らない)
- issue #20 にコメントで drift 明示: https://github.com/ebal5/vault-search-mcp/issues/20#issuecomment-4274957142

### 値型推論は heuristic

`frontmatter-normalization.md` の Option A (index-time str 正規化) により
型情報は喪失済み。そのため:

- `"true"` / `"false"` 完全一致 → boolean
- 数値 regex (`^-?\d+(\.\d+)?$`) → number
- それ以外のスカラー → string
- list → array
- dict → object (親 key)
- 複数 note で型混在 → mixed

日付 / 日時は string に丸まる (既知 limitation、description 明記)。

### sample_values

- top-5、頻度降順、同頻度は辞書順
- 配列は配列全体の JSON 文字列表現 (要素別頻度は `vault_tags` で取得)
- 空文字は sample から除外するが note_count には含める (「空が多い key」を
  差分で agent に示唆)
- 親 dict (object) は sample_values=[]

## TDD 3-commit 構成

1. **Red** (`4c7f7bf`) — `tests/test_frontmatter_key_info.py` 12 件追加
   (既存 src は無変更、12 failed / 499 passed)
2. **Green** (`096b089`) — `stats.py` / `indexer.py` / `mcp_contract.py` 実装 +
   既存テストの assert を mechanical 追従 (511 passed)
3. **Refactor** (`94496bf`) — Green で dead code 化した `_collect_nested_keys`
   削除 (`_collect_key_info` が拡張版として全経路を置換)

## Wire 変更 (observable)

Before:
\`\`\`json
{"frontmatter_keys": ["priority", "status", "tags"]}
\`\`\`

After:
\`\`\`json
{
  "frontmatter_keys": [
    {"key": "priority", "value_type": "number", "sample_values": ["5"], "note_count": 3},
    {"key": "status", "value_type": "string", "sample_values": ["active", "draft"], "note_count": 5},
    {"key": "tags", "value_type": "array", "sample_values": ["[\"todo\"]"], "note_count": 7}
  ]
}
\`\`\`

## Opus 計画評価で取り込んだ修正

- Red テストを当初案 18 → 10-12 件に削減 (冗長統合、Unicode/空 vault/同頻度 tiebreak 追加)
- `_infer_value_type` を module-level pure function で配置 (self method 化回避)
- `value_type`/`sample_values`/`note_count` の description に limitation 明記

## Test plan

- [x] `.venv/bin/pytest` — 511 passed (499 既存 + 12 新規)
- [x] `.venv/bin/ruff check` / `ruff format --check` クリーン
- [x] 3 commit (Red/Green/Refactor 独立)
- [x] `gh pr view --json headRefName,commits,files` で branch / 8 files 確認

## 関連

- Agent DX cluster: PR 1a #171 (merged) / 1b #38 / 2 #80 / 3 #39
- 既存契約 #136 (親 dict key も `list_frontmatter_keys()` に含める) を保持