### PR TITLE
Refactor: FrontmatterKeyInfo を schema_meta.py に分離 (#178)

### DIFF
--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -29,7 +29,7 @@ from .filter import (
     parse_metadata_filter,
 )
 from .parser import ParsedNote, parse_note
-from .stats import FrontmatterKeyInfo
+from .schema_meta import FrontmatterKeyInfo
 from .validation import normalize_folder
 
 logger = logging.getLogger(__name__)

--- a/src/vault_search/mcp_contract.py
+++ b/src/vault_search/mcp_contract.py
@@ -20,6 +20,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel
 
+from .schema_meta import FrontmatterKeyInfo
 from .schemas import (
     FolderCount,
     NoteDetail,
@@ -27,7 +28,7 @@ from .schemas import (
     SearchResponse,
     TagCount,
 )
-from .stats import FrontmatterKeyInfo, ReindexStats, VaultStats
+from .stats import ReindexStats, VaultStats
 from .validation import IDENTIFIER_JSON_PATTERN, IDENTIFIER_MAX_LEN, LIMIT_MAX
 
 __all__ = [

--- a/src/vault_search/schema_meta.py
+++ b/src/vault_search/schema_meta.py
@@ -1,0 +1,57 @@
+"""Vault 内容のスキーマ記述を表す型を集約する.
+
+`stats.py` は時系列の集計値 (ReindexStats / VaultStats) を扱うのに対し、
+本 module は vault の静的なスキーマ情報 (frontmatter key の型・サンプル等) を
+扱う。
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class FrontmatterKeyInfo(BaseModel):
+    """frontmatter キー 1 件のメタ情報 (Issue #20)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str = Field(
+        description=(
+            "frontmatter のキー名。ネスト dict は dotted key (例: 'meta.author') を含む。"
+            "トップレベルの親 dict キー (例: 'meta') も value_type='object' として公開される "
+            "(ただし metadata_filter では not filterable — 葉 dotted key を使うこと。"
+            "親キー名を metadata_filter に渡すと UNKNOWN_FRONTMATTER_KEY が返る)"
+        )
+    )
+    value_type: Literal["string", "number", "boolean", "array", "object", "mixed"] = Field(
+        description=(
+            "観測された値型。index 時に全スカラーが文字列に正規化されるため、"
+            "boolean / number はヒューリスティック推論 ('true'/'false' 完全一致で boolean、"
+            "数値 regex (指数表記含む) で number、それ以外の文字列は string)。"
+            "配列値は 'array' (要素型は問わない)。親 dict キーは 'object' "
+            "(not filterable、葉 dotted key を使うこと)。"
+            "複数 note で型が混在する場合は 'mixed' — filter は可能で、値は常に文字列表現 "
+            "(例: metadata_filter={'level': '5'} で int 5 の note もマッチ)。"
+            "日付/日時は 'string' に丸まる (正規化で型情報喪失、既知の limitation)。"
+            "YAML で引用符付きの数値文字列 (例: code: '007') も 'number' に分類される"
+            " (heuristic の限界)"
+        )
+    )
+    sample_values: list[str] = Field(
+        default_factory=list,
+        description=(
+            "出現頻度上位最大 5 件のサンプル値 (降順、重複なし、同頻度は辞書順で安定)。"
+            "これらは正規化済みの文字列表現で、そのまま metadata_filter の "
+            "eq / ne / in 値として使える (例: date は isoformat、int 5 は '5' として格納)。"
+            '配列フィールドは配列全体の JSON 文字列表現 (例: \'["a", "b"]\')。'
+            "この文字列をそのまま eq に渡すと配列全体一致の filter になるが通常は意図しない — "
+            "array 要素で filter したい場合は要素値 (例: 'a') を渡すこと。"
+            "配列要素別の頻度集計は vault_tags (tags 相当) を使うこと。"
+            "空文字・空白のみの値は sample_values から除外するが note_count には含める "
+            "(この差分から『空が多い key』が判る)。"
+            "親 dict キー (value_type='object') は sample_values が空リスト"
+        ),
+    )
+    note_count: int = Field(description="このキーを持つ note 数 (YAML null / 欠落は除外)")

--- a/src/vault_search/stats.py
+++ b/src/vault_search/stats.py
@@ -1,59 +1,12 @@
-"""インデックスの集計状態 / スキーマメタを表す型を集約する.
+"""インデックス処理の集計結果を表す時系列の統計型を集約する.
 
-検索結果や個別ノートを表す型は schemas.py に残る。
-将来的に境界が揺らぐ可能性あり (PR 1b/1c で再評価)。
+vault の静的なスキーマ記述 (FrontmatterKeyInfo 等) は `schema_meta.py` に、
+検索結果や個別ノートを表す型は `schemas.py` に分離されている。
 """
 
 from __future__ import annotations
 
-from typing import Literal
-
 from pydantic import BaseModel, ConfigDict, Field
-
-
-class FrontmatterKeyInfo(BaseModel):
-    """frontmatter キー 1 件のメタ情報 (Issue #20)."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    key: str = Field(
-        description=(
-            "frontmatter のキー名。ネスト dict は dotted key (例: 'meta.author') を含む。"
-            "トップレベルの親 dict キー (例: 'meta') も value_type='object' として公開される "
-            "(ただし metadata_filter では not filterable — 葉 dotted key を使うこと。"
-            "親キー名を metadata_filter に渡すと UNKNOWN_FRONTMATTER_KEY が返る)"
-        )
-    )
-    value_type: Literal["string", "number", "boolean", "array", "object", "mixed"] = Field(
-        description=(
-            "観測された値型。index 時に全スカラーが文字列に正規化されるため、"
-            "boolean / number はヒューリスティック推論 ('true'/'false' 完全一致で boolean、"
-            "数値 regex (指数表記含む) で number、それ以外の文字列は string)。"
-            "配列値は 'array' (要素型は問わない)。親 dict キーは 'object' "
-            "(not filterable、葉 dotted key を使うこと)。"
-            "複数 note で型が混在する場合は 'mixed' — filter は可能で、値は常に文字列表現 "
-            "(例: metadata_filter={'level': '5'} で int 5 の note もマッチ)。"
-            "日付/日時は 'string' に丸まる (正規化で型情報喪失、既知の limitation)。"
-            "YAML で引用符付きの数値文字列 (例: code: '007') も 'number' に分類される"
-            " (heuristic の限界)"
-        )
-    )
-    sample_values: list[str] = Field(
-        default_factory=list,
-        description=(
-            "出現頻度上位最大 5 件のサンプル値 (降順、重複なし、同頻度は辞書順で安定)。"
-            "これらは正規化済みの文字列表現で、そのまま metadata_filter の "
-            "eq / ne / in 値として使える (例: date は isoformat、int 5 は '5' として格納)。"
-            '配列フィールドは配列全体の JSON 文字列表現 (例: \'["a", "b"]\')。'
-            "この文字列をそのまま eq に渡すと配列全体一致の filter になるが通常は意図しない — "
-            "array 要素で filter したい場合は要素値 (例: 'a') を渡すこと。"
-            "配列要素別の頻度集計は vault_tags (tags 相当) を使うこと。"
-            "空文字・空白のみの値は sample_values から除外するが note_count には含める "
-            "(この差分から『空が多い key』が判る)。"
-            "親 dict キー (value_type='object') は sample_values が空リスト"
-        ),
-    )
-    note_count: int = Field(description="このキーを持つ note 数 (YAML null / 欠落は除外)")
 
 
 class ReindexStats(BaseModel):

--- a/tests/test_frontmatter_key_info.py
+++ b/tests/test_frontmatter_key_info.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 try:
-    from vault_search.stats import FrontmatterKeyInfo
+    from vault_search.schema_meta import FrontmatterKeyInfo
 except ImportError:
     FrontmatterKeyInfo = None  # Red では未定義、Green で実装される
 
@@ -27,7 +27,7 @@ from vault_search.indexer import VaultIndex
 
 def test_frontmatter_key_info_literal_and_forbid() -> None:
     """FrontmatterKeyInfo の Literal 制約と extra=forbid を検証する."""
-    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が schema_meta.py に未定義"
 
     # 正常構築
     obj = FrontmatterKeyInfo(key="x", value_type="mixed", note_count=1)
@@ -48,7 +48,7 @@ def test_frontmatter_key_info_literal_and_forbid() -> None:
 
 def test_frontmatter_key_info_sample_values_default() -> None:
     """sample_values は省略時に空リスト [] がデフォルト値になる."""
-    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が schema_meta.py に未定義"
 
     obj = FrontmatterKeyInfo(key="y", value_type="string", note_count=2)
     assert obj.sample_values == [], (
@@ -65,7 +65,7 @@ def test_list_frontmatter_keys_returns_frontmatter_key_info(
     vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
 ) -> None:
     """list_frontmatter_keys() が list[FrontmatterKeyInfo] を返す."""
-    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が schema_meta.py に未定義"
 
     _root, idx = vault_builder({"note.md": "---\npriority: high\n---\nbody\n"})
     result = idx.list_frontmatter_keys()
@@ -85,7 +85,7 @@ def test_value_type_boolean_and_number_and_string(
     vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
 ) -> None:
     """YAML bool/int/float は正規化後 value_type 推論で boolean/number に分類される."""
-    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が schema_meta.py に未定義"
 
     _root, idx = vault_builder(
         {
@@ -123,7 +123,7 @@ def test_value_type_array(
     vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
 ) -> None:
     """YAML list 値は value_type='array' に分類され、sample_values に JSON 文字列表現が入る."""
-    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が schema_meta.py に未定義"
 
     _root, idx = vault_builder({"arr_note.md": "---\ntags:\n  - a\n  - b\n---\nbody\n"})
     result = idx.list_frontmatter_keys()
@@ -145,7 +145,7 @@ def test_value_type_mixed(
     vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
 ) -> None:
     """同一キーに string と number が混在する場合 value_type='mixed' になる."""
-    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が schema_meta.py に未定義"
 
     _root, idx = vault_builder(
         {
@@ -172,7 +172,7 @@ def test_sample_values_top5_frequency_and_tiebreak(
     vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
 ) -> None:
     """sample_values は頻度降順 top-5、同頻度は辞書順で安定する."""
-    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が schema_meta.py に未定義"
 
     # status の頻度: active=3, draft=2, wip=1, todo=1, done=1, cancel=1
     _root, idx = vault_builder(
@@ -212,7 +212,7 @@ def test_sample_values_excludes_empty_but_note_count_includes(
     vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
 ) -> None:
     """空文字は sample_values から除外されるが note_count には含まれる."""
-    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が schema_meta.py に未定義"
 
     _root, idx = vault_builder(
         {
@@ -241,7 +241,7 @@ def test_note_count_excludes_null(
     vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
 ) -> None:
     """YAML null は note_count から除外される."""
-    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が schema_meta.py に未定義"
 
     _root, idx = vault_builder(
         {
@@ -267,7 +267,7 @@ def test_empty_vault_returns_empty_list(
     vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
 ) -> None:
     """frontmatter を持つ note が 0 件の場合、空リストが返る."""
-    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が schema_meta.py に未定義"
 
     _root, idx = vault_builder({"no_fm.md": "# Plain note\n\nNo frontmatter here.\n"})
     result = idx.list_frontmatter_keys()
@@ -279,7 +279,7 @@ def test_dotted_nested_key_returns_key_info(
     vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
 ) -> None:
     """ネスト frontmatter は親 dict key + dotted leaf key 両方が返る (#136 の既存契約保持)."""
-    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が schema_meta.py に未定義"
 
     _root, idx = vault_builder({"nested.md": "---\nmeta:\n  author: foo\n---\nbody\n"})
     result = idx.list_frontmatter_keys()
@@ -316,7 +316,7 @@ def test_unicode_key_and_value_supported(
     vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
 ) -> None:
     """Unicode キーと値が FrontmatterKeyInfo に正しく格納される."""
-    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義 (Green で追加)"
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が schema_meta.py に未定義"
 
     _root, idx = vault_builder({"unicode_note.md": "---\n日本語キー: あいうえお\n---\nbody\n"})
     result = idx.list_frontmatter_keys()
@@ -344,7 +344,7 @@ def test_value_type_number_exponent_notation(
     Python float の str 変換は 1e16 以上を ``'1e+16'`` 形式で出す。既存 regex
     ``^-?\\d+(\\.\\d+)?$`` はこれを string 扱いしていたため誤分類していた。
     """
-    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義"
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が schema_meta.py に未定義"
 
     _root, idx = vault_builder(
         {
@@ -373,7 +373,7 @@ def test_object_key_rejected_from_metadata_filter(
     """
     from vault_search.validation import ValidationError
 
-    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が stats.py に未定義"
+    assert FrontmatterKeyInfo is not None, "FrontmatterKeyInfo が schema_meta.py に未定義"
 
     _root, idx = vault_builder({"nested.md": "---\nmeta:\n  author: foo\n---\nbody\n"})
     # 親キー 'meta' は value_type='object' として list_frontmatter_keys に含まれるが、


### PR DESCRIPTION
## Summary

- PR #177 review D1 指摘 (#178) の解消
- `stats.py` の「時系列集計」と「静的スキーマ記述」の境界 ambiguity を
  `schema_meta.py` への split で確定。
- FrontmatterKeyInfo を schema_meta.py に移動、import 経路を更新。
- 振る舞い変更なし (純 refactor)。524 tests 全通過。

## 動機 (D1 より)

- `ReindexStats` / `VaultStats` は時系列値 (added/updated、db_size)
- `FrontmatterKeyInfo` は静的なスキーマ記述 (vault 内 frontmatter 構造)
- 両者が同 module にいると、後続 PR 1b (#38 overview / recommended_flow) や
  PR 2 (#80 vault_warnings) で「どこに置くか」判断が繰り返し発生する

## 変更内容

- `src/vault_search/schema_meta.py` 新設。`FrontmatterKeyInfo` を移動
- `src/vault_search/stats.py`: `ReindexStats` / `VaultStats` のみ、
  docstring を narrower scope に書き換え
- `src/vault_search/indexer.py` / `mcp_contract.py`: import 先を更新
- `tests/test_frontmatter_key_info.py`: import + assertion message 更新

## Test plan

- [x] `.venv/bin/pytest` — 524 tests pass
- [x] `ruff check` / `ruff format --check` clean

Closes #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)