### PR TITLE
Refactor: build_schema_payload を resources.py へ移動 (#184)

### DIFF
--- a/src/vault_search/mcp_contract.py
+++ b/src/vault_search/mcp_contract.py
@@ -12,7 +12,6 @@ input_schema / output_schema / annotations) を組み立て、AI エージェン
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -20,7 +19,6 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel
 
-from .schema_meta import FrontmatterKeyInfo
 from .schemas import (
     FolderCount,
     NoteDetail,
@@ -34,7 +32,6 @@ from .validation import IDENTIFIER_JSON_PATTERN, IDENTIFIER_MAX_LEN, LIMIT_MAX
 __all__ = [
     "TOOL_ENTRIES",
     "TOOL_SPECS",
-    "build_schema_payload",
     "inject_rich_output_schemas",
 ]
 
@@ -321,27 +318,14 @@ def _build_tool_entry(spec: _ToolSchemaSpec, tool_name: str) -> dict[str, Any]:
 
 # ``TOOL_ENTRIES`` は各ツールの (description / input_schema / output_schema) を
 # 束ねる唯一のカノニカルソース。以下 2 経路から参照される:
-#   1. ``build_schema_payload`` → ``schema://tools`` リソース (AI エージェント向け自己記述)
+#   1. ``resources.build_schema_payload`` → ``schema://tools`` リソース
+#      (AI エージェント向け自己記述)
 #   2. ``inject_rich_output_schemas`` → MCP ``tools/list`` の ``outputSchema``
 # FastMCP は ``dict[str, Any]`` 戻り型から rich schema を自動生成できないため、
 # 登録後に本エントリの ``output_schema`` を手動で差し込んで両経路の出力を一致させる。
 TOOL_ENTRIES: dict[str, dict[str, Any]] = {
     name: _build_tool_entry(spec, name) for name, spec in TOOL_SPECS.items()
 }
-
-
-def build_schema_payload(
-    frontmatter_keys: Iterable[FrontmatterKeyInfo],
-) -> dict[str, Any]:
-    """schema://tools resource payload の frontmatter_keys エンベロープ.
-
-    呼び出し側は ``VaultIndex.list_frontmatter_keys()`` 相当の反復可能オブジェクトを
-    そのまま渡す。
-    """
-    return {
-        "tools": TOOL_ENTRIES,
-        "frontmatter_keys": [item.model_dump(mode="json") for item in frontmatter_keys],
-    }
 
 
 # ---------------------------------------------------------------------------

--- a/src/vault_search/resources.py
+++ b/src/vault_search/resources.py
@@ -1,0 +1,31 @@
+"""MCP リソース payload の runtime 組み立て.
+
+`mcp_contract.py` は tool 契約 (schema 生成) に専念し、実データを wire 形式へ
+serialize する責務は本 module が担う (Issue #184)。`schema://tools` resource
+handler は本 module の関数を呼び出すだけ。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from .mcp_contract import TOOL_ENTRIES
+from .schema_meta import FrontmatterKeyInfo
+
+__all__ = ["build_schema_payload"]
+
+
+def build_schema_payload(
+    frontmatter_keys: Iterable[FrontmatterKeyInfo],
+) -> dict[str, Any]:
+    """schema://tools resource payload を組み立てる.
+
+    呼び出し側は ``VaultIndex.list_frontmatter_keys()`` 相当の反復可能オブジェクトを
+    そのまま渡す。Pydantic モデルを wire 形式の dict へ serialize するのは
+    resource layer (本 module) の責務。
+    """
+    return {
+        "tools": TOOL_ENTRIES,
+        "frontmatter_keys": [item.model_dump(mode="json") for item in frontmatter_keys],
+    }

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -30,9 +30,9 @@ from .indexer import VaultIndex
 from .mcp_contract import (
     _FOLDER_DESCRIPTION,
     TOOL_SPECS,
-    build_schema_payload,
     inject_rich_output_schemas,
 )
+from .resources import build_schema_payload
 from .schemas import (
     FolderCount,
     NoteDetail,

--- a/tests/test_mcp_wrapping.py
+++ b/tests/test_mcp_wrapping.py
@@ -23,7 +23,7 @@ import pytest
 
 from vault_search import server as server_mod
 from vault_search.indexer import VaultIndex
-from vault_search.mcp_contract import build_schema_payload
+from vault_search.resources import build_schema_payload
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_schema_resource.py
+++ b/tests/test_schema_resource.py
@@ -53,19 +53,19 @@ def _search_hit_properties(vault_search_output_schema: dict[str, Any]) -> dict[s
 
 
 # ---------------------------------------------------------------------------
-# build_schema_payload (schemas.py に追加予定)
+# build_schema_payload (resources.py)
 # ---------------------------------------------------------------------------
 
 
 def test_build_schema_payload_returns_dict(vault_index: VaultIndex) -> None:
-    from vault_search.mcp_contract import build_schema_payload
+    from vault_search.resources import build_schema_payload
 
     payload = build_schema_payload(vault_index.list_frontmatter_keys())
     assert isinstance(payload, dict)
 
 
 def test_build_schema_payload_has_tools_key(vault_index: VaultIndex) -> None:
-    from vault_search.mcp_contract import build_schema_payload
+    from vault_search.resources import build_schema_payload
 
     payload = build_schema_payload(vault_index.list_frontmatter_keys())
     assert "tools" in payload
@@ -73,7 +73,7 @@ def test_build_schema_payload_has_tools_key(vault_index: VaultIndex) -> None:
 
 
 def test_build_schema_payload_contains_all_tool_names(vault_index: VaultIndex) -> None:
-    from vault_search.mcp_contract import build_schema_payload
+    from vault_search.resources import build_schema_payload
 
     payload = build_schema_payload(vault_index.list_frontmatter_keys())
     tool_names = set(payload["tools"].keys())
@@ -82,7 +82,7 @@ def test_build_schema_payload_contains_all_tool_names(vault_index: VaultIndex) -
 
 
 def test_each_tool_entry_has_input_and_output_schema(vault_index: VaultIndex) -> None:
-    from vault_search.mcp_contract import build_schema_payload
+    from vault_search.resources import build_schema_payload
 
     payload = build_schema_payload(vault_index.list_frontmatter_keys())
     for name in EXPECTED_TOOL_NAMES:
@@ -100,7 +100,7 @@ def test_vault_search_output_schema_describes_search_hit_fields(
     """SearchHit の全フィールドが vault_search の output_schema 内に存在し、
     それぞれ非空文字列の description を持つことを確認。
     """
-    from vault_search.mcp_contract import build_schema_payload
+    from vault_search.resources import build_schema_payload
 
     payload = build_schema_payload(vault_index.list_frontmatter_keys())
     out_schema = payload["tools"]["vault_search"]["output_schema"]
@@ -119,7 +119,7 @@ def test_frontmatter_keys_listed(vault_index: VaultIndex) -> None:
     """ルートに 'frontmatter_keys' が list[dict] として存在し、
     tmp_vault の Welcome.md に含まれるキーを少なくとも含むこと。
     """
-    from vault_search.mcp_contract import build_schema_payload
+    from vault_search.resources import build_schema_payload
 
     payload = build_schema_payload(vault_index.list_frontmatter_keys())
     assert "frontmatter_keys" in payload
@@ -162,7 +162,7 @@ def test_server_exposes_schema_resource_handler(
     build_schema_payload と同じ dict を返すこと。
     """
     from vault_search import server as server_mod
-    from vault_search.mcp_contract import build_schema_payload
+    from vault_search.resources import build_schema_payload
 
     monkeypatch.setattr(server_mod, "_index", vault_index)
 
@@ -203,7 +203,7 @@ def test_list_returning_tools_have_envelope_output_schema(vault_index: VaultInde
     - vault_folders -> {"folders": [FolderCount, ...]}
     - vault_recent  -> {"notes":   [RecentNote,  ...]}
     """
-    from vault_search.mcp_contract import build_schema_payload
+    from vault_search.resources import build_schema_payload
 
     payload = build_schema_payload(vault_index.list_frontmatter_keys())
     for tool_name, env_key in [
@@ -234,7 +234,7 @@ def test_metadata_filter_grammar_structured_in_schema(vault_index: VaultIndex) -
     JSON Schema に露出していないと、エージェントが MongoDB 風の `$in` や
     `{"eq": "..."}` をハルシネーションしてしまう。
     """
-    from vault_search.mcp_contract import build_schema_payload
+    from vault_search.resources import build_schema_payload
 
     payload = build_schema_payload(vault_index.list_frontmatter_keys())
     mf_schema = payload["tools"]["vault_search"]["input_schema"]["properties"]["metadata_filter"]
@@ -272,7 +272,7 @@ def test_ne_operator_description_mentions_missing_key_behavior(vault_index: Vaul
     - ne プロパティが description を持つ
     - description に「キー欠落」「存在しない」「3値」「missing」のいずれかを含む
     """
-    from vault_search.mcp_contract import build_schema_payload
+    from vault_search.resources import build_schema_payload
 
     payload = build_schema_payload(vault_index.list_frontmatter_keys())
     mf_schema = payload["tools"]["vault_search"]["input_schema"]["properties"]["metadata_filter"]
@@ -308,7 +308,7 @@ def test_vault_get_note_output_schema_has_top_level_object_shape(vault_index: Va
     全 7 ツールで ``{"type": "object", "properties": {...}}`` 形を維持する。
     エージェントの schema クローラが ``type == 'object'`` 前提のことがあるため。
     """
-    from vault_search.mcp_contract import build_schema_payload
+    from vault_search.resources import build_schema_payload
 
     payload = build_schema_payload(vault_index.list_frontmatter_keys())
     schema = payload["tools"]["vault_get_note"]["output_schema"]
@@ -337,7 +337,7 @@ def test_read_resource_schema_tools_returns_payload(
     URI 登録チェックだけでなく実際の read_resource 呼び出しまで通す regression guard。
     """
     from vault_search import server as server_mod
-    from vault_search.mcp_contract import build_schema_payload
+    from vault_search.resources import build_schema_payload
 
     monkeypatch.setattr(server_mod, "_index", vault_index)
 

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -27,7 +27,7 @@ import pytest
 
 from vault_search import server as server_mod
 from vault_search.indexer import VaultIndex
-from vault_search.mcp_contract import build_schema_payload
+from vault_search.resources import build_schema_payload
 
 # 期待 annotations マトリクス (MCP spec 準拠).
 # ``None`` は「MCP spec で意味を持たないため意図的に未設定」を示す。


### PR DESCRIPTION
## Summary

- PR #177 review D3 指摘 (#184) の解消
- `mcp_contract.py` を「tool 契約 (schema 集約)」に専念させ、Pydantic モデルを
  wire 形式 dict へ serialize する runtime payload 構築を新 module
  `resources.py` に分離
- 振る舞い変更なし (純 refactor)。524 tests 全通過

## 動機 (D3 より)

`build_schema_payload` が
`[item.model_dump(mode="json") for item in frontmatter_keys]` を直接実行するが、
これは「実データを wire 形式に serialize する runtime 変換」で、
mcp_contract.py の本来責務「tool 契約 (schema) の集約」とは層が違う。

後続 PR #38 (overview / recommended_flow) や PR #80 (vault_warnings) で
payload が拡大すると mcp_contract.py が実質 "resource handler body" 化する
リスクがあるため、拡張前に分離する。

## 変更内容

- `src/vault_search/resources.py` 新設。`build_schema_payload` を移動
- `src/vault_search/mcp_contract.py`: 関数定義と Iterable / FrontmatterKeyInfo
  import を削除。`__all__` 更新
- `src/vault_search/server.py`: import 経路を更新
- 3 tests: import を `vault_search.resources` へ更新

## Test plan

- [x] `.venv/bin/pytest` — 524 tests pass
- [x] `ruff check` / `ruff format --check` clean

Closes #184. Unblocks #38 / #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)