### PR TITLE
metadata_filter_diagnostics on zero-total search (#80)

### DIFF
--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -552,10 +552,16 @@ class VaultIndex:
         """Issue #80: 0 件 + metadata_filter 指定時の per-key 診断情報を組み立てる.
 
         `key_infos` (``list_frontmatter_keys()`` の結果) をキー名で索引化し、
-        各 condition のキーを突き合わせて ``key_present_in_index`` と
-        ``observed_values_sample`` を返す。条件キーは parse 時点で
+        各 condition のキーを突き合わせて ``key_present_in_index`` /
+        ``value_type`` / ``observed_values_sample`` を返す。条件キーは parse 時点で
         ``known_keys`` と照合済みなので通常は全て hit するが、
         object 親キー (value_type='object') の一致など防衛的に false 分岐も保持する。
+
+        Note: tier 0/1 cache hit 時は ``results`` はキャッシュされた時点の
+        snapshot だが、``key_infos`` は現在の index 状態を反映する。
+        診断は advisory 情報なので意図的にこの非対称を許容する
+        (stale sample よりも現在の index 状態に基づく hint の方がエージェントの
+        自己修正に有用)。
         """
         info_by_key = {info.key: info for info in key_infos}
         diagnostics: list[dict[str, Any]] = []
@@ -566,6 +572,7 @@ class VaultIndex:
                     {
                         "key": cond.key,
                         "key_present_in_index": True,
+                        "value_type": info.value_type,
                         "observed_values_sample": list(info.sample_values),
                     }
                 )
@@ -574,6 +581,7 @@ class VaultIndex:
                     {
                         "key": cond.key,
                         "key_present_in_index": False,
+                        "value_type": None,
                         "observed_values_sample": [],
                     }
                 )

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -477,10 +477,11 @@ class VaultIndex:
         # 「親 dict なので dotted leaf key を使え」の hint を付与する (Round 2 E2)。
         known_keys: list[str] | None = None
         object_keys: list[str] = []
+        key_infos: list[FrontmatterKeyInfo] = []
         if metadata_filter:
-            _key_infos = self.list_frontmatter_keys()
-            known_keys = [info.key for info in _key_infos if info.value_type != "object"]
-            object_keys = [info.key for info in _key_infos if info.value_type == "object"]
+            key_infos = self.list_frontmatter_keys()
+            known_keys = [info.key for info in key_infos if info.value_type != "object"]
+            object_keys = [info.key for info in key_infos if info.value_type == "object"]
         conditions = parse_metadata_filter(
             metadata_filter, known_keys=known_keys, object_keys=object_keys
         )
@@ -497,12 +498,17 @@ class VaultIndex:
         tier, entry = self._cache.get(query, filters)
         if entry is not None:
             sliced = entry.result[offset : offset + limit]
-            return {
+            result: dict[str, Any] = {
                 "tier": tier,
                 "total": entry.total,
                 "truncated": entry.total > self._MAX_RESULTS,
                 "results": sliced,
             }
+            if metadata_filter and entry.total == 0:
+                result["metadata_filter_diagnostics"] = self._build_metadata_filter_diagnostics(
+                    conditions, key_infos
+                )
+            return result
 
         # Tier 2: FTS5 — 同一接続で FETCH と COUNT を実行する。
         # 別接続に分けると WAL の snapshot が食い違い、削除競合で
@@ -526,12 +532,52 @@ class VaultIndex:
         self._cache.put(query, filters, results, total=total)
 
         sliced = results[offset : offset + limit]
-        return {
+        result = {
             "tier": 2,
             "total": total,
             "truncated": total > self._MAX_RESULTS,
             "results": sliced,
         }
+        if metadata_filter and total == 0:
+            result["metadata_filter_diagnostics"] = self._build_metadata_filter_diagnostics(
+                conditions, key_infos
+            )
+        return result
+
+    @staticmethod
+    def _build_metadata_filter_diagnostics(
+        conditions: list[MetadataCondition],
+        key_infos: list[FrontmatterKeyInfo],
+    ) -> list[dict[str, Any]]:
+        """Issue #80: 0 件 + metadata_filter 指定時の per-key 診断情報を組み立てる.
+
+        `key_infos` (``list_frontmatter_keys()`` の結果) をキー名で索引化し、
+        各 condition のキーを突き合わせて ``key_present_in_index`` と
+        ``observed_values_sample`` を返す。条件キーは parse 時点で
+        ``known_keys`` と照合済みなので通常は全て hit するが、
+        object 親キー (value_type='object') の一致など防衛的に false 分岐も保持する。
+        """
+        info_by_key = {info.key: info for info in key_infos}
+        diagnostics: list[dict[str, Any]] = []
+        for cond in conditions:
+            info = info_by_key.get(cond.key)
+            if info is not None and info.note_count > 0:
+                diagnostics.append(
+                    {
+                        "key": cond.key,
+                        "key_present_in_index": True,
+                        "observed_values_sample": list(info.sample_values),
+                    }
+                )
+            else:
+                diagnostics.append(
+                    {
+                        "key": cond.key,
+                        "key_present_in_index": False,
+                        "observed_values_sample": [],
+                    }
+                )
+        return diagnostics
 
     def _build_match_clause(
         self,

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -554,38 +554,21 @@ class VaultIndex:
         `key_infos` (``list_frontmatter_keys()`` の結果) をキー名で索引化し、
         各 condition のキーを突き合わせて ``key_present_in_index`` /
         ``value_type`` / ``observed_values_sample`` を返す。条件キーは parse 時点で
-        ``known_keys`` と照合済みなので通常は全て hit するが、
-        object 親キー (value_type='object') の一致など防衛的に false 分岐も保持する。
-
-        Note: tier 0/1 cache hit 時は ``results`` はキャッシュされた時点の
-        snapshot だが、``key_infos`` は現在の index 状態を反映する。
-        診断は advisory 情報なので意図的にこの非対称を許容する
-        (stale sample よりも現在の index 状態に基づく hint の方がエージェントの
-        自己修正に有用)。
+        ``known_keys`` (= value_type が object 以外の FrontmatterKeyInfo) と
+        照合済みなので、ここに渡る cond.key は必ず info_by_key にヒットする。
+        不一致は validation 段階のバグなので ``KeyError`` を silently catch せず
+        surface させる (防衛 fallback は dead code になる)。
         """
         info_by_key = {info.key: info for info in key_infos}
-        diagnostics: list[dict[str, Any]] = []
-        for cond in conditions:
-            info = info_by_key.get(cond.key)
-            if info is not None and info.note_count > 0:
-                diagnostics.append(
-                    {
-                        "key": cond.key,
-                        "key_present_in_index": True,
-                        "value_type": info.value_type,
-                        "observed_values_sample": list(info.sample_values),
-                    }
-                )
-            else:
-                diagnostics.append(
-                    {
-                        "key": cond.key,
-                        "key_present_in_index": False,
-                        "value_type": None,
-                        "observed_values_sample": [],
-                    }
-                )
-        return diagnostics
+        return [
+            {
+                "key": cond.key,
+                "key_present_in_index": True,
+                "value_type": info_by_key[cond.key].value_type,
+                "observed_values_sample": list(info_by_key[cond.key].sample_values),
+            }
+            for cond in conditions
+        ]
 
     def _build_match_clause(
         self,

--- a/src/vault_search/schema_meta.py
+++ b/src/vault_search/schema_meta.py
@@ -11,6 +11,11 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+# FrontmatterKeyInfo.value_type の enum を集約する型エイリアス。
+# schemas.MetadataFilterDiagnostic.value_type でも同一 Literal を共有し、
+# JSON schema に enum 情報を残す (Issue #80 round 2 レビュー指摘)。
+FrontmatterValueType = Literal["string", "number", "boolean", "array", "object", "mixed"]
+
 
 class FrontmatterKeyInfo(BaseModel):
     """frontmatter キー 1 件のメタ情報 (Issue #20)."""
@@ -25,7 +30,7 @@ class FrontmatterKeyInfo(BaseModel):
             "親キー名を metadata_filter に渡すと UNKNOWN_FRONTMATTER_KEY が返る)"
         )
     )
-    value_type: Literal["string", "number", "boolean", "array", "object", "mixed"] = Field(
+    value_type: FrontmatterValueType = Field(
         description=(
             "観測された値型。index 時に全スカラーが文字列に正規化されるため、"
             "boolean / number はヒューリスティック推論 ('true'/'false' 完全一致で boolean、"

--- a/src/vault_search/schemas.py
+++ b/src/vault_search/schemas.py
@@ -71,6 +71,16 @@ class MetadataFilterDiagnostic(BaseModel):
             "UNKNOWN_FRONTMATTER_KEY でより早期に拒否される — 本フラグは防衛的な冗長化)。"
         ),
     )
+    value_type: str | None = Field(
+        default=None,
+        description=(
+            "このキーで観測された値の推論型 (FrontmatterKeyInfo.value_type と同じ enum: "
+            "string / number / boolean / array / object / mixed)。"
+            "型不一致で 0 件になっていないか (例: archived が boolean なのに "
+            '"1"/"0" で渡そうとしている) のヒントに使う。key_present_in_index=false の'
+            "ときは null。"
+        ),
+    )
     observed_values_sample: list[str] = Field(
         default_factory=list,
         description=(

--- a/src/vault_search/schemas.py
+++ b/src/vault_search/schemas.py
@@ -14,6 +14,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from .schema_meta import FrontmatterValueType
+
 # ---------------------------------------------------------------------------
 # Search responses
 # ---------------------------------------------------------------------------
@@ -67,26 +69,26 @@ class MetadataFilterDiagnostic(BaseModel):
     key_present_in_index: bool = Field(
         description=(
             "このキーを持つノートが index 内に 1 件以上あるか。"
-            "false のときは typo の可能性が高い (ただし通常ルートでは unknown key は "
-            "UNKNOWN_FRONTMATTER_KEY でより早期に拒否される — 本フラグは防衛的な冗長化)。"
+            "通常ルートでは unknown key は UNKNOWN_FRONTMATTER_KEY で parse 段階で拒否される"
+            "ため、diagnostics が返る時点で常に true。将来 validation が relax された際の"
+            "forward-compat + エージェント向けの意味論明示のために残している。"
         ),
     )
-    value_type: str | None = Field(
-        default=None,
+    value_type: FrontmatterValueType = Field(
         description=(
             "このキーで観測された値の推論型 (FrontmatterKeyInfo.value_type と同じ enum: "
             "string / number / boolean / array / object / mixed)。"
             "型不一致で 0 件になっていないか (例: archived が boolean なのに "
-            '"1"/"0" で渡そうとしている) のヒントに使う。key_present_in_index=false の'
-            "ときは null。"
+            '"1"/"0" で渡そうとしている) のヒントに使う。'
         ),
     )
     observed_values_sample: list[str] = Field(
         default_factory=list,
         description=(
             "このキーで実際に観測されている値のサンプル (頻度降順、最大 5 件)。"
-            "正規化済みの文字列表現。配列型 frontmatter は JSON 配列表現で入る "
-            "(FrontmatterKeyInfo.sample_values と同じ)。"
+            "正規化済みの文字列表現。配列型 frontmatter は配列全体の JSON 文字列表現で入る "
+            '(例: categories=[work,urgent] の sample は \'["work", "urgent"]\' — '
+            "要素 'work' 単体のサンプルではない。FrontmatterKeyInfo.sample_values と同じ契約)。"
             "ここに含まれない値を filter に指定していた場合、typo または存在しない値。"
         ),
     )

--- a/src/vault_search/schemas.py
+++ b/src/vault_search/schemas.py
@@ -52,6 +52,36 @@ class SearchHit(BaseModel):
     )
 
 
+class MetadataFilterDiagnostic(BaseModel):
+    """0 件 + metadata_filter 指定時の per-key 診断情報 (Issue #80).
+
+    `total==0` かつ `metadata_filter` が指定されている場合のみ
+    `SearchResponse.metadata_filter_diagnostics` として返る。エージェントが
+    「キーは存在するが値が全件不一致」なのか「そもそもキーが無い」のかを
+    区別できるよう、観測された値サンプルとキー存在フラグを添える。
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str = Field(description="フィルタに使われた frontmatter キー")
+    key_present_in_index: bool = Field(
+        description=(
+            "このキーを持つノートが index 内に 1 件以上あるか。"
+            "false のときは typo の可能性が高い (ただし通常ルートでは unknown key は "
+            "UNKNOWN_FRONTMATTER_KEY でより早期に拒否される — 本フラグは防衛的な冗長化)。"
+        ),
+    )
+    observed_values_sample: list[str] = Field(
+        default_factory=list,
+        description=(
+            "このキーで実際に観測されている値のサンプル (頻度降順、最大 5 件)。"
+            "正規化済みの文字列表現。配列型 frontmatter は JSON 配列表現で入る "
+            "(FrontmatterKeyInfo.sample_values と同じ)。"
+            "ここに含まれない値を filter に指定していた場合、typo または存在しない値。"
+        ),
+    )
+
+
 class SearchResponse(BaseModel):
     """`vault_search` ツールのレスポンス."""
 
@@ -84,6 +114,15 @@ class SearchResponse(BaseModel):
     results: list[SearchHit] = Field(
         default_factory=list,
         description="limit/offset でスライスされた検索ヒット一覧",
+    )
+    metadata_filter_diagnostics: list[MetadataFilterDiagnostic] | None = Field(
+        default=None,
+        description=(
+            "Issue #80: total==0 かつ metadata_filter 指定時のみ付与される per-key 診断。"
+            "各要素は filter に使われたキーの存在可否と観測値サンプルを示し、"
+            "エージェントが「値が全件不一致」と「キー欠落」を区別できるようにする。"
+            "それ以外の場合 (ヒットあり or filter 無し) は null。"
+        ),
     )
 
 

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -116,10 +116,16 @@ def vault_search(
         ``truncated`` は結果配列が内部上限 (現在 500 件) で打ち切られた状態を
         true で示す。true のとき offset>=500 は空配列を返すため、クエリを絞るか
         tags / folder / metadata_filter を追加して 500 件以下に収めてから
-        ページングを続けること。構造の詳細 (SearchResponse の rich JSON Schema)
-        は ``schema://tools`` リソースの ``tools.vault_search.output_schema``
-        を参照。ツール戻り型を Union にすると FastMCP が structured content を
-        ``{"result": ...}`` でラップしてしまうため、dict 統一で回避している。
+        ページングを続けること。
+        ``total==0`` かつ ``metadata_filter`` 指定時のみ、追加で
+        ``metadata_filter_diagnostics`` (list) を含む。各要素は filter に使った
+        キーの存在可否 (``key_present_in_index``) と観測値サンプル
+        (``observed_values_sample``) を示し、「値が全件不一致」か「キー欠落」か
+        をエージェントが区別する助けになる (Issue #80)。
+        構造の詳細 (SearchResponse の rich JSON Schema) は ``schema://tools``
+        リソースの ``tools.vault_search.output_schema`` を参照。ツール戻り型を
+        Union にすると FastMCP が structured content を ``{"result": ...}`` で
+        ラップしてしまうため、dict 統一で回避している。
     """
     validate_pagination(limit, offset)
     raw = _get_index().search(
@@ -135,7 +141,8 @@ def vault_search(
         total=raw["total"],
         truncated=raw.get("truncated", False),
         results=[SearchHit(**hit) for hit in raw["results"]],
-    ).model_dump(mode="json")
+        metadata_filter_diagnostics=raw.get("metadata_filter_diagnostics"),
+    ).model_dump(mode="json", exclude_none=True)
 
 
 @mcp.tool(annotations=TOOL_SPECS["vault_get_note"].annotations)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1129,3 +1129,27 @@ def test_metadata_filter_diagnostics_ne_operator(
     assert len(diag) == 1
     assert diag[0]["key"] == "status"
     assert diag[0]["observed_values_sample"] == ["active"]
+
+
+def test_metadata_filter_diagnostics_value_type_included(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """diagnostics に value_type を含める (Issue #80 cause #3: 型不一致の早期気付き).
+
+    frontmatter は index 時に文字列に正規化されるため、bool や int の値を
+    filter する際も ``"true"`` / ``"5"`` 形式で渡す必要がある。observed 値が
+    ``"true"/"false"`` で value_type が ``"boolean"`` と判れば、エージェントが
+    型不一致で silent miss しているケースを自己発見できる。
+    """
+    _root, idx = vault_builder(
+        {
+            "a.md": "---\narchived: true\n---\nbody\n",
+            "b.md": "---\narchived: false\n---\nbody\n",
+        }
+    )
+    # 意図的にヒットしない値を指定して 0 件を引く
+    res = idx.search("", metadata_filter={"archived": "notabool"})
+    assert res["total"] == 0
+    diag = res["metadata_filter_diagnostics"]
+    assert len(diag) == 1
+    assert diag[0]["value_type"] == "boolean"

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1075,20 +1075,21 @@ def test_metadata_filter_diagnostics_attached_on_zero_total(
 def test_metadata_filter_diagnostics_multiple_keys(
     vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
 ) -> None:
-    """複数キーの AND で 0 件になったとき、全キーの diagnostics が並ぶ."""
+    """複数キーの AND で 0 件になったとき、全キーの diagnostics が並び、
+    各キーの observed_values_sample は頻度降順 (同頻度は辞書順) で pin される."""
     _root, idx = vault_builder(_META_FILTER_NOTES)
     # status=active かつ priority=medium の組合せは存在しない (medium は draft のみ)
     res = idx.search("", metadata_filter={"status": "active", "priority": "medium"})
     assert res["total"] == 0
     diag = res["metadata_filter_diagnostics"]
-    keys = {entry["key"] for entry in diag}
-    assert keys == {"status", "priority"}
-    for entry in diag:
-        assert entry["key_present_in_index"] is True
-        assert isinstance(entry["observed_values_sample"], list)
-        assert entry["observed_values_sample"], (
-            f"{entry['key']}: observed_values_sample must be non-empty when key present in index"
-        )
+    by_key = {entry["key"]: entry for entry in diag}
+    assert set(by_key) == {"status", "priority"}
+    # status: active (2) / draft (1) → 頻度降順で ["active", "draft"]
+    assert by_key["status"]["key_present_in_index"] is True
+    assert by_key["status"]["observed_values_sample"] == ["active", "draft"]
+    # priority: high (1) / low (1) / medium (1) → 同頻度、辞書順 ["high", "low", "medium"]
+    assert by_key["priority"]["key_present_in_index"] is True
+    assert by_key["priority"]["observed_values_sample"] == ["high", "low", "medium"]
 
 
 def test_metadata_filter_diagnostics_absent_when_results_non_empty(
@@ -1155,3 +1156,51 @@ def test_metadata_filter_diagnostics_value_type_included(
     diag = res["metadata_filter_diagnostics"]
     assert len(diag) == 1
     assert diag[0]["value_type"] == "boolean"
+
+
+def test_metadata_filter_diagnostics_on_cache_hit(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """Tier 0 cache hit 経路でも diagnostics が付与される.
+
+    初回呼び出しは Tier 2 (FTS5) で総件数 0 を cache に格納し、
+    2 回目の同一クエリは Tier 0 で cache から返す。indexer.search() の
+    cache hit 分岐でも ``_build_metadata_filter_diagnostics`` を通すことを
+    lock-in し、将来 Tier 0/1 branch で silent に diagnostics が落ちた場合の
+    regression を検知する。
+    """
+    _root, idx = vault_builder(_META_FILTER_NOTES)
+    filt = {"status": "nonexistent_value"}
+    first = idx.search("", metadata_filter=filt)
+    assert first["total"] == 0
+    assert first["tier"] == 2
+    assert "metadata_filter_diagnostics" in first
+
+    second = idx.search("", metadata_filter=filt)
+    assert second["total"] == 0
+    assert second["tier"] == 0, f"2 回目は Tier 0 cache hit になるはず (tier={second['tier']})"
+    assert "metadata_filter_diagnostics" in second, (
+        "Tier 0 cache hit 経路でも diagnostics が付与されるべき"
+    )
+    # 両 tier で同じ diagnostics を返す (cache は key_infos を参照しないので安定)
+    assert second["metadata_filter_diagnostics"] == first["metadata_filter_diagnostics"]
+
+
+def test_metadata_filter_diagnostics_with_non_empty_query(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """非空 FTS query + metadata_filter で 0 件のときも diagnostics が付く.
+
+    FTS term + filter の積集合で 0 件になるパターン。indexer.search() の
+    FTS 経路が filter 条件独立に diagnostics を emit することを確認する。
+    """
+    _root, idx = vault_builder(_META_FILTER_NOTES)
+    # alpha/beta/gamma は本文に "obsidian" を含まないのでヒット 0、
+    # かつ filter 条件も明示的に 0 件になるように指定
+    res = idx.search("obsidian", metadata_filter={"status": "nonexistent_value"})
+    assert res["total"] == 0
+    assert "metadata_filter_diagnostics" in res
+    diag = res["metadata_filter_diagnostics"]
+    assert len(diag) == 1
+    assert diag[0]["key"] == "status"
+    assert diag[0]["observed_values_sample"] == ["active", "draft"]

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1039,3 +1039,96 @@ def test_search_query_with_double_quote_does_not_raise(vault_index: VaultIndex) 
         raise AssertionError(f"FTS5 quote leaked as syntax error: {exc}") from exc
     # 結果の形式が壊れていないこと
     assert isinstance(res["results"], list)
+
+
+# ---------------------------------------------------------------------------
+# Issue #80: metadata_filter_diagnostics when total == 0
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_filter_diagnostics_attached_on_zero_total(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """0 件 + metadata_filter 指定時は diagnostics が付与される (Issue #80).
+
+    エージェントが「キーは存在するが値が全件不一致」なのか区別できるよう、
+    filter に使った各キーの observed_values_sample を添える。
+    """
+    _root, idx = vault_builder(_META_FILTER_NOTES)
+    # status キーは存在するが "nonexistent_value" は index 内のどの値とも不一致
+    res = idx.search("", metadata_filter={"status": "nonexistent_value"})
+    assert res["total"] == 0
+    assert "metadata_filter_diagnostics" in res, (
+        "0 件 + metadata_filter 指定時は metadata_filter_diagnostics が必要 (Issue #80)"
+    )
+    diag = res["metadata_filter_diagnostics"]
+    assert isinstance(diag, list) and len(diag) == 1
+    entry = diag[0]
+    assert entry["key"] == "status"
+    assert entry["key_present_in_index"] is True
+    # _META_FILTER_NOTES は status = active / active / draft を持つので観測値は {active, draft}
+    assert set(entry["observed_values_sample"]) == {"active", "draft"}
+
+
+def test_metadata_filter_diagnostics_multiple_keys(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """複数キーの AND で 0 件になったとき、全キーの diagnostics が並ぶ."""
+    _root, idx = vault_builder(_META_FILTER_NOTES)
+    # status=active かつ priority=medium の組合せは存在しない (medium は draft のみ)
+    res = idx.search(
+        "", metadata_filter={"status": "active", "priority": "medium"}
+    )
+    assert res["total"] == 0
+    diag = res["metadata_filter_diagnostics"]
+    keys = {entry["key"] for entry in diag}
+    assert keys == {"status", "priority"}
+    for entry in diag:
+        assert entry["key_present_in_index"] is True
+        assert isinstance(entry["observed_values_sample"], list)
+        assert entry["observed_values_sample"], (
+            f"{entry['key']}: observed_values_sample must be non-empty "
+            f"when key present in index"
+        )
+
+
+def test_metadata_filter_diagnostics_absent_when_results_non_empty(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """>0 件ヒット時は diagnostics を付けない (過剰なノイズを避ける)."""
+    _root, idx = vault_builder(_META_FILTER_NOTES)
+    res = idx.search("", metadata_filter={"status": "active"})
+    assert res["total"] > 0
+    assert "metadata_filter_diagnostics" not in res
+
+
+def test_metadata_filter_diagnostics_absent_without_metadata_filter(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """metadata_filter 未指定なら 0 件でも diagnostics は付けない."""
+    _root, idx = vault_builder(_META_FILTER_NOTES)
+    res = idx.search("queryThatMatchesNothingZZZ")
+    assert res["total"] == 0
+    assert "metadata_filter_diagnostics" not in res
+
+
+def test_metadata_filter_diagnostics_ne_operator(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """ne 演算で 0 件のときも diagnostics が付く.
+
+    全ノートが同じ値を持つ場合、`{ne: X}` で 0 件になる。
+    observed_values_sample が `[X]` だと「全件 X で絞れない」と気付ける。
+    """
+    _root, idx = vault_builder(
+        {
+            "a.md": "---\nstatus: active\n---\nbody\n",
+            "b.md": "---\nstatus: active\n---\nbody\n",
+        }
+    )
+    res = idx.search("", metadata_filter={"status": {"ne": "active"}})
+    assert res["total"] == 0
+    diag = res["metadata_filter_diagnostics"]
+    assert len(diag) == 1
+    assert diag[0]["key"] == "status"
+    assert diag[0]["observed_values_sample"] == ["active"]

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1066,8 +1066,10 @@ def test_metadata_filter_diagnostics_attached_on_zero_total(
     entry = diag[0]
     assert entry["key"] == "status"
     assert entry["key_present_in_index"] is True
-    # _META_FILTER_NOTES は status = active / active / draft を持つので観測値は {active, draft}
-    assert set(entry["observed_values_sample"]) == {"active", "draft"}
+    # _META_FILTER_NOTES は status = active (alpha,beta) / draft (gamma)。
+    # sample_values は頻度降順なので active → draft の順で並ぶ
+    # (FrontmatterKeyInfo.sample_values の契約を引き継ぐ)。
+    assert entry["observed_values_sample"] == ["active", "draft"]
 
 
 def test_metadata_filter_diagnostics_multiple_keys(

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1076,9 +1076,7 @@ def test_metadata_filter_diagnostics_multiple_keys(
     """複数キーの AND で 0 件になったとき、全キーの diagnostics が並ぶ."""
     _root, idx = vault_builder(_META_FILTER_NOTES)
     # status=active かつ priority=medium の組合せは存在しない (medium は draft のみ)
-    res = idx.search(
-        "", metadata_filter={"status": "active", "priority": "medium"}
-    )
+    res = idx.search("", metadata_filter={"status": "active", "priority": "medium"})
     assert res["total"] == 0
     diag = res["metadata_filter_diagnostics"]
     keys = {entry["key"] for entry in diag}
@@ -1087,8 +1085,7 @@ def test_metadata_filter_diagnostics_multiple_keys(
         assert entry["key_present_in_index"] is True
         assert isinstance(entry["observed_values_sample"], list)
         assert entry["observed_values_sample"], (
-            f"{entry['key']}: observed_values_sample must be non-empty "
-            f"when key present in index"
+            f"{entry['key']}: observed_values_sample must be non-empty when key present in index"
         )
 
 

--- a/tests/test_mcp_wrapping.py
+++ b/tests/test_mcp_wrapping.py
@@ -146,6 +146,29 @@ def test_mcp_vault_recent_full_response_validates(vault_index: VaultIndex) -> No
     jsonschema.validate(structured, schema)
 
 
+def test_mcp_vault_search_diagnostics_validates_zero_total(
+    vault_index: VaultIndex,
+) -> None:
+    """Issue #80: 0 件 + metadata_filter 時の diagnostics 付き structuredContent が
+    lowlevel の jsonschema.validate を通る.
+
+    FastMCP の call_tool 経路だけでは MCP lowlevel の
+    ``jsonschema.validate(structured, outputSchema)`` をバイパスする
+    (.claude/rules/fastmcp-gotchas.md 「テスト経路」)。本テストは
+    diagnostics list を持つ response shape が injected outputSchema に
+    適合することを明示検証し、``MetadataFilterDiagnostic`` の JSON schema
+    drift を検知する。
+    """
+    # Welcome.md は status=active を持つ → 値を外して 0 件 + diagnostics を誘発
+    _content, structured = _call_tool(
+        "vault_search", {"query": "", "metadata_filter": {"status": "nonexistent"}}
+    )
+    assert structured["total"] == 0
+    assert "metadata_filter_diagnostics" in structured
+    schema = _get_tool_output_schema("vault_search")
+    jsonschema.validate(structured, schema)
+
+
 def test_vault_reindex_structured_content_not_wrapped(vault_index: VaultIndex) -> None:
     """vault_reindex の structured content が ``result`` でラップされない.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -155,6 +155,35 @@ def test_mcp_tool_vault_search_truncated_true_path(
     SearchResponse.model_validate(res)
 
 
+def test_mcp_tool_vault_search_diagnostics_on_zero_total(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #80: MCP tool の戻り dict が metadata_filter_diagnostics を含む.
+
+    server 層が indexer からの diagnostics を SearchResponse に通過させ、
+    SearchResponse (extra='forbid') が schema drift せず受理できることを確認する。
+    """
+    vault = tmp_path / "diag_vault"
+    vault.mkdir()
+    (vault / "a.md").write_text("---\nstatus: active\n---\nbody\n", encoding="utf-8")
+    (vault / "b.md").write_text("---\nstatus: draft\n---\nbody\n", encoding="utf-8")
+    idx = VaultIndex(vault, db_path=tmp_path / "diag.db")
+    idx.build_index()
+    monkeypatch.setattr(server_mod, "_index", idx)
+
+    fn = _fn(server_mod.vault_search)
+    res = fn("", metadata_filter={"status": "nonexistent"})
+    assert res["total"] == 0
+    assert "metadata_filter_diagnostics" in res
+    diag = res["metadata_filter_diagnostics"]
+    assert len(diag) == 1
+    assert diag[0]["key"] == "status"
+    assert diag[0]["key_present_in_index"] is True
+    assert set(diag[0]["observed_values_sample"]) == {"active", "draft"}
+    # SearchResponse として再構成可能 (extra='forbid' が drift しない)
+    SearchResponse.model_validate(res)
+
+
 def test_mcp_tool_vault_get_note_missing(vault_index: VaultIndex) -> None:
     """存在しないパスでは NoteNotFoundError を送出する (旧 error dict から変更)."""
     fn = _fn(server_mod.vault_get_note)


### PR DESCRIPTION
## Summary

Issue #80: `vault_search` で `metadata_filter` 指定 + `total==0` のとき、エージェントが「値が全件不一致」「キーの型不一致」を区別できなかった問題を解消する。
レスポンスに optional `metadata_filter_diagnostics` を追加し、filter に使われた各キーの `key_present_in_index` / `value_type` / `observed_values_sample` を返す。

- 付与は `total==0` かつ `metadata_filter` 指定時のみ。その他の経路 (ヒットあり / filter 無し) では `exclude_none=True` で wire から落として旧来と同じ形で返す
- 既存の `FrontmatterKeyInfo` キャッシュから引くので追加 SQL / I/O はゼロ
- 値は FrontmatterKeyInfo.sample_values と同じ「頻度降順・最大5件」契約
- `value_type` は `FrontmatterValueType = Literal[...]` エイリアス経由で `FrontmatterKeyInfo` と同じ enum を共有

## Scope 判断

- **did_you_mean は意図的に入れていない**: 上流で `UNKNOWN_FRONTMATTER_KEY` ValidationError が fire するので typo (Issue 原因 #1) は到達前に弾かれる。diagnostics は「値が不一致」経路に特化
- **配列型 frontmatter の sample は follow-up issue に分離**: `categories: [work, urgent]` の sample は配列全体の JSON 文字列 (`'["work", "urgent"]'`) になる既存 `FrontmatterKeyInfo` 契約を踏襲。element-level に変える UX 改善は #190 として分離

## Review-loop

**Round 1** (Opus 1 reviewer, agent DX 軸): minor 1 件 (value_type 追加) を commit fda741a / 699a43e で取り込み。
**Round 2** (Opus 2 reviewer parallel, schema/contract + testing/edge-case 軸):

- Testing reviewer blocker 2 件 → `Refactor:` dbe019d + `Test:` 7b4aaba で対応
  - Tier 0/1 cache-hit 経路の untested → 2-call regression test 追加
  - misleading staleness docstring → 削除 (実際には `_invalidate_caches()` で同時 invalidate されるので非対称は発生しない)
- Schema reviewer nit 対応
  - `value_type: str | None` → `FrontmatterValueType` (Literal enum) に tighten
  - lowlevel `jsonschema.validate` の regression guard を `test_mcp_wrapping.py` に追加
- 残 nit (dead `False` branch / loose multiple_keys assertion) も解消
- 配列型 sample UX は follow-up issue #190 に分離

## Commits

- `Red:` (7bc82f9) metadata_filter_diagnostics on zero-total search
- `Green:` (02334a3) attach metadata_filter_diagnostics on zero-total search
- `Red:` (fda741a) include value_type in metadata_filter_diagnostics (round 1)
- `Green:` (699a43e) add value_type + cache-hit comment + frequency-order pin (round 1)
- `Refactor:` (dbe019d) drop dead branch, Literal value_type, drop misleading comment (round 2)
- `Test:` (7b4aaba) cache-hit / non-empty query / jsonschema.validate regression guards (round 2)

## Test plan

- [x] 新規 10 テスト pass (`tests/test_indexer.py` 8 + `tests/test_server.py` 1 + `tests/test_mcp_wrapping.py` 1)
- [x] 既存 524 テスト regressions なし (total 534 pass)
- [x] `ruff check` / `ruff format` クリーン
- [x] Tier 2 FTS5 経路 + Tier 0 cache-hit 経路 両方で diagnostics 付与を pin
- [x] 非空 query 経路で diagnostics 付与を pin
- [x] MCP lowlevel の `jsonschema.validate(structured, outputSchema)` で new shape 適合性を検証
- [x] `test_schema_resource.py` / `test_mcp_wrapping.py` が outputSchema injection 経路で pass

## Follow-up

- #190: 配列型 frontmatter の observed_values_sample を element-level に

https://claude.ai/code/session_01Xuv1bo15zifouVjE4xB7QR