### PR TITLE
Feat: schema://tools top-level metadata 拡張 (#38, #179)

### DIFF
--- a/src/vault_search/resources.py
+++ b/src/vault_search/resources.py
@@ -3,6 +3,11 @@
 `mcp_contract.py` は tool 契約 (schema 生成) に専念し、実データを wire 形式へ
 serialize する責務は本 module が担う (Issue #184)。`schema://tools` resource
 handler は本 module の関数を呼び出すだけ。
+
+Top-level metadata (version / overview / recommended_flow / errors /
+frontmatter_key_info_schema) も本 module の module-level 定数として集約する
+(Issue #38 / #179)。各定数は import 時に 1 度だけ評価され、以降は毎回同じ
+オブジェクトが payload に挿入される。
 """
 
 from __future__ import annotations
@@ -10,10 +15,98 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
+from .exceptions import NoteNotFoundError
 from .mcp_contract import TOOL_ENTRIES
 from .schema_meta import FrontmatterKeyInfo
 
 __all__ = ["build_schema_payload"]
+
+
+# ---------------------------------------------------------------------------
+# schema://tools payload の top-level metadata 定数 (#38 / #179)
+# ---------------------------------------------------------------------------
+#
+# これらは schema://tools resource payload 形式自身のメタデータであり、各 tool
+# の入出力契約バージョン (tools[name].input_schema / output_schema) とは別の
+# 層。payload shape を破壊する変更 (key rename / 型変更) を入れる際に手動で
+# 更新する (自動 derive しない)。
+_SCHEMA_VERSION: str = "1.0"
+
+_OVERVIEW: str = (
+    "vault-search-mcp は Obsidian Vault を構造化された知識ベースとして公開する MCP サーバー。"
+    "SQLite FTS5 trigram インデックスで日英両対応の全文検索を提供し、note 単位の frontmatter を"
+    "機械可読な値として metadata_filter 経由で絞り込める。\n\n"
+    "エージェントはまず本 schema://tools resource を読み、利用可能な tool 一覧、"
+    "frontmatter_keys の型・値例、代表エラーの構造を把握してから recommended_flow の順で "
+    "tool を呼び出すことが推奨される。全スカラー frontmatter 値は index 時に文字列へ"
+    "正規化される (例: int 5 → '5'、date 2024-01-15 → '2024-01-15'、"
+    "bool true → 'true')。vault 本体を変更するのは vault_reindex のみで、他は全て read-only。"
+)
+
+# Tool 名は TOOL_SPECS 経由で tests/test_schema_resource.py の drift guard が照合する。
+# schema://tools resource 自身は step 0 (overview の冒頭) で触れる想定で本 flow には含めない。
+_RECOMMENDED_FLOW: list[dict[str, Any]] = [
+    {
+        "step": 1,
+        "tool": "vault_folders",
+        "purpose": "フォルダ構造を列挙して後続検索の scope を決める",
+    },
+    {
+        "step": 2,
+        "tool": "vault_tags",
+        "purpose": "タグ一覧を取得して metadata_filter の候補を把握する",
+    },
+    {
+        "step": 3,
+        "tool": "vault_search",
+        "purpose": "query と tags / folder / metadata_filter を組み合わせて全文検索する",
+    },
+    {
+        "step": 4,
+        "tool": "vault_get_note",
+        "purpose": "検索で見つけた path を指定して note 本文を取得する",
+    },
+    {
+        "step": 5,
+        "tool": "vault_recent",
+        "purpose": "最近編集された note を取得したい場合の補助",
+    },
+    {
+        "step": 6,
+        "tool": "vault_stats",
+        "purpose": "index の健全性と note 数を確認する",
+    },
+    {
+        "step": 7,
+        "tool": "vault_reindex",
+        "purpose": "watcher 外の変更や破損があった場合のみ index を再構築する (通常不要)",
+    },
+]
+
+# error_code は NoteNotFoundError などの live class 属性を参照して drift を防ぐ
+# (tests/test_schema_resource.py::test_errors_error_code_matches_live_exception_class)。
+_ERRORS: dict[str, dict[str, str]] = {
+    "NoteNotFoundError": {
+        "error_code": NoteNotFoundError.error_code,
+        "description": (
+            "指定された path の note が index に存在しない。"
+            "vault_search や vault_folders で path を先に確認してから再試行する。"
+        ),
+        "example": "Note not found: Projects/foo.md",
+    },
+    "ValidationError": {
+        "error_code": "VALIDATION_ERROR",
+        "description": (
+            "エージェント入力の検証失敗 (識別子不正 / 未知の frontmatter key / "
+            "ページング範囲外 など)。hint や did_you_mean で自己修正ヒントを付けて返す。"
+        ),
+        "example": "Unknown frontmatter key 'statu'; did you mean: status?",
+    },
+}
+
+# Pydantic v2 は同一モデルに対する model_json_schema() を内部キャッシュするが、
+# ここでも import 時に 1 度だけ評価して以降 dict instance を共有する。
+_FRONTMATTER_KEY_INFO_SCHEMA: dict[str, Any] = FrontmatterKeyInfo.model_json_schema()
 
 
 def build_schema_payload(
@@ -26,6 +119,11 @@ def build_schema_payload(
     resource layer (本 module) の責務。
     """
     return {
+        "version": _SCHEMA_VERSION,
+        "overview": _OVERVIEW,
+        "recommended_flow": _RECOMMENDED_FLOW,
+        "errors": _ERRORS,
         "tools": TOOL_ENTRIES,
         "frontmatter_keys": [item.model_dump(mode="json") for item in frontmatter_keys],
+        "frontmatter_key_info_schema": _FRONTMATTER_KEY_INFO_SCHEMA,
     }

--- a/src/vault_search/resources.py
+++ b/src/vault_search/resources.py
@@ -8,6 +8,30 @@ Top-level metadata (version / overview / recommended_flow / errors /
 frontmatter_key_info_schema) も本 module の module-level 定数として集約する
 (Issue #38 / #179)。各定数は import 時に 1 度だけ評価され、以降は毎回同じ
 オブジェクトが payload に挿入される。
+
+## Read-only 契約
+
+``build_schema_payload`` が返す dict は ``_RECOMMENDED_FLOW`` / ``_ERRORS`` /
+``TOOL_ENTRIES`` 等の module-level 定数への直接参照を含む。呼出側は返り値を
+**read-only として扱うこと** — mutate すると以降の呼出および他セッションに
+波及する。MCP resource 経路は即座に JSON serialize するためこの制約で実害は
+出ないが、future 拡張 (test や非 MCP 呼出) での罠を避けるため明記する。
+
+## 言語方針
+
+``_OVERVIEW`` / ``_RECOMMENDED_FLOW[].purpose`` / ``_ERRORS[].description`` は
+ja-JP で固定。field 名 (``version`` / ``step`` / ``tool`` / ``purpose`` /
+``error_code`` 等) のみ英語。多言語対応は i18n frontmatter (例:
+``overview.en`` / ``overview.ja`` 構造) が必要になった段階で defer する。
+
+## Agent 向け prose と実装の drift guard
+
+machine-readable なキー (``tool`` / ``error_code``) は test 層で live 参照に
+よる drift guard を入れている (``test_schema_resource.py`` 参照)。一方 prose
+部 (``overview`` / ``purpose`` / ``description``) の内容は implementation
+との drift guard を意図的に入れていない — test が fragile 化するためで、
+agent 向け文言は「単一 SoT の実装記述」ではなく「自然言語ガイド」として保守
+する前提。
 """
 
 from __future__ import annotations
@@ -18,6 +42,7 @@ from typing import Any
 from .exceptions import NoteNotFoundError
 from .mcp_contract import TOOL_ENTRIES
 from .schema_meta import FrontmatterKeyInfo
+from .validation import ValidationError
 
 __all__ = ["build_schema_payload"]
 
@@ -83,8 +108,15 @@ _RECOMMENDED_FLOW: list[dict[str, Any]] = [
     },
 ]
 
-# error_code は NoteNotFoundError などの live class 属性を参照して drift を防ぐ
+# error_code は live class 属性を参照して drift を防ぐ
 # (tests/test_schema_resource.py::test_errors_error_code_matches_live_exception_class)。
+#
+# MCP wire format 注記: FastMCP は例外を ToolError でラップするため、agent が
+# 実際に受け取る文字列は 'Error executing tool <tool_name>: <raw_message>' 形式。
+# `example` 値は raw_message 部分のみを示す (.claude/rules/fastmcp-gotchas.md
+# の「Tool error — 構造化属性の wire 消失」節参照)。`error_code` 属性は
+# 現状の MCP wire には含まれないため、agent は error_code ベースの programmatic
+# 分岐ではなく message 文字列を見ることになる。
 _ERRORS: dict[str, dict[str, str]] = {
     "NoteNotFoundError": {
         "error_code": NoteNotFoundError.error_code,
@@ -95,7 +127,7 @@ _ERRORS: dict[str, dict[str, str]] = {
         "example": "Note not found: Projects/foo.md",
     },
     "ValidationError": {
-        "error_code": "VALIDATION_ERROR",
+        "error_code": ValidationError.error_code,
         "description": (
             "エージェント入力の検証失敗 (識別子不正 / 未知の frontmatter key / "
             "ページング範囲外 など)。hint や did_you_mean で自己修正ヒントを付けて返す。"
@@ -124,6 +156,8 @@ def build_schema_payload(
         "recommended_flow": _RECOMMENDED_FLOW,
         "errors": _ERRORS,
         "tools": TOOL_ENTRIES,
-        "frontmatter_keys": [item.model_dump(mode="json") for item in frontmatter_keys],
+        # frontmatter_key_info_schema を frontmatter_keys より前に置くことで
+        # agent が value_type の許容値 enum を先に読んでから実データを解釈できる。
         "frontmatter_key_info_schema": _FRONTMATTER_KEY_INFO_SCHEMA,
+        "frontmatter_keys": [item.model_dump(mode="json") for item in frontmatter_keys],
     }

--- a/tests/test_schema_resource.py
+++ b/tests/test_schema_resource.py
@@ -414,9 +414,6 @@ def test_payload_has_version_key(vault_index: VaultIndex) -> None:
     assert payload.get("version") == _SCHEMA_VERSION, (
         f"payload['version']={payload.get('version')!r} vs _SCHEMA_VERSION={_SCHEMA_VERSION!r}"
     )
-    assert isinstance(payload["version"], str) and payload["version"].strip(), (
-        f"version must be non-empty str, got: {payload['version']!r}"
-    )
 
 
 def test_payload_has_overview_with_entry_point_guidance(vault_index: VaultIndex) -> None:
@@ -424,8 +421,9 @@ def test_payload_has_overview_with_entry_point_guidance(vault_index: VaultIndex)
 
     文字数検証は brittle なので、**agent が overview から読み取るべき contractual
     invariant** をテストする: 「schema://tools resource を入り口とすること」と
-    「recommended_flow の参照」を勧める旨のキーワードが含まれる。
-    文言の細かい改善で壊れないよう複数候補の OR 判定とする。
+    「recommended_flow の参照」の **両方が必須** (AND 判定)。両キーワードが
+    overview に揃って初めて agent が「自分が読んでいる resource 名」と「推奨
+    呼出順序の所在」を一度に把握できる。
     """
     from vault_search.resources import build_schema_payload
 

--- a/tests/test_schema_resource.py
+++ b/tests/test_schema_resource.py
@@ -401,50 +401,55 @@ def test_read_resource_unknown_uri_raises_error(
 
 
 def test_payload_has_version_key(vault_index: VaultIndex) -> None:
-    """payload に schema version が含まれ、非空文字列であること.
+    """payload["version"] が module の _SCHEMA_VERSION 定数と一致すること.
 
     schema://tools resource payload 自身のバージョン (各 tool 契約のバージョン
-    ではない)。改変検知用に agent 側で pin できる。
+    ではない)。agent が改変検知のために pin する対象。定数を直接 import して
+    test 側にリテラルを置かないことで drift する唯一の SoT を resources.py に
+    一本化する。
     """
-    from vault_search.resources import build_schema_payload
+    from vault_search.resources import _SCHEMA_VERSION, build_schema_payload
 
     payload = build_schema_payload(vault_index.list_frontmatter_keys())
-    assert "version" in payload, f"'version' key missing from payload: keys={list(payload)}"
-    version = payload["version"]
-    assert isinstance(version, str) and version.strip(), (
-        f"version must be non-empty str, got: {version!r}"
+    assert payload.get("version") == _SCHEMA_VERSION, (
+        f"payload['version']={payload.get('version')!r} vs _SCHEMA_VERSION={_SCHEMA_VERSION!r}"
+    )
+    assert isinstance(payload["version"], str) and payload["version"].strip(), (
+        f"version must be non-empty str, got: {payload['version']!r}"
     )
 
 
-def test_payload_has_overview_japanese_prose(vault_index: VaultIndex) -> None:
-    """payload に overview (日本語 1-2 段落) が含まれること.
+def test_payload_has_overview_with_entry_point_guidance(vault_index: VaultIndex) -> None:
+    """payload["overview"] が初見 agent へのエントリ導線を案内すること.
 
-    既存の tool description 群と一貫して日本語で書く (codebase tone 維持)。
-    field name は英語、prose は日本語という #38 Issue 方針に従う。
+    文字数検証は brittle なので、**agent が overview から読み取るべき contractual
+    invariant** をテストする: 「schema://tools resource を入り口とすること」と
+    「recommended_flow の参照」を勧める旨のキーワードが含まれる。
+    文言の細かい改善で壊れないよう複数候補の OR 判定とする。
     """
     from vault_search.resources import build_schema_payload
 
     payload = build_schema_payload(vault_index.list_frontmatter_keys())
     assert "overview" in payload, f"'overview' key missing: keys={list(payload)}"
     overview = payload["overview"]
-    assert isinstance(overview, str), f"overview must be str, got {type(overview).__name__}"
-    assert len(overview) >= 100, (
-        f"overview should be 1-2 paragraphs (>=100 chars), got {len(overview)}"
+    assert isinstance(overview, str) and overview.strip(), (
+        f"overview must be non-empty str, got: {overview!r}"
     )
-    # 日本語文字が含まれていること (ひらがな / カタカナ / 漢字のいずれか 1 文字以上)
-    has_japanese = any(
-        "\u3040" <= ch <= "\u309f"  # ひらがな
-        or "\u30a0" <= ch <= "\u30ff"  # カタカナ
-        or "\u4e00" <= ch <= "\u9fff"  # CJK 統合漢字
-        for ch in overview
+    # 初回エントリ導線としての schema://tools 自身への言及
+    assert "schema://tools" in overview, (
+        f"overview should mention 'schema://tools' as entry point: {overview[:80]!r}..."
     )
-    assert has_japanese, f"overview should contain Japanese characters: {overview[:50]!r}..."
+    # 推奨 flow への参照 (recommended_flow key の存在を agent に伝えるため)
+    assert "recommended_flow" in overview, (
+        f"overview should reference 'recommended_flow' top-level key: {overview[:80]!r}..."
+    )
 
 
 def test_payload_has_recommended_flow_structure(vault_index: VaultIndex) -> None:
     """payload["recommended_flow"] が step/tool/purpose キーを持つ list[dict].
 
-    step は 1-based int (エージェントが "step 3 から" と言及しやすい可読性のため)。
+    step は 1-based int で **連番かつ重複なし** (エージェントが "step 3 から"
+    と言及しやすい可読性のため)。重複や 0 や 9 が混入していたら即検知する。
     """
     from vault_search.resources import build_schema_payload
 
@@ -469,6 +474,11 @@ def test_payload_has_recommended_flow_structure(vault_index: VaultIndex) -> None
         assert isinstance(step["purpose"], str) and step["purpose"], (
             f"purpose must be non-empty str, got {step['purpose']!r}"
         )
+
+    step_numbers = [step["step"] for step in flow]
+    assert step_numbers == list(range(1, len(flow) + 1)), (
+        f"step numbers must be consecutive 1-based ints with no gaps/duplicates, got {step_numbers}"
+    )
 
 
 def test_recommended_flow_tool_names_in_tool_specs(vault_index: VaultIndex) -> None:
@@ -517,10 +527,12 @@ def test_errors_error_code_matches_live_exception_class(vault_index: VaultIndex)
 
     ErrorCode Literal の drift をテスト層で pin する (exceptions.py の rename や
     code 変更時に即検知)。Refactor で import-time assert を置く代わりに runtime
-    テストで吸収する。
+    テストで吸収する。NoteNotFoundError と ValidationError 両方とも class
+    attribute (default error_code) を持つので live class 比較で対称化する。
     """
     from vault_search.exceptions import NoteNotFoundError
     from vault_search.resources import build_schema_payload
+    from vault_search.validation import ValidationError as VE
 
     payload = build_schema_payload(vault_index.list_frontmatter_keys())
     errors = payload["errors"]
@@ -530,16 +542,10 @@ def test_errors_error_code_matches_live_exception_class(vault_index: VaultIndex)
         f"payload={errors['NoteNotFoundError']['error_code']!r} "
         f"vs live={NoteNotFoundError.error_code!r}"
     )
-    # ValidationError は instance-level の default で classvar を持たないため
-    # ErrorCode Literal 集合に含まれていることのみ確認
-    from typing import get_args
-
-    from vault_search.exceptions import ErrorCode
-
-    allowed_codes = set(get_args(ErrorCode))
-    assert errors["ValidationError"]["error_code"] in allowed_codes, (
-        f"ValidationError error_code {errors['ValidationError']['error_code']!r} "
-        f"not in ErrorCode Literal: {allowed_codes}"
+    assert errors["ValidationError"]["error_code"] == VE.error_code, (
+        f"ValidationError error_code drifted: "
+        f"payload={errors['ValidationError']['error_code']!r} "
+        f"vs live={VE.error_code!r}"
     )
 
 
@@ -589,25 +595,8 @@ def test_frontmatter_key_info_schema_pins_value_type_enum(vault_index: VaultInde
     )
 
 
-def test_read_resource_exposes_top_level_metadata(
-    vault_index: VaultIndex, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """read_resource("schema://tools") JSON に top-level metadata が含まれること.
-
-    build_schema_payload の直接呼び出しだけでなく、FastMCP の JSON round-trip
-    (resource handler → pydantic → JSON serialize) でも新 keys が保持されるこ
-    とを担保する。
-    """
-    from vault_search import server as server_mod
-
-    monkeypatch.setattr(server_mod, "_index", vault_index)
-
-    contents = asyncio.run(server_mod.mcp.read_resource("schema://tools"))
-    items = list(contents)
-    payload = json.loads(items[0].content)
-
-    for key in ("version", "overview", "recommended_flow", "errors", "frontmatter_key_info_schema"):
-        assert key in payload, f"'{key}' missing from read_resource payload: keys={list(payload)}"
-    assert payload["version"] == "1.0", f"version mismatch: {payload['version']!r}"
-    assert isinstance(payload["recommended_flow"], list)
-    assert isinstance(payload["errors"], dict)
+# NOTE: read_resource 経路の JSON round-trip 検証は
+# `test_read_resource_schema_tools_returns_payload` (上方) が
+# `payload == expected` の strict 等値で完全カバーしているため、新 top-level
+# keys 専用の重複テストは設けない (C-R5)。新 keys は build_schema_payload に
+# 追加された時点で expected も自動的に変わるため drift しない設計。

--- a/tests/test_schema_resource.py
+++ b/tests/test_schema_resource.py
@@ -388,3 +388,226 @@ def test_read_resource_unknown_uri_raises_error(
     assert "unknown" in str(exc_info.value).lower() or "resource" in str(exc_info.value).lower(), (
         f"expected error message to mention resource or unknown, got: {exc_info.value}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #38 / #179: schema://tools top-level metadata
+# ---------------------------------------------------------------------------
+#
+# エージェントが初回接続時に overview / recommended_flow / errors を読むことで
+# tool description 全体を context に入れずに済むようにする (B2.4)。
+# #179 は FrontmatterKeyInfo の JSON Schema を公開して value_type の許容値を
+# 機械検証可能にする (B4)。
+
+
+def test_payload_has_version_key(vault_index: VaultIndex) -> None:
+    """payload に schema version が含まれ、非空文字列であること.
+
+    schema://tools resource payload 自身のバージョン (各 tool 契約のバージョン
+    ではない)。改変検知用に agent 側で pin できる。
+    """
+    from vault_search.resources import build_schema_payload
+
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
+    assert "version" in payload, f"'version' key missing from payload: keys={list(payload)}"
+    version = payload["version"]
+    assert isinstance(version, str) and version.strip(), (
+        f"version must be non-empty str, got: {version!r}"
+    )
+
+
+def test_payload_has_overview_japanese_prose(vault_index: VaultIndex) -> None:
+    """payload に overview (日本語 1-2 段落) が含まれること.
+
+    既存の tool description 群と一貫して日本語で書く (codebase tone 維持)。
+    field name は英語、prose は日本語という #38 Issue 方針に従う。
+    """
+    from vault_search.resources import build_schema_payload
+
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
+    assert "overview" in payload, f"'overview' key missing: keys={list(payload)}"
+    overview = payload["overview"]
+    assert isinstance(overview, str), f"overview must be str, got {type(overview).__name__}"
+    assert len(overview) >= 100, (
+        f"overview should be 1-2 paragraphs (>=100 chars), got {len(overview)}"
+    )
+    # 日本語文字が含まれていること (ひらがな / カタカナ / 漢字のいずれか 1 文字以上)
+    has_japanese = any(
+        "\u3040" <= ch <= "\u309f"  # ひらがな
+        or "\u30a0" <= ch <= "\u30ff"  # カタカナ
+        or "\u4e00" <= ch <= "\u9fff"  # CJK 統合漢字
+        for ch in overview
+    )
+    assert has_japanese, f"overview should contain Japanese characters: {overview[:50]!r}..."
+
+
+def test_payload_has_recommended_flow_structure(vault_index: VaultIndex) -> None:
+    """payload["recommended_flow"] が step/tool/purpose キーを持つ list[dict].
+
+    step は 1-based int (エージェントが "step 3 から" と言及しやすい可読性のため)。
+    """
+    from vault_search.resources import build_schema_payload
+
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
+    assert "recommended_flow" in payload, f"'recommended_flow' missing: keys={list(payload)}"
+    flow = payload["recommended_flow"]
+    assert isinstance(flow, list) and len(flow) > 0, (
+        f"recommended_flow must be non-empty list, got {flow!r}"
+    )
+
+    for idx, step in enumerate(flow, start=1):
+        assert isinstance(step, dict), f"flow[{idx - 1}] must be dict: {step!r}"
+        assert set(step.keys()) >= {"step", "tool", "purpose"}, (
+            f"flow[{idx - 1}] missing required keys: got {set(step.keys())}"
+        )
+        assert isinstance(step["step"], int) and step["step"] >= 1, (
+            f"step must be 1-based int, got {step['step']!r}"
+        )
+        assert isinstance(step["tool"], str) and step["tool"], (
+            f"tool must be non-empty str, got {step['tool']!r}"
+        )
+        assert isinstance(step["purpose"], str) and step["purpose"], (
+            f"purpose must be non-empty str, got {step['purpose']!r}"
+        )
+
+
+def test_recommended_flow_tool_names_in_tool_specs(vault_index: VaultIndex) -> None:
+    """recommended_flow の各 step.tool は実在する MCP tool 名であること.
+
+    TOOL_SPECS と drift したら即検知 (典型: tool rename / 削除時の取り残し)。
+    resource URI (schema://tools) は tool 名フィールドに混ぜず overview で触れる。
+    """
+    from vault_search.mcp_contract import TOOL_SPECS
+    from vault_search.resources import build_schema_payload
+
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
+    flow = payload["recommended_flow"]
+    tool_names = {step["tool"] for step in flow}
+    unknown = tool_names - set(TOOL_SPECS.keys())
+    assert not unknown, (
+        f"recommended_flow references unknown tool names: {unknown}\n"
+        f"allowed (TOOL_SPECS): {sorted(TOOL_SPECS.keys())}"
+    )
+
+
+def test_payload_has_errors_section(vault_index: VaultIndex) -> None:
+    """payload["errors"] が NoteNotFoundError と ValidationError を含む dict.
+
+    各値は description / error_code / example キーを持つこと。
+    """
+    from vault_search.resources import build_schema_payload
+
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
+    assert "errors" in payload, f"'errors' key missing: keys={list(payload)}"
+    errors = payload["errors"]
+    assert isinstance(errors, dict), f"errors must be dict, got {type(errors).__name__}"
+    for cls_name in ("NoteNotFoundError", "ValidationError"):
+        assert cls_name in errors, f"errors['{cls_name}'] missing: got {list(errors)}"
+        entry = errors[cls_name]
+        assert isinstance(entry, dict), f"errors['{cls_name}'] must be dict: {entry!r}"
+        for field in ("description", "error_code", "example"):
+            assert field in entry, f"errors['{cls_name}'] missing '{field}': {entry!r}"
+            assert isinstance(entry[field], str) and entry[field].strip(), (
+                f"errors['{cls_name}']['{field}'] must be non-empty str: {entry[field]!r}"
+            )
+
+
+def test_errors_error_code_matches_live_exception_class(vault_index: VaultIndex) -> None:
+    """errors[cls]['error_code'] が実クラスの error_code 属性と一致すること.
+
+    ErrorCode Literal の drift をテスト層で pin する (exceptions.py の rename や
+    code 変更時に即検知)。Refactor で import-time assert を置く代わりに runtime
+    テストで吸収する。
+    """
+    from vault_search.exceptions import NoteNotFoundError
+    from vault_search.resources import build_schema_payload
+
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
+    errors = payload["errors"]
+
+    assert errors["NoteNotFoundError"]["error_code"] == NoteNotFoundError.error_code, (
+        f"NoteNotFoundError error_code drifted: "
+        f"payload={errors['NoteNotFoundError']['error_code']!r} "
+        f"vs live={NoteNotFoundError.error_code!r}"
+    )
+    # ValidationError は instance-level の default で classvar を持たないため
+    # ErrorCode Literal 集合に含まれていることのみ確認
+    from typing import get_args
+
+    from vault_search.exceptions import ErrorCode
+
+    allowed_codes = set(get_args(ErrorCode))
+    assert errors["ValidationError"]["error_code"] in allowed_codes, (
+        f"ValidationError error_code {errors['ValidationError']['error_code']!r} "
+        f"not in ErrorCode Literal: {allowed_codes}"
+    )
+
+
+def test_payload_has_frontmatter_key_info_schema(vault_index: VaultIndex) -> None:
+    """payload に FrontmatterKeyInfo の JSON Schema が含まれること (#179).
+
+    agent が value_type の許容値集合や sample_values の型を機械検証できるよう
+    Pydantic model_json_schema() をそのまま公開する。
+    """
+    from vault_search.resources import build_schema_payload
+
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
+    assert "frontmatter_key_info_schema" in payload, (
+        f"'frontmatter_key_info_schema' missing: keys={list(payload)}"
+    )
+    schema = payload["frontmatter_key_info_schema"]
+    assert isinstance(schema, dict), f"schema must be dict: {type(schema).__name__}"
+    assert schema.get("type") == "object", f"top-level must be object: {schema!r}"
+    assert "properties" in schema, f"schema must have properties: {list(schema)}"
+    for field in ("key", "value_type", "sample_values", "note_count"):
+        assert field in schema["properties"], (
+            f"FrontmatterKeyInfo field '{field}' missing from JSON Schema"
+        )
+
+
+def test_frontmatter_key_info_schema_pins_value_type_enum(vault_index: VaultIndex) -> None:
+    """value_type プロパティの enum 集合が Literal 宣言値と一致すること.
+
+    Pydantic v2 upgrade 等で Literal 展開挙動が変わった場合の regression guard。
+    agent が value_type を比較するときの許容値集合を pin する。
+    """
+    from vault_search.resources import build_schema_payload
+
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
+    schema = payload["frontmatter_key_info_schema"]
+    value_type_schema = schema["properties"]["value_type"]
+
+    enum = value_type_schema.get("enum")
+    assert enum is not None, (
+        f"value_type must expose enum for machine validation, got: {value_type_schema!r}"
+    )
+    expected = {"string", "number", "boolean", "array", "object", "mixed"}
+    assert set(enum) == expected, (
+        f"value_type enum drifted from FrontmatterKeyInfo Literal:\n"
+        f"  got: {set(enum)}\n"
+        f"  expected: {expected}"
+    )
+
+
+def test_read_resource_exposes_top_level_metadata(
+    vault_index: VaultIndex, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """read_resource("schema://tools") JSON に top-level metadata が含まれること.
+
+    build_schema_payload の直接呼び出しだけでなく、FastMCP の JSON round-trip
+    (resource handler → pydantic → JSON serialize) でも新 keys が保持されるこ
+    とを担保する。
+    """
+    from vault_search import server as server_mod
+
+    monkeypatch.setattr(server_mod, "_index", vault_index)
+
+    contents = asyncio.run(server_mod.mcp.read_resource("schema://tools"))
+    items = list(contents)
+    payload = json.loads(items[0].content)
+
+    for key in ("version", "overview", "recommended_flow", "errors", "frontmatter_key_info_schema"):
+        assert key in payload, f"'{key}' missing from read_resource payload: keys={list(payload)}"
+    assert payload["version"] == "1.0", f"version mismatch: {payload['version']!r}"
+    assert isinstance(payload["recommended_flow"], list)
+    assert isinstance(payload["errors"], dict)


### PR DESCRIPTION
## Summary

- **#38 (B2.4)** の解消: schema://tools payload に `version` / `overview` /
  `recommended_flow` / `errors` top-level メタを追加
- **#179 (B4)** の解消: `frontmatter_key_info_schema` に `FrontmatterKeyInfo`
  の JSON Schema を公開し、value_type の許容値 enum を機械検証可能にする
- エージェントが初回接続で全 tool description を context に入れる必要を減らし、
  推奨呼出順序を明示
- 533 tests 全通過 (+9 from Red)

## 変更内容

### resources.py (`src/vault_search/resources.py`)

module-level 定数を追加:
- `_SCHEMA_VERSION = "1.0"` — payload shape のバージョン
- `_OVERVIEW` — 日本語 2 段落のエージェント向け全体像
- `_RECOMMENDED_FLOW` — 7 ステップ (`vault_folders` → `vault_tags` →
  `vault_search` → `vault_get_note` → `vault_recent` → `vault_stats` →
  `vault_reindex`)
- `_ERRORS` — `NoteNotFoundError` / `ValidationError` の description /
  error_code / example。`error_code` は `NoteNotFoundError.error_code` live
  参照で drift を防ぐ
- `_FRONTMATTER_KEY_INFO_SCHEMA` — `FrontmatterKeyInfo.model_json_schema()`
  を import 時に freeze

`build_schema_payload` signature は不変。既存呼出側 (server.py /
test_tool_annotations.py / test_mcp_wrapping.py) は影響なし。

### tests/test_schema_resource.py

section `# Issue #38 / #179: schema://tools top-level metadata` を追加し、
9 件の Red テストを追記:
1. `test_payload_has_version_key`
2. `test_payload_has_overview_japanese_prose`
3. `test_payload_has_recommended_flow_structure`
4. `test_recommended_flow_tool_names_in_tool_specs` — TOOL_SPECS drift guard
5. `test_payload_has_errors_section`
6. `test_errors_error_code_matches_live_exception_class` — live ErrorCode drift guard
7. `test_payload_has_frontmatter_key_info_schema`
8. `test_frontmatter_key_info_schema_pins_value_type_enum` — Pydantic Literal 展開 pin
9. `test_read_resource_exposes_top_level_metadata` — FastMCP JSON round-trip 検証

## 設計上の決定

### Language: 日本語 prose / 英語 field names

既存 `TOOL_SPECS` / `_FOLDER_DESCRIPTION` / `FrontmatterKeyInfo` の Field
description 群は全て日本語で書かれており、codebase tone と一貫させるため
overview / errors.description / recommended_flow.purpose も日本語で統一。
field 名は英語 (`version` / `step` / `tool` / `purpose` / `error_code` 等)。

### version は hardcode "1.0" (pyproject.toml から derive しない)

payload schema 自身のバージョンは個別 tool 契約バージョンとは独立概念で、
`importlib.metadata.version()` が editable install 前に失敗するリスクを
避けるため、hardcode + 手動更新の方針。コメントで明記。

### recommended_flow の tool は TOOL_SPECS のみ許可

schema://tools resource URI を `tool` キーに混ぜると Literal union が膨らみ
agent parse が複雑化するため、resource 経由の initial introspection は
overview で触れる形に分離。`test_recommended_flow_tool_names_in_tool_specs`
が TOOL_SPECS との drift を即検知する。

### step は 1-based int

JSON array index 依存でなく `step` キー明示。"step 3 から" と agent が
参照しやすい可読性を優先。リナンバリングは 1 箇所の修正で完結。

### errors の error_code は live class 参照

`NoteNotFoundError.error_code` を直接使うことで `exceptions.ErrorCode`
Literal の rename や `ClassVar` 変更時に `test_errors_error_code_matches_live_exception_class`
が即失敗する drift guard を確立。

## Refactor 省略の理由

Green diff は 98 行の additive (constants + payload dict に 5 keys 追加) で、
default 付き hack / local import / 重複コピペ等の応急措置ゼロ。`tdd-workflow.md`
の「Green が既に minimal で housekeeping ゼロなら Refactor は作らず PR body で
省略理由を明示」方針に従い Refactor commit は作成しない。

## Test plan

- [x] `.venv/bin/pytest` — 533 tests pass (+9 new)
- [x] `ruff check` / `ruff format --check` clean
- [x] Red で 9 件すべて期待通り失敗、Green で全通過を確認
- [x] TOOL_SPECS drift guard / live ErrorCode drift guard / Pydantic Literal
  enum pin の 3 本の regression guard が実装済み
- [ ] (レビュー後) review-loop skill で複数視点レビューを回す

Closes #38, closes #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)