### PR TITLE
Docs: PR #204 HANDOVER 知見を rules / skill に反映

### DIFF
--- a/.claude/rules/tdd-workflow.md
+++ b/.claude/rules/tdd-workflow.md
@@ -159,6 +159,49 @@ commit prefix は「振る舞いが変わるか」で選ぶ:
 - `git pull --rebase` 相当の自動調停は禁止 (意図しないマージは親の責任)
 - 同一ファイルを 2 エージェントが書く予定があれば逐次化、並列しない
 
+## 同一ファイル touch issue の統合 PR ガイドライン
+
+複数 issue が同じファイルを必ず触る場合、個別 PR にすると merge 順序の rebase
+コストが累積する。以下の判定で統合 PR を採用する:
+
+### 統合 PR を採用する条件 (AND)
+
+1. **責務を 1 行で言語化できる** (例: 「schema://tools payload の agent DX 改善」)
+   — 複数 issue を同じ責務クラスタとして説明できる
+2. **同一ファイルを高確率で touch** (例: 全部 `resources.py` の同一 dict)
+3. **個別 PR に分けても review が独立しない** — どの issue を先 merge しても
+   後続が rebase 必須
+
+### 個別 PR を維持する条件
+
+- 責務が異なる (例: cache 改善 + observability 改善は同じ indexer.py でも別責務)
+- 1 issue が他に依存しない、片方だけ revert したい可能性がある
+- review reviewer の専門が分かれる (perf / security / DX が混在)
+
+### 統合 PR の commit 粒度
+
+issue ごとに Red/Green/Refactor を分けると 4 issue × 3 commit = 12 commits
+となり review が破綻する。**1 つの責務として TDD 構成する**:
+
+- `Red`: 全 issue 統合の失敗テスト追加 (1 commit)
+- `Green`: 全 issue 統合の最小実装 (1 commit)
+- `Fix Round N`: review-loop 指摘対応 (round 1 commit)
+
+PR body の commit 説明節で「issue → commit hash」の対応を書く。
+
+### 並行 PR で同一 issue が独立実装された場合の rebase 戦略
+
+別セッションが同じ issue を独立実装し先に merge された場合 (PR #204 と #203
+の #196 衝突実例):
+
+1. 先着 PR が採用した実装方針を rebase で取り込む (=自分の同 issue 実装は捨てる)
+2. 自分の追加要件 (本 PR 例: #192 の optional/condition フィールド) を上書き
+   復元する
+3. **副次的 drift** に注意: 先着の docstring と自分の implementation 解決が
+   独立に rebase されて整合性が崩れる典型シナリオ。rebase 完了後に
+   `git diff origin/main..HEAD` で docstring と実装の言及内容が一致するか
+   目視確認する
+
 ## 複数 issue の並列運用パターン
 
 Phase A/B のように「互いにほぼ独立した 2-4 issue を短時間でまとめて片付けたい」

--- a/.claude/skills/review-loop/SKILL.md
+++ b/.claude/skills/review-loop/SKILL.md
@@ -166,6 +166,41 @@ reviewer または fix エージェントが動作確認のため一時スクリ
 - `reviewer 自らに収束判定を求める` instruction を Round 2 以降の prompt に
   入れると Opus reviewer が明示的な「Round N 不要」判定を返しやすい
 
+## PR #204 実績 (2026-04-20): 3 round 軽量化パターン
+
+4 issue 統合 PR (diff ~250 行) の review-loop サンプル:
+
+- **Round 1** (4 視点 A/B/C Sonnet + D Opus 並列): 19 件指摘 → PR 内 fix 6 件
+  (score 6-7) + Issue 起票 4 件 (#199-202)
+- **Round 2** (2 視点 Sonnet + Opus): 5 件追加 → PR 内 fix 3 件 (R2-2 phantom
+  promise enforcement test 等)、2 件は Round 1 起票 issue に集約
+- **Round 3** (Sonnet 1 reviewer 軽量): 0 件 (CONVERGED 判定) — rebase 後
+  整合性チェック中心の probes に絞る
+
+### Round 数の絞り込み判定
+
+findings 半減を観測したら次 round は reviewer 数を減らす:
+
+| Round | Findings | Reviewer 数 | 狙い |
+|---|---|---|---|
+| 1 | 多数 (15-20+) | 4 視点並列 | 網羅的発見 |
+| 2 | 半減 (3-7) | 2 視点 (Sonnet+Opus) | 残ベクトル探索 |
+| 3 | <5 想定 | 1 視点 (Sonnet) | CONVERGED 判定 |
+
+**Round 3 で 5+ findings が再発した場合**: probe を新たに加えて Round 4 へ。
+ただし通常は Round 2 で 5+ が出尽くしているため、Round 3 が CONVERGED を
+返すなら Round 4 不要 (PR #204 実例)。
+
+### Round 3 軽量 reviewer の prompt 構成
+
+- Round 1+2 fixes と起票済み issue を全列挙 (don't re-raise リスト)
+- 「rebase 後の整合性」「test 重複」「docstring と implementation の drift」
+  などの **integration probes** に絞る
+- 末尾で必ず CONVERGED / NOT CONVERGED 判定を要求
+
+このパターンは PR diff <300 行 + issue 数 <5 のケースで有効。大規模 refactor
+には適用しない (Round 1 が「網羅探索」では収まらない可能性が高い)。
+
 ## プロジェクト固有メモの拡張
 
 プロジェクトごとの conventions (特定 SDK の罠、命名規則、test infrastructure


### PR DESCRIPTION
## Summary

PR #204 (#191/#192/#193/#196 統合 PR) の作業セッションで得た 3 つの知見を
プロジェクト内ルール / skill に書き戻す documentation-only な PR。

## 反映内容

### `.claude/rules/tdd-workflow.md` — 統合 PR ガイドライン (新規節)

- 同一ファイルを高確率で touch する複数 issue は統合 PR を選ぶ判定条件
- 統合 PR の commit 粒度 (issue ごとの TDD ではなく **責務単位の TDD**)
- 並行 PR で同一 issue が独立実装された場合の rebase 戦略
  - 先着 PR の実装方針を base として採用
  - 後着の追加要件を上書き復元
  - rebase 後の docstring drift に注意

### `.claude/skills/review-loop/SKILL.md` — PR #204 実績節 (新規)

- 3 round 軽量化パターンの実例 (Round 1=19件 / Round 2=5件 / Round 3=0件)
- reviewer 数の絞り込み判定基準
  - Round 1: 4 視点並列
  - Round 2: 2 視点 (Sonnet + Opus)
  - Round 3: 1 視点 (Sonnet) + integration probes に絞る
- Round 3 軽量 reviewer の prompt 構成

## 別途反映済み (本 PR 対象外)

- `~/.claude/projects/.../memory/feedback_concurrent_pr_rebase.md`: 並行 PR
  rebase 戦略の memory entry。個人 memory のため本 PR には含まれない

## Test plan

- [x] documentation のみ、コード変更なし
- [x] markdown のレンダリング確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)