### PR TITLE
Simplify: _query_array_element_samples の冗長 WHERE 条件を削除 (#190)

### DIFF
--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -632,13 +632,12 @@ class VaultIndex:
                 rows = conn.execute(
                     "SELECT value, COUNT(*) AS cnt "
                     "FROM notes, json_each(json_extract(frontmatter, ?)) "
-                    "WHERE json_extract(frontmatter, ?) IS NOT NULL "
-                    "  AND json_type(frontmatter, ?) = 'array' "
+                    "WHERE json_type(frontmatter, ?) = 'array' "
                     "  AND value IS NOT NULL "
                     "GROUP BY value "
                     "ORDER BY cnt DESC, value ASC "
                     "LIMIT 5",
-                    (json_path, json_path, json_path),
+                    (json_path, json_path),
                 ).fetchall()
                 # frontmatter 値は parser._normalize_fm により index 時に文字列化
                 # 済み。念のため str() で wrap し、SQLite が int/float を返した


### PR DESCRIPTION
## Summary

PR #206 (merged) の review-loop 軽量 pass で検出した finding [1] への follow-up fix。

`_query_array_element_samples` (indexer.py:632-641) の WHERE 句に
`json_extract(frontmatter, ?) IS NOT NULL` と
`json_type(frontmatter, ?) = 'array'` が並んでいたが、後者が真なら前者は
論理的に常に真 (array 型判定されたなら値は存在する)。冗長条件を除去し
`json_path` placeholder を 3 → 2 に削減。

## Test plan

- [x] `pytest tests/test_indexer.py -k metadata_filter_diagnostics` 全通 (11 passed)
- [x] `ruff check` / `ruff format --check` clean
- [ ] CI 緑確認

Related: #190 の follow-up。挙動変化なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)