### PR TITLE
Fix: folder docstring SSOT + vault_reindex 非破壊マージ (#37, #174)

### DIFF
--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -73,7 +73,25 @@ mcp = FastMCP("vault-search")
 # server.py 側で定数を重複定義しない。
 
 
+def _with_folder_description(fn):
+    """docstring の ``{FOLDER_DESCRIPTION}`` placeholder を ``_FOLDER_DESCRIPTION``
+    の本文で置換する (Issue #37 — SSOT).
+
+    ``_FOLDER_DESCRIPTION`` は ``mcp_contract._FOLDER_DESCRIPTION`` を単一
+    ソースとし、``Field(description=...)`` (MCP inputSchema 経由) と docstring
+    (``inspect.getdoc`` / ``help`` / FastMCP description 経由) の両方でこの値を
+    共有する。backslash escape 差で drift しないよう、docstring には
+    ``{FOLDER_DESCRIPTION}`` という placeholder を書き、本 decorator で runtime
+    に差し替える。``@mcp.tool()`` より内側 (decorator スタックの下) で適用する
+    ことで、FastMCP が ``__doc__`` を読む時点で既に展開済みにする。
+    """
+    if fn.__doc__ and "{FOLDER_DESCRIPTION}" in fn.__doc__:
+        fn.__doc__ = fn.__doc__.replace("{FOLDER_DESCRIPTION}", _FOLDER_DESCRIPTION)
+    return fn
+
+
 @mcp.tool(annotations=TOOL_SPECS["vault_search"].annotations)
+@_with_folder_description
 def vault_search(
     query: str,
     tags: list[str] | None = None,
@@ -92,9 +110,7 @@ def vault_search(
     Args:
         query: 検索クエリ。スペース区切りで AND 検索。日本語・英語混在可。
         tags: タグフィルタ（例: ["project/hermes-agent", "status/decided"]）。全て AND。
-        folder: フォルダプレフィックスフィルタ（例: "Projects/Hermes Agent"）。
-            末尾 '/' および '\\' 区切りは自動で正規化される（例: "Projects/" → "Projects"）。
-            スラッシュのみの入力（'/', '//', '\\\\'）はフィルタなし（= 全件）として扱う。
+        folder: {FOLDER_DESCRIPTION}
         limit: 最大返却件数（デフォルト 20）。
         offset: 開始位置（ページネーション用）。
         metadata_filter: frontmatter プロパティでの AND フィルタ。
@@ -169,6 +185,7 @@ def vault_get_note(path: str) -> dict[str, Any]:
 
 
 @mcp.tool(annotations=TOOL_SPECS["vault_recent"].annotations)
+@_with_folder_description
 def vault_recent(
     limit: int = 20,
     offset: int = 0,
@@ -181,9 +198,7 @@ def vault_recent(
         offset: ページング用の開始位置（デフォルト 0, >=0）。vault_search と同じ
                 意味論で、最近更新順 (file_mtime DESC) の先頭から offset 件を
                 スキップして limit 件返す。
-        folder: フォルダプレフィックスで絞り込み（例: "Research"）。
-            末尾 '/' および '\\' 区切りは自動で正規化される（例: "Research/" → "Research"）。
-            スラッシュのみの入力（'/', '//', '\\\\'）はフィルタなし（= 全件）として扱う。
+        folder: {FOLDER_DESCRIPTION}
 
     副作用: 読み取り専用 (vault / DB 書き込み無し)。
 
@@ -272,9 +287,8 @@ def vault_reindex(force: bool = False) -> dict[str, Any]:
             それぞれ ``0`` / ``null``。
     """
     stats = _get_index().build_index(force=force)
-    if _watcher is not None:
-        stats.update(_watcher.failure_stats())
-    return ReindexStats(**stats).model_dump(mode="json")
+    watcher_stats = _watcher.failure_stats() if _watcher is not None else {}
+    return ReindexStats(**stats, **watcher_stats).model_dump(mode="json")
 
 
 @mcp.tool(annotations=TOOL_SPECS["vault_stats"].annotations)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -289,6 +289,53 @@ def test_mcp_tool_vault_reindex_includes_watcher_failures(
     assert res["last_watcher_error_at"] == "2026-04-19T12:00:00+00:00"
 
 
+def test_vault_reindex_does_not_mutate_build_index_return(
+    vault_index: VaultIndex, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``vault_reindex`` は ``build_index()`` の戻り dict を in-place 変更しない (#174).
+
+    現状 ``build_index()`` は毎回新しい dict を返すため実害はないが、将来
+    キャッシュや共有オブジェクトを返すように変更された場合 ``stats.update()``
+    がそれを破壊する。watcher の failure stats をマージする際は dict spread で
+    非破壊的に merge すべき (Issue #174)。
+
+    verification: 呼び出し後に indexer が返したオリジナル dict のキーセットが
+    増えていないこと — つまり watcher 側のキー (watcher_failure_count /
+    last_watcher_error_at) が混入していないことを確認する。
+    """
+    idx = server_mod._get_index()
+    original_build_index = idx.build_index
+    captured_returns: list[dict[str, int]] = []
+
+    def capturing_build_index(*, force: bool = False) -> dict[str, int]:
+        stats = original_build_index(force=force)
+        captured_returns.append(stats)
+        return stats
+
+    monkeypatch.setattr(idx, "build_index", capturing_build_index)
+
+    watcher = VaultWatcher(idx)
+    with watcher._lock:
+        watcher._watcher_failure_count = 3
+        watcher._last_watcher_error_at = "2026-04-19T13:00:00+00:00"
+    monkeypatch.setattr(server_mod, "_watcher", watcher)
+
+    fn = _fn(server_mod.vault_reindex)
+    fn(False)
+
+    assert len(captured_returns) == 1, "build_index は 1 回だけ呼ばれる想定"
+    stats = captured_returns[0]
+    # build_index が返した dict に watcher 由来のキーが混入していないこと
+    assert "watcher_failure_count" not in stats, (
+        "vault_reindex が build_index() 戻り dict を in-place 変更している (#174). "
+        "watcher stats は dict spread で非破壊的にマージすべき。"
+    )
+    assert "last_watcher_error_at" not in stats, (
+        "vault_reindex が build_index() 戻り dict を in-place 変更している (#174). "
+        "watcher stats は dict spread で非破壊的にマージすべき。"
+    )
+
+
 def test_main_stops_watcher_on_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """mcp.run() が例外を起こしても _watcher.stop() が呼ばれる (#39 try/finally)."""
     import sys as _sys

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -328,6 +328,36 @@ def test_vault_reindex_docstring_explains_force_behavior() -> None:
     )
 
 
+def test_folder_docstring_contains_schema_description() -> None:
+    """``folder`` 引数を持つツールの docstring が ``_FOLDER_DESCRIPTION`` を
+    そのまま含むこと (Issue #37).
+
+    schema://tools の input_schema は ``_FOLDER_DESCRIPTION`` を参照して
+    「兄弟プレフィックス除外」などの挙動を明記しているが、Python docstring
+    を読むクライアント (FastMCP の一部経路 / SDK / help() / IDE ホバー等)
+    には元々この説明が届かず、agent が ``folder='Projects'`` が
+    ``'Projects Hermes/...'`` もマッチすると誤解するリスクがあった。
+
+    本テストは docstring と schema description の文言ドリフトを regression
+    guard する。``_FOLDER_DESCRIPTION`` を single source of truth として
+    そのまま埋め込む方針 (Issue #37 推奨修正)。
+    """
+    import inspect
+
+    from vault_search.mcp_contract import _FOLDER_DESCRIPTION
+
+    for tool_name in ("vault_search", "vault_recent"):
+        tool = getattr(server_mod, tool_name)
+        doc = inspect.getdoc(tool)
+        assert doc is not None, f"{tool_name} has no docstring"
+        assert _FOLDER_DESCRIPTION in doc, (
+            f"{tool_name} docstring must contain the canonical folder "
+            f"description from _FOLDER_DESCRIPTION verbatim (Issue #37). "
+            f"This ensures docstring readers see the sibling-exclusion "
+            f"semantics (例: 'Projects' は 'Projects Hermes' を除外する)。"
+        )
+
+
 def test_schema_tools_resource_exposes_annotations(vault_index: VaultIndex) -> None:
     """``schema://tools`` リソースも各 tool の annotations を公開する.
 


### PR DESCRIPTION
## Summary

server.py の tool contract 規律を 2 件まとめて修正:

- **#37** (B2.3): `folder` パラメータの意味論が MCP inputSchema の `_FOLDER_DESCRIPTION` にしか存在せず、docstring (`inspect.getdoc` / `help` / FastMCP description) 経路では簡略版に drift していた。`_with_folder_description` decorator で runtime placeholder 置換して SSOT 化
- **#174**: `vault_reindex` が `build_index()` の戻り dict を `stats.update(...)` で in-place mutate。dict spread (`{**stats, **watcher_stats}` 相当の `ReindexStats(**stats, **watcher_stats)`) で非破壊マージに変更

## Why bundle

両 issue とも `src/vault_search/server.py` の同一 tool (`vault_search` / `vault_recent` / `vault_reindex`) を触るため、並列 PR はコンフリクト確実。共通責務は **「server.py の tool contract 規律 — docstring SSOT + return value 非破壊」**。

## Test plan

- [x] `tests/test_tool_annotations.py::test_folder_docstring_contains_schema_description` — `inspect.getdoc(server.vault_search)` / `vault_recent` に `_FOLDER_DESCRIPTION` が verbatim 含まれることを検証 (FastMCP description 経路も間接保証)
- [x] `tests/test_server.py::test_vault_reindex_does_not_mutate_build_index_return` — `build_index()` が返した dict のキーセットが mutate されないことを `monkeypatch` capture で検証
- [x] 全 559 tests pass / ruff clean

## TDD

- Red: `fa547ee` — 両 regression test を追加 (失敗確認済)
- Green: `ef557b8` — `_with_folder_description` helper + `{FOLDER_DESCRIPTION}` placeholder + dict spread 修正
- Refactor: 省略 (Green diff は minimal、helper 1 個 + decorator 2 箇所 + 3 行修正のみ、`.claude/rules/tdd-workflow.md` の省略判定基準を満たす)

🤖 Generated with [Claude Code](https://claude.com/claude-code)