### PR TITLE
Docs: FastMCP docstring caching + machine migration 破損検知をルール化

### DIFF
--- a/.claude/rules/fastmcp-gotchas.md
+++ b/.claude/rules/fastmcp-gotchas.md
@@ -14,6 +14,25 @@
 - List 戻り (`list[Model]`) も FastMCP に wrap される → envelope dict
   (`{"tags": [...]}`, `{"folders": [...]}`, `{"notes": [...]}`) に統一
 
+## docstring caching timing
+
+- `@mcp.tool()` は decoration 時点で `Tool.from_function` が `fn.__doc__` を
+  読んで description を**キャッシュ**する
+  (`site-packages/mcp/server/fastmcp/tools/base.py:66` —
+  `func_doc = description or fn.__doc__ or ""`)
+- docstring を runtime で書き換える decorator (placeholder 置換等) は
+  `@mcp.tool()` より**内側 (下)** に配置する必要がある。decorator chain は
+  内側が先に適用されるため、FastMCP が `__doc__` を読む時点で既に展開済みに
+  できる。外側 (上) だと未置換 docstring がキャッシュされる
+- 具体例: `server.py:_with_folder_description` — `{FOLDER_DESCRIPTION}`
+  placeholder を `_FOLDER_DESCRIPTION` 本文で runtime 置換する decorator。
+  `vault_search` / `vault_recent` で `@mcp.tool(...)` の**下** (`fn` に近い側)
+  に置かれている
+- **regression guard**: `tests/test_tool_annotations.py::
+  test_folder_docstring_contains_schema_description` が `inspect.getdoc()`
+  経路で `_FOLDER_DESCRIPTION` の存在を検証。FastMCP `tools/list` description
+  経路の直接 assert は未実装 (upgrade 耐性を上げたいなら追加候補)
+
 ## outputSchema の手動注入
 
 - `@mcp.tool()` に `output_schema` 引数がないため、dict 戻り型は generic な

--- a/.claude/rules/tdd-workflow.md
+++ b/.claude/rules/tdd-workflow.md
@@ -139,6 +139,36 @@ worktree 運用記述通り)。
 「`.venv` pth の指す先を確認するか、無条件で `rm .venv && uv sync`」を
 組み込むのが安全。
 
+### 既知の落とし穴: machine migration 後の working tree 不整合
+
+別マシンで作業履歴のあるセッションを引き継ぐと、working tree が HEAD と
+不整合な状態で現れることがある (2026-04-20 PR #209 で観測)。具体例:
+
+- 一部 tracked files が HEAD より**古い** 状態にリバートされている
+- 別の tracked files は origin/main の**新しい** commit 分まで進んでいる
+- `git status` は一律 `modified` と表示するため、作業中の変更と破損が区別
+  できない
+
+**検知手順** (セッション開始時の sanity check):
+
+```bash
+git status              # modified 表示の存在を確認
+git diff HEAD --stat    # ファイル別の ± 行数で「意図しない変更」を炙り出す
+git stash list          # 未処理の作業が stash に退避されていないか
+```
+
+3 点セットで「未コミット作業ゼロ」かつ「working tree が HEAD と乖離」が
+確認できた場合は破損と判断:
+
+```bash
+git checkout -- .       # tracked files を HEAD に合わせてリセット
+git rebase origin/main  # ブランチを最新 main に乗せ直す
+```
+
+**教訓**: `git status` 単独では不足。`git diff HEAD --stat` + `git stash
+list` を組み合わせて「未コミット作業」と「working tree 破損」を区別する
+のが必須。破損放置で rebase すると unstaged changes エラーが出て進まない。
+
 ## Red/Green vs Test/Refactor — prefix 選択ガイド
 
 commit prefix は「振る舞いが変わるか」で選ぶ:


### PR DESCRIPTION
## Summary

- **fastmcp-gotchas.md**: `@mcp.tool()` が decoration 時点で `fn.__doc__` を
  キャッシュする挙動 (`Tool.from_function` の `func_doc = description or
  fn.__doc__ or ""`) と、docstring 書換え decorator を `@mcp.tool()` より
  内側 (下) に配置する必要性を記録。`server.py:_with_folder_description`
  を具体例として参照
- **tdd-workflow.md**: machine migration 跨ぎで working tree が HEAD と
  不整合になる (一部ファイル古く、他が新しい) 落とし穴を「既知の落とし穴」
  に追加。`git status` + `git diff HEAD --stat` + `git stash list` の
  3 点セットで作業中変更と破損を区別、`git checkout -- .` + `git rebase
  origin/main` で復旧する手順

## 背景

PR #209 (#37 + #174 bundle) の実装中に 2 件とも実地で検証した:

- docstring caching は `_with_folder_description` を `@mcp.tool()` の内側に
  置く判断の根拠
- machine migration 破損は PR #209 のセッション開始時に実際に遭遇し、
  `git checkout -- .` + rebase で復旧した

非自明な運用知見で、後続セッション / 新 contributor が再発時に同じ
調査コストを払わないようルール化。

## Test plan

- [x] markdown lint (既存 doc のみ変更、構文問題なし)
- [x] 既存テストに影響なし (rules/ 直下の markdown のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)