### PR TITLE
Harden watcher observability (#172 #173 #175 #176)

### DIFF
--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -295,7 +295,10 @@ def vault_reindex(force: bool = False) -> dict[str, Any]:
     watcher_stats: dict[str, Any] = {}
     if _watcher is not None:
         watcher_stats.update(_watcher.failure_stats())
-        watcher_stats["watcher_active"] = True
+        # _watcher is not None だけでは不足 — main() は start() の返り値に関わらず
+        # assign するため、watchdog 未インストールや inotify 上限で start() が
+        # False を返しても _watcher は残る。実際の監視状態は is_active() で判定 (#173)。
+        watcher_stats["watcher_active"] = _watcher.is_active()
     return ReindexStats(**stats, **watcher_stats).model_dump(mode="json")
 
 

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -281,13 +281,21 @@ def vault_reindex(force: bool = False) -> dict[str, Any]:
     Returns:
         dict: ReindexStats に相当する flat JSON
             (``added`` / ``updated`` / ``deleted`` / ``skipped`` / ``errors`` /
-            ``watcher_failure_count`` / ``last_watcher_error_at``)。
-            末尾 2 つは VaultWatcher が差分更新で失敗した累計 (#39) を返す。
+            ``watcher_failure_count`` / ``last_watcher_error_at`` /
+            ``watcher_active``)。
+            ``watcher_failure_count`` / ``last_watcher_error_at`` は
+            VaultWatcher が差分更新で失敗した累計 (#39) を返す。
             ``--no-watch`` で watcher 無効の場合と起動以降失敗ゼロの場合は
             それぞれ ``0`` / ``null``。
+            ``watcher_active`` (#173) は watcher 起動中かを bool で示し、
+            ``watcher_failure_count=0`` が「未起動」と「失敗ゼロ」どちらかを
+            区別できるようにする。
     """
     stats = _get_index().build_index(force=force)
-    watcher_stats = _watcher.failure_stats() if _watcher is not None else {}
+    watcher_stats: dict[str, Any] = {}
+    if _watcher is not None:
+        watcher_stats.update(_watcher.failure_stats())
+        watcher_stats["watcher_active"] = True
     return ReindexStats(**stats, **watcher_stats).model_dump(mode="json")
 
 

--- a/src/vault_search/stats.py
+++ b/src/vault_search/stats.py
@@ -25,7 +25,9 @@ class ReindexStats(BaseModel):
             "VaultWatcher が差分更新で失敗した累計件数 (プロセス起動以降)。"
             "0 より大きいとき、watcher が監視している Vault の一部が"
             "インデックスと drift している可能性がある。"
-            "--no-watch で watcher 無効の場合と、一度も失敗していない場合はいずれも 0"
+            "--no-watch で watcher 無効の場合と、一度も失敗していない場合はいずれも 0。"
+            "リカバリ: `vault_reindex(force=True)` を呼ぶことでインデックスを"
+            "完全再構築できる"
         ),
     )
     last_watcher_error_at: str | None = Field(
@@ -35,6 +37,16 @@ class ReindexStats(BaseModel):
             "例: '2026-04-19T12:00:00+00:00')。"
             "一度も失敗していない / watcher 無効の場合は null。"
             "watcher_failure_count が 0 でない場合の最新エラーのみ指す"
+        ),
+    )
+    watcher_active: bool = Field(
+        default=False,
+        description=(
+            "VaultWatcher が起動中であれば true。"
+            "--no-watch オプション指定時または watchdog 未インストール時は false。"
+            "true でも watcher_failure_count が 0 より大きければ drift の可能性がある。"
+            "watcher_failure_count=0 のみでは「未起動」と「失敗ゼロ」を区別できないため、"
+            "watcher 有効性の判定にはこのフィールドを参照する"
         ),
     )
 

--- a/src/vault_search/watcher.py
+++ b/src/vault_search/watcher.py
@@ -24,11 +24,17 @@ try:
         FileSystemEvent,
         FileSystemEventHandler,
     )
+    from watchdog.observers import Observer
 
     _WATCHDOG_AVAILABLE = True
 except ImportError:  # pragma: no cover - watchdog is a hard dep but keep guard for sdist installs
+    # `watchdog.events` と `watchdog.observers` のどちらが欠けても利用不可扱い (#172)。
+    # 旧実装は events のみ check し、Observer は start() 内で lazy import していたため
+    # 部分的 sdist インストールで `_WATCHDOG_AVAILABLE=True` でも start() が
+    # ImportError を投げ、main() の graceful fallback (return False) を迂回した。
     _WATCHDOG_AVAILABLE = False
     FileSystemEventHandler = object  # type: ignore[assignment,misc]
+    Observer = None  # type: ignore[assignment,misc]
 
 
 class VaultEventHandler(FileSystemEventHandler):  # type: ignore[misc]
@@ -112,8 +118,6 @@ class VaultWatcher:
         if not _WATCHDOG_AVAILABLE:
             logger.warning("watchdog not installed — file watching disabled")
             return False
-
-        from watchdog.observers import Observer
 
         handler = VaultEventHandler(self._index, self._schedule_update)
         self._observer = Observer()

--- a/src/vault_search/watcher.py
+++ b/src/vault_search/watcher.py
@@ -107,6 +107,7 @@ class VaultWatcher:
         self._index = index
         self._debounce_sec = debounce_sec
         self._observer: Any = None
+        self._started: bool = False
         self._pending: dict[str, float] = {}
         self._timer: threading.Timer | None = None
         self._lock = threading.Lock()
@@ -124,8 +125,18 @@ class VaultWatcher:
         self._observer.schedule(handler, str(self._index.vault_root), recursive=True)
         self._observer.daemon = True
         self._observer.start()
+        self._started = True
         logger.info("File watcher started: %s", self._index.vault_root)
         return True
+
+    def is_active(self) -> bool:
+        """Observer が実際に起動済みかを返す (#173 review fix).
+
+        ``server.main()`` は ``_watcher = VaultWatcher(_index); _watcher.start()``
+        と assign するため、``start()`` が False を返しても ``_watcher`` は None に
+        ならない。``watcher_active`` wire には本 method を使って実状態を反映する。
+        """
+        return self._started
 
     def stop(self) -> None:
         if self._observer:
@@ -133,6 +144,7 @@ class VaultWatcher:
             if self._observer.is_alive():
                 self._observer.join(timeout=5)
             self._observer = None
+        self._started = False
 
     def _schedule_update(self, rel_path: str) -> None:
         """デバウンス付きインデックス更新スケジューリング."""

--- a/tests/test_mcp_wrapping.py
+++ b/tests/test_mcp_wrapping.py
@@ -223,10 +223,10 @@ def test_vault_reindex_watcher_active_true_when_watcher_running(
 
 
 def test_vault_reindex_watcher_failure_description_mentions_recovery() -> None:
-    """#175: ``watcher_failure_count`` description にリカバリ手順 (vault_reindex(force=True)) が載る.
+    """#175: ``watcher_failure_count`` description にリカバリ手順を記載する.
 
     エージェントが ``watcher_failure_count > 0`` を観測した際の次アクションを
-    schema 経由で発見できることを保証する。
+    (``vault_reindex(force=True)``) schema 経由で発見できることを保証する。
     """
     schema = _get_tool_output_schema("vault_reindex")
     props = schema.get("properties", {})

--- a/tests/test_mcp_wrapping.py
+++ b/tests/test_mcp_wrapping.py
@@ -175,15 +175,65 @@ def test_vault_reindex_structured_content_not_wrapped(vault_index: VaultIndex) -
     ReindexStats (Pydantic) 戻り型のままだと FastMCP のバージョン依存で
     wrap_output の挙動が変わる (silent regression 導線)。dict 統一後は
     wrap が発生しないことを保証する。
+
+    Issue #39 で追加された ``watcher_failure_count`` / ``last_watcher_error_at``
+    および Issue #173 で追加された ``watcher_active`` も MCP wire に乗っている
+    ことを issubset で検証する (#176)。これらが ``model_dump(exclude=...)`` 等で
+    silent に除外されても検知できるようにする。
     """
     _content, structured = _call_tool("vault_reindex", {})
     assert isinstance(structured, dict)
     assert "result" not in structured, f"vault_reindex wrap drift: keys={list(structured.keys())}"
-    assert {"added", "updated", "deleted", "skipped", "errors"}.issubset(structured.keys()), (
-        f"vault_reindex missing ReindexStats keys: {structured!r}"
-    )
+    assert {
+        "added",
+        "updated",
+        "deleted",
+        "skipped",
+        "errors",
+        "watcher_failure_count",
+        "last_watcher_error_at",
+        "watcher_active",
+    }.issubset(structured.keys()), f"vault_reindex missing ReindexStats keys: {structured!r}"
+    # 値の型も確認 — fixture では watcher 未設定なので default 値で wire に乗るはず
+    assert isinstance(structured["watcher_failure_count"], int)
+    assert structured["last_watcher_error_at"] is None
+    assert structured["watcher_active"] is False
     schema = _get_tool_output_schema("vault_reindex")
     jsonschema.validate(structured, schema)
+
+
+def test_vault_reindex_watcher_active_true_when_watcher_running(
+    vault_index: VaultIndex, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#173: ``_watcher`` が設定されていれば ``watcher_active=True`` が返る.
+
+    ``watcher_failure_count=0`` は「watcher 未起動」と「起動しているが失敗ゼロ」を
+    区別できないため、``watcher_active`` bool フィールドで明示する。
+    """
+
+    class _StubWatcher:
+        def failure_stats(self) -> dict[str, Any]:
+            return {"watcher_failure_count": 0, "last_watcher_error_at": None}
+
+    monkeypatch.setattr(server_mod, "_watcher", _StubWatcher())
+    _content, structured = _call_tool("vault_reindex", {})
+    assert structured["watcher_active"] is True
+    assert structured["watcher_failure_count"] == 0
+    assert structured["last_watcher_error_at"] is None
+
+
+def test_vault_reindex_watcher_failure_description_mentions_recovery() -> None:
+    """#175: ``watcher_failure_count`` description にリカバリ手順 (vault_reindex(force=True)) が載る.
+
+    エージェントが ``watcher_failure_count > 0`` を観測した際の次アクションを
+    schema 経由で発見できることを保証する。
+    """
+    schema = _get_tool_output_schema("vault_reindex")
+    props = schema.get("properties", {})
+    desc = props.get("watcher_failure_count", {}).get("description", "")
+    assert "vault_reindex" in desc and "force=True" in desc, (
+        f"watcher_failure_count description lacks recovery hint: {desc!r}"
+    )
 
 
 def test_vault_stats_structured_content_not_wrapped(vault_index: VaultIndex) -> None:

--- a/tests/test_mcp_wrapping.py
+++ b/tests/test_mcp_wrapping.py
@@ -212,6 +212,9 @@ def test_vault_reindex_watcher_active_true_when_watcher_running(
     """
 
     class _StubWatcher:
+        def is_active(self) -> bool:
+            return True
+
         def failure_stats(self) -> dict[str, Any]:
             return {"watcher_failure_count": 0, "last_watcher_error_at": None}
 
@@ -220,6 +223,36 @@ def test_vault_reindex_watcher_active_true_when_watcher_running(
     assert structured["watcher_active"] is True
     assert structured["watcher_failure_count"] == 0
     assert structured["last_watcher_error_at"] is None
+
+
+def test_vault_reindex_watcher_active_false_when_start_failed(
+    vault_index: VaultIndex, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#173 review fix: watcher 生成後 start() が False を返したら watcher_active=False.
+
+    server.py の main() は ``_watcher = VaultWatcher(_index); _watcher.start()``
+    と unconditionally に assign する。watchdog 部分欠落 (#172) や inotify 上限等で
+    ``start()`` が False を返した場合でも ``_watcher is not None`` は True に残るため、
+    ``watcher_active = _watcher is not None`` で wire すると #173 の目的
+    (「watcher_failure_count=0 の曖昧さ解消」) が破綻する。
+
+    VaultWatcher.is_active() を介して実際の監視状態をチェックすべき。
+    """
+
+    class _NotStartedWatcher:
+        """start() が False を返した watcher を模擬 (observer 未起動)."""
+
+        def is_active(self) -> bool:
+            return False
+
+        def failure_stats(self) -> dict[str, Any]:
+            return {"watcher_failure_count": 0, "last_watcher_error_at": None}
+
+    monkeypatch.setattr(server_mod, "_watcher", _NotStartedWatcher())
+    _content, structured = _call_tool("vault_reindex", {})
+    assert structured["watcher_active"] is False, (
+        f"watcher_active should be False when start() returned False: {structured!r}"
+    )
 
 
 def test_vault_reindex_watcher_failure_description_mentions_recovery() -> None:

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -339,12 +339,14 @@ def test_watchdog_available_implies_observer_importable() -> None:
     """
     import vault_search.watcher as w
 
-    if w._WATCHDOG_AVAILABLE:
-        assert hasattr(w, "Observer"), (
-            "_WATCHDOG_AVAILABLE=True なのに Observer が module attribute に無い. "
-            "start() 内の lazy import に頼っている可能性: "
-            "`from watchdog.observers import Observer` を module-level try/except に含めること"
-        )
+    # watchdog は pyproject.toml の hard dep なので CI / dev 環境では常に True。
+    # `if` で skip せず assert で CI の guard を強制する (review suggestion)。
+    assert w._WATCHDOG_AVAILABLE, "watchdog is a hard dep; expected _WATCHDOG_AVAILABLE=True"
+    assert hasattr(w, "Observer"), (
+        "_WATCHDOG_AVAILABLE=True なのに Observer が module attribute に無い. "
+        "start() 内の lazy import に頼っている可能性: "
+        "`from watchdog.observers import Observer` を module-level try/except に含めること"
+    )
 
 
 def test_watcher_stop_safe_when_observer_not_started(vault: Path, index: VaultIndex) -> None:

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -325,6 +325,28 @@ def test_watcher_flush_accumulates_multiple_failures(
     assert stats["watcher_failure_count"] == 2
 
 
+def test_watchdog_available_implies_observer_importable() -> None:
+    """#172: ``_WATCHDOG_AVAILABLE=True`` は Observer の import 成功も含意する.
+
+    現行の watcher.py は module-level try/except で ``watchdog.events`` のみ
+    import していた。``watchdog.observers`` が欠落した部分的 sdist インストール
+    では ``_WATCHDOG_AVAILABLE=True`` なのに ``start()`` 内の lazy import が
+    ``ImportError`` を投げ、``main()`` の graceful fallback を迂回する。
+
+    モジュールレベルで Observer も同じ try/except に含めることで、フラグの
+    意味論と実挙動が一致する。このテストは ``_WATCHDOG_AVAILABLE=True`` なら
+    Observer が module attribute として露出していることを要求する。
+    """
+    import vault_search.watcher as w
+
+    if w._WATCHDOG_AVAILABLE:
+        assert hasattr(w, "Observer"), (
+            "_WATCHDOG_AVAILABLE=True なのに Observer が module attribute に無い. "
+            "start() 内の lazy import に頼っている可能性: "
+            "`from watchdog.observers import Observer` を module-level try/except に含めること"
+        )
+
+
 def test_watcher_stop_safe_when_observer_not_started(vault: Path, index: VaultIndex) -> None:
     """``stop()`` が ``observer.start()`` 未呼び出し状態でも安全に完了する (#39).
 


### PR DESCRIPTION
## Summary

#39 follow-up cluster。責務「watcher observability hardening」として 4 issue を統合 TDD (パターン A) で解消。

- **#172**: `_WATCHDOG_AVAILABLE=True` でも `watchdog.observers` 欠落で `start()` が `ImportError` を投げる既知バグを解消。module-level try/except に Observer import を含める。
- **#173**: `ReindexStats.watcher_active: bool` 追加。`watcher_failure_count=0` で区別できなかった「watcher 未起動」と「失敗ゼロ」が bool で明示される。
- **#175**: `watcher_failure_count` description に `vault_reindex(force=True)` のリカバリ手順を追記。
- **#176**: `test_vault_reindex_structured_content_not_wrapped` の issubset に新 field 3 個追加 + 値の型/default 検証。

## Commits

| commit | issue | 内容 |
|---|---|---|
| Red (39b3edf) | all | 4 issue 統合の失敗テスト追加 |
| Green (3577ba5) | all | watcher.py / stats.py / server.py の最小実装 |

Refactor 省略理由: Green diff は +32/-8 行で repetition / 応急措置 / stale comment ゼロ。`.claude/rules/tdd-workflow.md` §「Refactor 省略の判断基準」準拠。

## Test plan

- [x] `uv run pytest` — 562 passed
- [x] `uv run ruff check && uv run ruff format` — clean
- [x] #172: `tests/test_watcher.py::test_watchdog_available_implies_observer_importable`
- [x] #173: `tests/test_mcp_wrapping.py::test_vault_reindex_watcher_active_true_when_watcher_running`
- [x] #175: `tests/test_mcp_wrapping.py::test_vault_reindex_watcher_failure_description_mentions_recovery`
- [x] #176: `tests/test_mcp_wrapping.py::test_vault_reindex_structured_content_not_wrapped` (extended)

https://claude.ai/code/session_0162Nfv33UDw3qDqD7Vhi7GN