### PR TITLE
Perf: skip COUNT(*) when search results fit under cap (#166)

### DIFF
--- a/src/vault_search/cache.py
+++ b/src/vault_search/cache.py
@@ -72,8 +72,9 @@ class TieredCache:
 
         ヒット時に ``CacheEntry`` 丸ごとを返すのは、``entry.total`` が
         ``len(entry.result)`` より大きいケース (結果が内部 cap で truncate
-        されたが COUNT(*) 経由で accurate な総件数が取れている状態) を
-        呼び出し側に伝えるため (#17)。
+        された over-cap エントリで accurate な総件数が別途取得された状態) を
+        呼び出し側に伝えるため (#17)。under-cap エントリでは
+        ``entry.total == len(entry.result)`` が成立する (#166)。
         """
         now = time.monotonic()
         key = self._cache_key(query, filters)
@@ -117,10 +118,11 @@ class TieredCache:
     ) -> None:
         """(query, filters) に対する結果を total 付きで格納する.
 
-        ``total`` は backend が報告した accurate な件数 (COUNT(*) 経由)。
-        ``len(result)`` が内部 cap (``_MAX_RESULTS``) で truncate された場合
-        でも ``total`` は実件数を保持するため、ページング終端判定は
-        ``entry.total`` を見ること (#17)。
+        ``total`` は呼び出し元が確定した accurate な件数。``VaultIndex.search``
+        では under-cap で ``len(result)`` を、over-cap で COUNT(*) クエリの
+        値をそれぞれ渡す (#166)。いずれも近似ではなく、``len(result)`` が内部
+        cap (``_MAX_RESULTS``) で truncate された場合でも ``total`` は実件数を
+        保持するため、ページング終端判定は ``entry.total`` を見ること (#17)。
 
         **Precondition (#31)**: ``result`` の各要素は rel-path を ``"path"`` キー
         で含むこと。含まれない要素は ``entry.paths`` から silent に抜け、

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -551,22 +551,29 @@ class VaultIndex:
         # Tier 2: FTS5 — 同一接続で FETCH と COUNT を実行する。
         # 別接続に分けると WAL の snapshot が食い違い、削除競合で
         # `total < len(results)` のような非整合が発生しうる (PR #165 review A1)。
+        # Issue #166: LIMIT を ``_MAX_RESULTS + 1`` にして truncation 判定を
+        # 結果サイズから導く。cap 以内 (通常ケース) は 1 クエリで総数が確定し、
+        # cap を超えた場合のみ COUNT(*) を発行して accurate total を取得する。
         with self.connection() as conn:
             results = self._fts5_search(
                 query,
                 tags=tags,
                 folder=folder,
                 metadata_conditions=conditions,
-                limit=self._MAX_RESULTS,
+                limit=self._MAX_RESULTS + 1,
                 conn=conn,
             )
-            total = self._count_matches(
-                query,
-                tags=tags,
-                folder=folder,
-                metadata_conditions=conditions,
-                conn=conn,
-            )
+            if len(results) <= self._MAX_RESULTS:
+                total = len(results)
+            else:
+                results = results[: self._MAX_RESULTS]
+                total = self._count_matches(
+                    query,
+                    tags=tags,
+                    folder=folder,
+                    metadata_conditions=conditions,
+                    conn=conn,
+                )
         self._cache.put(query, filters, results, total=total)
 
         sliced = results[offset : offset + limit]

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -185,9 +185,13 @@ class VaultIndex:
     """SQLite + FTS5 によるインデックスと検索エンジン."""
 
     # FTS5 / filter-only 結果をキャッシュに保持する上限 (Issue #17)。
-    # ``total`` は別途 COUNT(*) で取得するため ``_MAX_RESULTS`` を超えても
-    # accurate な件数がクライアントに届く。``truncated`` フラグで
-    # 「cache 側で切り詰められたか」を明示する。
+    # ``total`` は ``search()`` 内で under-cap なら ``len(results)``、
+    # over-cap なら COUNT(*) クエリ由来で確定する (Issue #166)。
+    # いずれも近似ではなく、``_MAX_RESULTS`` を超えた場合でも accurate な
+    # 件数がクライアントに届く。``truncated`` フラグで「cache 側で切り詰め
+    # られたか」を明示する。
+    # `validation.LIMIT_MAX` と同値。乖離すると over-cap の total が
+    # 入力 cap を超えうるため常に同期すること。
     _MAX_RESULTS = 500
 
     def __init__(self, vault_root: str | Path, db_path: str | Path | None = None):
@@ -499,6 +503,12 @@ class VaultIndex:
         ``query`` が空でも ``tags`` / ``folder`` / ``metadata_filter`` の
         いずれかが指定されていれば、DB 全体を対象に構造化フィルタだけで
         絞り込む。全引数が空の場合は空結果を返す。
+
+        ``total`` は tier 0/2 いずれでも近似ではなく常に accurate な件数を
+        返す。Tier 2 の cache miss では結果件数が内部 cap (``_MAX_RESULTS``)
+        以内なら ``len(results)`` を、cap を超えた場合は COUNT(*) クエリから
+        確定する (#166)。Tier 1 fuzzy hit のみ別クエリの ``total`` を再利用
+        するため近似値 (``schema://tools`` 参照)。
         """
         # folder を canonical 形式に正規化する。先頭 '/' や '\\' 区切りの
         # 入力を吸収し、スラッシュのみの場合は None (フィルタなし) にする。
@@ -810,6 +820,11 @@ class VaultIndex:
 
         ``_MAX_RESULTS`` での truncation を避け、ページング終端をエージェントに
         正しく伝えるために別クエリで発行する。
+
+        ``search()`` からは **over-cap 時のみ** 呼ばれる (#166): under-cap では
+        ``len(results)`` が accurate な total と一致するため COUNT(*) は不要。
+        直接呼び出すテスト / 他 caller は条件付きでない精確な件数が欲しい
+        場合に利用する。
 
         ``conn`` を渡せば caller と同一接続 (= 同一 WAL snapshot) で実行される。
         ``_fts5_search`` と pair で呼ぶときは必ず同じ接続を使うこと。

--- a/src/vault_search/schemas.py
+++ b/src/vault_search/schemas.py
@@ -112,8 +112,9 @@ class SearchResponse(BaseModel):
     total: int = Field(
         description=(
             "フィルタ後の総件数 (limit/offset 適用前)。"
-            "tier=0 (完全一致) / tier=2 (FTS5) では内部結果上限での truncate なしに正確な件数。"
-            "tier=1 (fuzzy cache hit) のみ類似クエリの件数を近似値として返す点に注意"
+            "tier=0 (完全一致) / tier=2 (FTS5) では truncated=false/true を問わず"
+            "accurate な件数。truncated=true (over-cap) のときは別 COUNT(*) クエリで取得される。"
+            "tier=1 (fuzzy cache hit) のみ類似クエリの件数を再利用する近似値である点に注意"
         ),
     )
     truncated: bool = Field(

--- a/src/vault_search/schemas.py
+++ b/src/vault_search/schemas.py
@@ -112,8 +112,8 @@ class SearchResponse(BaseModel):
     total: int = Field(
         description=(
             "フィルタ後の総件数 (limit/offset 適用前)。"
-            "tier=0 (完全一致) / tier=2 (FTS5) では truncated=false/true を問わず"
-            "accurate な件数。truncated=true (over-cap) のときは別 COUNT(*) クエリで取得される。"
+            "tier=0 (完全一致) / tier=2 (FTS5) では truncated=false/true を問わず "
+            "accurate な件数 (over-cap でも実件数が確定している)。"
             "tier=1 (fuzzy cache hit) のみ類似クエリの件数を再利用する近似値である点に注意"
         ),
     )

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -767,19 +767,37 @@ def test_search_total_accurate_beyond_max_results_fts_path(
 @pytest.mark.slow
 def test_search_truncated_flag_false_exactly_at_cap(
     bulk_vault_over_cap: tuple[Path, VaultIndex, int],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Issue #17: total == _MAX_RESULTS (ちょうど cap) のとき truncated=False.
+    """Issue #17 + #166: total == _MAX_RESULTS (ちょうど cap) のとき truncated=False.
 
-    境界判定が `>=` に劣化すると false positive の truncated になる regression。
+    境界判定が `>=` に劣化すると false positive の truncated になる regression (Issue #17)。
     bulk vault の先頭 cap 件に付与された ``AT_CAP_EDGE_TAG`` で filter し、
     総件数が cap ちょうどになるケースを独立 vault 構築なしで再現する (#169)。
+    加えて #166 の COUNT(*) skip 最適化も cap 境界で動作すること (`_count_matches`
+    を発行しない) を spy で確認する (C3: 同一 fixture を使う 2 契約を 1 テストに集約)。
     """
     _root, idx, cap = bulk_vault_over_cap
+    # Tier 0 / Tier 1 キャッシュが前テストの遺留値を返さないようリセット
+    # (`_count_matches` 呼出 0 の assertion は cache miss 経路 = Tier 2 で意味を持つ)。
+    idx._invalidate_caches()
+
+    count_calls = 0
+    original = idx._count_matches
+
+    def spy(*args: object, **kwargs: object) -> int:
+        nonlocal count_calls
+        count_calls += 1
+        return original(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(idx, "_count_matches", spy)
+
     res = idx.search("", tags=[AT_CAP_EDGE_TAG])
     assert res["total"] == cap
     assert res["truncated"] is False, (
         f"total=={cap} は cap 以内なので truncated=False; got {res['truncated']}"
     )
+    assert count_calls == 0, f"exactly-at-cap は COUNT(*) を skip する (#166); got {count_calls}"
 
 
 def test_search_truncated_flag_false_below_cap(
@@ -873,62 +891,62 @@ def test_search_under_cap_skips_count_query(
     assert count_calls == 0, "under-cap では COUNT(*) を発行しない"
 
 
+@pytest.mark.parametrize(
+    ("query", "extra_filters"),
+    [
+        pytest.param("", {"tags": ["bulk-tag"]}, id="filter-only"),
+        # "obsidian-bulk" は fixture 本文の FTS5 trigram marker (13 文字)。
+        # FTS5 JOIN 経路を通すことで filter-only と別 SQL 構造を別途 cover する。
+        pytest.param("obsidian-bulk", {}, id="fts"),
+    ],
+)
 def test_search_over_cap_issues_count_query(
     bulk_vault_over_cap: tuple[Path, VaultIndex, int],
     monkeypatch: pytest.MonkeyPatch,
+    query: str,
+    extra_filters: dict[str, object],
 ) -> None:
     """Issue #166: 結果が cap を超えたとき ``_count_matches`` で accurate total を取得する.
 
     cap+1 件ある vault で ``_count_matches`` がちょうど 1 回呼ばれ、
     truncated=True と accurate total が維持されることを確認する。
+    filter-only / FTS5 両パス (``_build_match_clause`` の ``FROM notes n`` vs
+    ``FROM notes_fts f JOIN notes n``) を parametrize で cover する (A2/C2)。
+
+    また ``_fts5_search`` に渡る ``limit`` が ``_MAX_RESULTS + 1`` である
+    こと (= over-cap sentinel fetch) を別 spy で pin する。これを外すと
+    旧 ``limit=_MAX_RESULTS`` の挙動でも本テストが通ってしまい vacuous に
+    なる (C1): under-cap テストだけでなく over-cap 側でも LIMIT 変更自体を
+    regression guard する狙い。
     """
     _root, idx, cap = bulk_vault_over_cap
 
     count_calls = 0
-    original = idx._count_matches
+    original_count = idx._count_matches
 
-    def spy(*args: object, **kwargs: object) -> int:
+    def count_spy(*args: object, **kwargs: object) -> int:
         nonlocal count_calls
         count_calls += 1
-        return original(*args, **kwargs)  # type: ignore[arg-type]
+        return original_count(*args, **kwargs)  # type: ignore[arg-type]
 
-    monkeypatch.setattr(idx, "_count_matches", spy)
+    fetch_limits: list[int] = []
+    original_fts = idx._fts5_search
 
-    res = idx.search("", tags=["bulk-tag"], limit=10)
+    def fts_spy(*args: object, **kwargs: object) -> list[dict[str, object]]:
+        fetch_limits.append(int(kwargs.get("limit", -1)))
+        return original_fts(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(idx, "_count_matches", count_spy)
+    monkeypatch.setattr(idx, "_fts5_search", fts_spy)
+
+    res = idx.search(query, limit=10, **extra_filters)  # type: ignore[arg-type]
     assert res["total"] == cap + 1
     assert res["truncated"] is True
     assert len(res["results"]) == 10
     assert count_calls == 1, "over-cap でのみ COUNT(*) を発行する"
-
-
-def test_search_exactly_at_cap_skips_count_query(
-    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Issue #166: total == cap ちょうどのケースでも COUNT(*) を skip する.
-
-    境界判定が ``>= cap`` に劣化すると cap ちょうどで COUNT(*) が走る
-    regression が起きる。LIMIT を cap+1 にして「cap+1 件取れたときだけ
-    COUNT」の契約が守られることを pin する。
-    """
-    cap = VaultIndex._MAX_RESULTS
-    notes = {f"edge/note_{i:04d}.md": "---\ntags: [edge]\n---\nbody\n" for i in range(cap)}
-    _root, idx = vault_builder(notes)
-
-    count_calls = 0
-    original = idx._count_matches
-
-    def spy(*args: object, **kwargs: object) -> int:
-        nonlocal count_calls
-        count_calls += 1
-        return original(*args, **kwargs)  # type: ignore[arg-type]
-
-    monkeypatch.setattr(idx, "_count_matches", spy)
-
-    res = idx.search("", tags=["edge"])
-    assert res["total"] == cap
-    assert res["truncated"] is False
-    assert count_calls == 0, "exactly-at-cap でも COUNT(*) を発行しない"
+    assert fetch_limits == [cap + 1], (
+        f"over-cap detect には LIMIT=_MAX_RESULTS+1 必須; got {fetch_limits}"
+    )
 
 
 def test_folder_prefix_does_not_match_sibling(vault_index: VaultIndex, tmp_vault: Path) -> None:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -891,6 +891,7 @@ def test_search_under_cap_skips_count_query(
     assert count_calls == 0, "under-cap では COUNT(*) を発行しない"
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     ("query", "extra_filters"),
     [

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -837,6 +837,100 @@ def test_search_tier1_fuzzy_preserves_truncated(
     assert second["truncated"] is True, "tier=1 でも truncated が保持される"
 
 
+# ---------------------------------------------------------------------------
+# Issue #166: cache miss 時の COUNT(*) 別発行が 2x コスト regression。
+# 結果が cap 以内なら COUNT(*) を skip し、cap を超えた truncate 発生時のみ
+# COUNT(*) を発行する optimization の regression guard。
+# ---------------------------------------------------------------------------
+
+
+def test_search_under_cap_skips_count_query(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #166: 結果が cap 以内のとき ``_count_matches`` を呼ばない.
+
+    通常ケース (vault の大半) で FTS5/filter SQL が 1 回だけ評価される
+    ことを spy で検証する。2 回評価される regression (cache miss 時 2x) を
+    防ぐガード。
+    """
+    notes = {f"a_{i}.md": "---\ntags: [few]\n---\nbody\n" for i in range(3)}
+    _root, idx = vault_builder(notes)
+
+    count_calls = 0
+    original = idx._count_matches
+
+    def spy(*args: object, **kwargs: object) -> int:
+        nonlocal count_calls
+        count_calls += 1
+        return original(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(idx, "_count_matches", spy)
+
+    res = idx.search("", tags=["few"])
+    assert res["total"] == 3
+    assert res["truncated"] is False
+    assert count_calls == 0, "under-cap では COUNT(*) を発行しない"
+
+
+def test_search_over_cap_issues_count_query(
+    bulk_vault_over_cap: tuple[Path, VaultIndex, int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #166: 結果が cap を超えたとき ``_count_matches`` で accurate total を取得する.
+
+    cap+1 件ある vault で ``_count_matches`` がちょうど 1 回呼ばれ、
+    truncated=True と accurate total が維持されることを確認する。
+    """
+    _root, idx, cap = bulk_vault_over_cap
+
+    count_calls = 0
+    original = idx._count_matches
+
+    def spy(*args: object, **kwargs: object) -> int:
+        nonlocal count_calls
+        count_calls += 1
+        return original(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(idx, "_count_matches", spy)
+
+    res = idx.search("", tags=["bulk-tag"], limit=10)
+    assert res["total"] == cap + 1
+    assert res["truncated"] is True
+    assert len(res["results"]) == 10
+    assert count_calls == 1, "over-cap でのみ COUNT(*) を発行する"
+
+
+def test_search_exactly_at_cap_skips_count_query(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #166: total == cap ちょうどのケースでも COUNT(*) を skip する.
+
+    境界判定が ``>= cap`` に劣化すると cap ちょうどで COUNT(*) が走る
+    regression が起きる。LIMIT を cap+1 にして「cap+1 件取れたときだけ
+    COUNT」の契約が守られることを pin する。
+    """
+    cap = VaultIndex._MAX_RESULTS
+    notes = {f"edge/note_{i:04d}.md": "---\ntags: [edge]\n---\nbody\n" for i in range(cap)}
+    _root, idx = vault_builder(notes)
+
+    count_calls = 0
+    original = idx._count_matches
+
+    def spy(*args: object, **kwargs: object) -> int:
+        nonlocal count_calls
+        count_calls += 1
+        return original(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(idx, "_count_matches", spy)
+
+    res = idx.search("", tags=["edge"])
+    assert res["total"] == cap
+    assert res["truncated"] is False
+    assert count_calls == 0, "exactly-at-cap でも COUNT(*) を発行しない"
+
+
 def test_folder_prefix_does_not_match_sibling(vault_index: VaultIndex, tmp_vault: Path) -> None:
     """folder='Projects' が 'Projects Hermes' のような兄弟を拾わないこと."""
     # 兄弟フォルダに同一トークンを含むノートを置く。


### PR DESCRIPTION
## Summary

Issue #166 の follow-up (PR #165 Reviewer D score 6/10)。`VaultIndex.search()` の cache miss 時に `_fts5_search(limit=500)` と `_count_matches()` が常に 2 回 DB を走る regression を解消する。

- `_fts5_search` の LIMIT を `_MAX_RESULTS + 1` に引き上げ
- 結果件数 ≤ cap なら `len(results)` を total として採用、COUNT(*) を skip
- 結果件数 == cap+1 のときのみ truncate + `_count_matches` で accurate total を取得

filter-only パス (空クエリ + tag / folder / metadata_filter) の full scan + index 2 度走査を解消し、large vault での latency regression を防ぐ。

## Commits (rebased on latest main)

- `dde8e3e` **Red**: `_count_matches` 呼出回数を spy する 3 ケース (under-cap / over-cap / exactly-at-cap)
- `7d1bbbf` **Green**: early-exit 条件分岐を `search()` に追加 (SQL 1 回 / 2 回の分岐)
- `7ba401a` **Fix (Round 1)**: review-loop Round 1 (4 Sonnet reviewers) 指摘を反映
  - docstring rot 解消 (`cache.py` / `indexer.py` / `schemas.py`) — "total は COUNT(*) 経由" の旧記述を under-cap/over-cap dual-path に書き直し
  - over-cap test を `[filter-only, fts]` parametrize 化 + `fetch_limits` spy で `_MAX_RESULTS+1` LIMIT を pin (vacuousness 解消)
  - exactly-at-cap の重複 500-note 構築を既存テストに合流
- `2c4d7b2` **Fix (Round 2)**: Round 2 reviewer D (score 5) / A (score 4) 指摘を反映
  - `SearchResponse.total` description の Round 1 Fix drift を outcome 記述に置換 ("別 COUNT(*) クエリで取得される" は tier=0 cache hit × truncated=true で不正確 / space 欠落)
- `dd6e13b` **Fix (rebase)**: #229 の universal marker guard との整合化
  - rebase で取り込んだ `tests/test_fixture_markers.py` (#229) が over-cap parametrize の `@pytest.mark.slow` 欠落を検出 → marker 追加

## Refactor を省略した理由

Green diff は 15 insertions / 8 deletions の 1 箇所局所変更で、repetition / 応急措置 / stale comment は混入していない (`.claude/rules/tdd-workflow.md` の省略判定基準 参照)。Round 1/2 Fix は review-loop 指摘由来なので Refactor とは独立の commit として分離。

## Follow-up Issue

- **#226** — `_MAX_RESULTS` (indexer 内部 sentinel) と `LIMIT_MAX` (tool validation 上限) の sync regression guard。現状は code comment で明記済だが test ガードがないため、Round 1 Reviewer D (score 6) 指摘を独立 issue として追跡。

## 完了条件 (issue #166)

- [x] 通常ケース (結果が cap 以内) で 1 クエリ発行になることをテストで確認 (`test_search_under_cap_skips_count_query`)
- [x] truncate ケースで既存挙動 (accurate total + truncated=True) を維持 (既存 `test_search_total_accurate_beyond_max_results_*` が継続通過)
- [x] 追加テストで cap 境界 (500 件ちょうど / 501 件) を両方カバー (`test_search_truncated_flag_false_exactly_at_cap` に count spy 併設 / `test_search_over_cap_issues_count_query[filter-only,fts]`)

## Review-loop 判定

- **Round 1** (4 Sonnet reviewers, A/B/C/D 視点): findings を `7ba401a` で吸収、#226 起票
- **Round 2** (2 Sonnet reviewers, A/D 視点): `2c4d7b2` で最終 fix、両 reviewer とも **CONVERGED** 判定 (新規 score ≥6 ゼロ)

## Test plan

- [x] `.venv/bin/pytest` — 596 passed
- [x] `.venv/bin/ruff check` / `ruff format` — clean
- [x] CI (lint + test 3.11/3.12/3.13) — all green (rebased branch で再実行予定)

https://claude.ai/code/session_01Uth7AG18ZnaYbDXtnMnXHj