### PR TITLE
build_index 差分 rebuild でも granular cache invalidate を使う (#219)

### DIFF
--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -330,7 +330,9 @@ class VaultIndex:
                 )
                 stats["deleted"] = len(deleted_paths)
 
-            # 追加・更新
+            # 追加・更新 — 差分 rebuild では UPSERT した path を収集し
+            # granular invalidate に渡す (#219)。
+            touched: set[str] = set(deleted_paths)
             for rel_path, mtime in current_files.items():
                 if not force and rel_path in existing:
                     if existing[rel_path] >= mtime:
@@ -344,6 +346,7 @@ class VaultIndex:
                     continue
 
                 self._upsert_note(conn, note, mtime)
+                touched.add(rel_path)
 
                 if rel_path in existing:
                     stats["updated"] += 1
@@ -352,7 +355,9 @@ class VaultIndex:
 
             conn.commit()
 
-            self._invalidate_caches()
+            # force=True は全件再構築なので全 clear。force=False は touched 集合
+            # を渡して unrelated query の Tier 0/1 cache を温存する (#219)。
+            self._invalidate_caches(changed_paths=None if force else touched)
 
             logger.info(
                 "Index built: added=%d updated=%d deleted=%d skipped=%d errors=%d",

--- a/src/vault_search/indexer.py
+++ b/src/vault_search/indexer.py
@@ -331,7 +331,8 @@ class VaultIndex:
                 stats["deleted"] = len(deleted_paths)
 
             # 追加・更新 — 差分 rebuild では UPSERT した path を収集し
-            # granular invalidate に渡す (#219)。
+            # granular invalidate に渡す (#219)。force=True は全 clear なので
+            # touched を populate しない (dead work 回避)。
             touched: set[str] = set(deleted_paths)
             for rel_path, mtime in current_files.items():
                 if not force and rel_path in existing:
@@ -346,7 +347,8 @@ class VaultIndex:
                     continue
 
                 self._upsert_note(conn, note, mtime)
-                touched.add(rel_path)
+                if not force:
+                    touched.add(rel_path)
 
                 if rel_path in existing:
                     stats["updated"] += 1

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -531,6 +531,10 @@ def test_build_index_differential_granular_invalidate_preserves_unrelated(
     res_beta_after = idx.search("beta")
     assert res_alpha_after["tier"] == 2, "a.md を含む alpha cache は drop される"
     assert res_beta_after["tier"] == 0, "b.md のみの beta cache は granular で残る"
+    # Tier 2 再実行で a.md がまだヒットすることを確認 (FTS 再索引の健全性)
+    assert {r["path"] for r in res_alpha_after["results"]} == {"a.md"}
+    # 保全された beta cache の内容が正しいことを確認
+    assert {r["path"] for r in res_beta_after["results"]} == {"b.md"}
 
 
 def test_build_index_differential_granular_invalidate_on_deletion(
@@ -559,6 +563,8 @@ def test_build_index_differential_granular_invalidate_on_deletion(
     assert res_alpha["tier"] == 2
     assert res_beta["tier"] == 0
     assert res_alpha["results"] == []
+    # 保全された beta cache の内容が正しいことを確認
+    assert {r["path"] for r in res_beta["results"]} == {"b.md"}
 
 
 def test_build_index_force_true_clears_all_caches(
@@ -578,47 +584,65 @@ def test_build_index_force_true_clears_all_caches(
     idx.search("alpha")
     idx.search("beta")
 
+    # aggregate cache も warm up
+    idx.list_frontmatter_keys()
+    idx.known_keys_set()
+
     idx.build_index(force=True)
 
-    # どちらも drop されて Tier 2 再実行
+    # どちらの tiered cache も drop されて Tier 2 再実行
     res_alpha = idx.search("alpha")
     res_beta = idx.search("beta")
     assert res_alpha["tier"] == 2
     assert res_beta["tier"] == 2
+    # force=True は aggregate cache も全 clear
+    assert idx._frontmatter_keys_cache is None
+    assert idx._known_keys_cache is None
 
 
 def test_build_index_differential_invalidates_frontmatter_keys_cache(
     vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
 ) -> None:
-    """Issue #219: 差分 rebuild でも frontmatter_keys / known_keys cache は full clear.
+    """Issue #219: 差分 rebuild は tiered cache を granular に保全しつつ aggregate は必ず全 clear.
 
-    granular invalidate は tiered cache のみに適用し、aggregate 依存の
-    frontmatter_keys / known_keys cache は従来通り全 clear する (1 note の
-    frontmatter 変化が aggregate 全体に波及しうるため)。
+    b.md のみ編集した差分 rebuild 後:
+    - ``frontmatter_keys_cache`` / ``known_keys_cache`` は全 clear (aggregate 依存)
+    - a.md のみを結果に含む tiered cache entry は保全 (granular invalidate の効果)
+
+    後者のアサーションは「旧コードでは Tier 2 (全 clear) になる」ため、このテストは
+    旧コードでは FAIL する — テスト自体が PR #219 固有の新動作を確かめている。
     """
     root, idx = vault_builder(
         {
-            "a.md": "---\nstatus: active\n---\n\nbody\n",
-            "b.md": "---\nstatus: draft\n---\n\nbody\n",
+            "a.md": "---\nstatus: active\n---\n\nalpha specific body\n",
+            "b.md": "---\nstatus: draft\n---\n\nbeta specific body\n",
         }
     )
-    # cache を warm up
+    # tiered cache と aggregate cache を warm up
+    res_alpha = idx.search("alpha")
+    assert res_alpha["tier"] == 2
+    assert {r["path"] for r in res_alpha["results"]} == {"a.md"}
     idx.list_frontmatter_keys()
     idx.known_keys_set()
     assert idx._frontmatter_keys_cache is not None
     assert idx._known_keys_cache is not None
 
-    # 差分 rebuild — b.md を編集 (status 値を変える)
+    # 差分 rebuild — b.md のみ編集 (a.md は mtime 変化なし → skip)
     b_path = root / "b.md"
-    b_path.write_text("---\nstatus: archived\n---\n\nbody\n", encoding="utf-8")
+    b_path.write_text("---\nstatus: archived\n---\n\nbeta specific body\n", encoding="utf-8")
     future = time.time() + 10.0
     os.utime(b_path, (future, future))
 
-    idx.build_index(force=False)
+    stats = idx.build_index(force=False)
+    assert stats["updated"] == 1
+    assert stats["skipped"] == 1  # a.md は skip
 
-    # aggregate cache は常に clear
+    # aggregate cache は常に clear (granular invalidate の対象外)
     assert idx._frontmatter_keys_cache is None
     assert idx._known_keys_cache is None
+    # tiered cache は a.md を結果に含む entry を保全 — 旧コードでは Tier 2 になる
+    res_alpha_after = idx.search("alpha")
+    assert res_alpha_after["tier"] == 0, "a.md のみの alpha cache は granular で残る"
 
 
 def test_search_empty_query_returns_empty(vault_index: VaultIndex) -> None:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -492,6 +493,132 @@ def test_cache_granular_invalidate_on_file_deletion(
     assert res_beta["tier"] == 0
     # 削除後の alpha 検索結果は空
     assert res_alpha["results"] == []
+
+
+def test_build_index_differential_granular_invalidate_preserves_unrelated(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """Issue #219: ``build_index(force=False)`` の差分 rebuild が granular invalidate を使う.
+
+    ``a.md`` のみ "alpha" を含み、``b.md`` のみ "beta" を含む。``a.md`` を編集した
+    後に差分 rebuild を走らせると、"beta" cache (b.md のみを結果に含む) は Tier 0
+    のまま残り、"alpha" cache (a.md を含む) は drop されて Tier 2 再実行になる。
+    """
+    root, idx = vault_builder(
+        {
+            "a.md": "# A\n\nalpha content here.\n",
+            "b.md": "# B\n\nbeta content here.\n",
+        }
+    )
+    res_alpha = idx.search("alpha")
+    res_beta = idx.search("beta")
+    assert res_alpha["tier"] == 2
+    assert res_beta["tier"] == 2
+    assert {r["path"] for r in res_alpha["results"]} == {"a.md"}
+    assert {r["path"] for r in res_beta["results"]} == {"b.md"}
+
+    # a.md を編集し、mtime を明示的に進める (粗い mtime 粒度の FS での flaky 回避)。
+    a_path = root / "a.md"
+    a_path.write_text("# A updated\n\nalpha content updated.\n", encoding="utf-8")
+    future = time.time() + 10.0
+    os.utime(a_path, (future, future))
+
+    stats = idx.build_index(force=False)
+    assert stats["updated"] == 1
+    assert stats["skipped"] == 1  # b.md は skip
+
+    res_alpha_after = idx.search("alpha")
+    res_beta_after = idx.search("beta")
+    assert res_alpha_after["tier"] == 2, "a.md を含む alpha cache は drop される"
+    assert res_beta_after["tier"] == 0, "b.md のみの beta cache は granular で残る"
+
+
+def test_build_index_differential_granular_invalidate_on_deletion(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """Issue #219: 差分 rebuild の DELETE 経路でも granular invalidate を呼ぶ.
+
+    vault から ``a.md`` を削除した後に ``build_index(force=False)`` を走らせると、
+    ``a.md`` を含む cache entry が drop される。無関係な entry は Tier 0 を保つ。
+    """
+    root, idx = vault_builder(
+        {
+            "a.md": "# A\n\nalpha content.\n",
+            "b.md": "# B\n\nbeta content.\n",
+        }
+    )
+    idx.search("alpha")
+    idx.search("beta")
+
+    (root / "a.md").unlink()
+    stats = idx.build_index(force=False)
+    assert stats["deleted"] == 1
+
+    res_alpha = idx.search("alpha")
+    res_beta = idx.search("beta")
+    assert res_alpha["tier"] == 2
+    assert res_beta["tier"] == 0
+    assert res_alpha["results"] == []
+
+
+def test_build_index_force_true_clears_all_caches(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """Issue #219: ``force=True`` は従来通り全 clear する (granular invalidate しない).
+
+    force=True は vault が壊れている / スキーマ更新等の full rebuild ユースケースなので、
+    touched path 集合を組み立てず ``changed_paths=None`` 相当で全 entry を落とす。
+    """
+    _root, idx = vault_builder(
+        {
+            "a.md": "# A\n\nalpha content.\n",
+            "b.md": "# B\n\nbeta content.\n",
+        }
+    )
+    idx.search("alpha")
+    idx.search("beta")
+
+    idx.build_index(force=True)
+
+    # どちらも drop されて Tier 2 再実行
+    res_alpha = idx.search("alpha")
+    res_beta = idx.search("beta")
+    assert res_alpha["tier"] == 2
+    assert res_beta["tier"] == 2
+
+
+def test_build_index_differential_invalidates_frontmatter_keys_cache(
+    vault_builder: Callable[[dict[str, str]], tuple[Path, VaultIndex]],
+) -> None:
+    """Issue #219: 差分 rebuild でも frontmatter_keys / known_keys cache は full clear.
+
+    granular invalidate は tiered cache のみに適用し、aggregate 依存の
+    frontmatter_keys / known_keys cache は従来通り全 clear する (1 note の
+    frontmatter 変化が aggregate 全体に波及しうるため)。
+    """
+    root, idx = vault_builder(
+        {
+            "a.md": "---\nstatus: active\n---\n\nbody\n",
+            "b.md": "---\nstatus: draft\n---\n\nbody\n",
+        }
+    )
+    # cache を warm up
+    idx.list_frontmatter_keys()
+    idx.known_keys_set()
+    assert idx._frontmatter_keys_cache is not None
+    assert idx._known_keys_cache is not None
+
+    # 差分 rebuild — b.md を編集 (status 値を変える)
+    b_path = root / "b.md"
+    b_path.write_text("---\nstatus: archived\n---\n\nbody\n", encoding="utf-8")
+    future = time.time() + 10.0
+    os.utime(b_path, (future, future))
+
+    idx.build_index(force=False)
+
+    # aggregate cache は常に clear
+    assert idx._frontmatter_keys_cache is None
+    assert idx._known_keys_cache is None
 
 
 def test_search_empty_query_returns_empty(vault_index: VaultIndex) -> None:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -643,6 +643,8 @@ def test_build_index_differential_invalidates_frontmatter_keys_cache(
     # tiered cache は a.md を結果に含む entry を保全 — 旧コードでは Tier 2 になる
     res_alpha_after = idx.search("alpha")
     assert res_alpha_after["tier"] == 0, "a.md のみの alpha cache は granular で残る"
+    # 保全された cache 内容が a.md を指していることを確認 (C6 パターンに一致)
+    assert {r["path"] for r in res_alpha_after["results"]} == {"a.md"}
 
 
 def test_search_empty_query_returns_empty(vault_index: VaultIndex) -> None:


### PR DESCRIPTION
## Summary

- `VaultIndex.build_index(force=False)` が touched rel-path 集合 (削除 ∪ UPSERT) を組み立てて `_invalidate_caches(changed_paths=...)` に渡すようにした。PR #216 で `update_single` に導入した granular invalidation を build_index 差分経路にも拡張し、1 ファイル編集で unrelated query の Tier 0/1 cache を温存する。
- `force=True` は従来通り全 clear (`changed_paths=None`)。aggregate 依存の `_frontmatter_keys_cache` / `_known_keys_cache` は `_invalidate_caches` 内で無条件全 clear なので、従来挙動を保つ。

## Commit

- `d9e9355` **Red**: 4 tests (2 FAIL / 2 PASS — preserve / delete / force=True / aggregate cache clear)
- `2bbc66a` **Green**: `touched: set[str]` を組み立て、`_invalidate_caches(changed_paths=None if force else touched)` に切替 (+7 / -2 lines)
- Refactor は省略。Green diff に repetition / 応急回避 / stale comment なく、touched 集合を `deleted_paths` で初期化して UPSERT で `add` する minimal な構造のみ。

## Test plan

- [x] `.venv/bin/pytest -q` — 591 passed (4 new + 587 既存)
- [x] `.venv/bin/ruff check src tests` — clean
- [x] `.venv/bin/ruff format --check src tests` — 34 files already formatted

## 完了条件

- [x] `build_index(force=False)` が touched path 集合を組み立てて `_invalidate_caches(changed_paths=...)` に渡す
- [x] `force=True` は従来通り full clear (`changed_paths=None`)
- [x] 差分 rebuild で unrelated cache が残る integration test (`test_build_index_differential_granular_invalidate_preserves_unrelated` / `_on_deletion`)
- [x] `frontmatter_keys_cache` / `known_keys_cache` は従来通り full clear を維持 (regression test `test_build_index_differential_invalidates_frontmatter_keys_cache` で pin)

Closes #219

https://claude.ai/code/session_01JdP3BEWXemX1FPPYJ3nar2