### PR TITLE
Add wire_prefix to error entries for standalone wire format understanding

### DIFF
--- a/src/vault_search/payload_meta.py
+++ b/src/vault_search/payload_meta.py
@@ -89,7 +89,10 @@ from .schema_meta import FrontmatterKeyInfo
 # errors から abstract=True entry を除外 (VAULT_SEARCH_ERROR / #200 — agent
 # 視点の destructive subset 変更だが ErrorCode Literal には残るため minor
 # 扱い: agent が version<2.1 を cache していた場合のみ key 集合 diff が出る)。
-_SCHEMA_VERSION: str = "2.1"
+# 2.2: errors[code] に wire_prefix field 追加 (additive, #214) — entry 単独で
+# FastMCP wrap 形式を理解できるよう top-level errors_wire_format_note への
+# backreference を per-entry に置く。
+_SCHEMA_VERSION: str = "2.2"
 
 # payload["version"] の bumping policy。agent が cache invalidation 判断に使う。
 # version 2.0 はこのポリシーを確立した版であり、同時に 1.x からの破壊的変更

--- a/src/vault_search/payload_meta.py
+++ b/src/vault_search/payload_meta.py
@@ -131,6 +131,8 @@ _OVERVIEW: str = (
     "エラー応答は FastMCP により 'Error executing tool <tool>: <message>' 形式で wrap されるため、"
     "errors セクションを使う前に top-level の errors_wire_format_note を読むこと。"
     "errors[code].example は wrap 前の raw message を示し、agent は substring matching で判定する。"
+    "exact wire message が必要な場合は "
+    "errors[code].wire_prefix.replace('<tool>', tool_name) + errors[code].example で構築できる。"
 )
 
 # Tool 名は server.mcp.list_tools() 経由で tests/test_schema_resource.py の drift guard が

--- a/src/vault_search/resources.py
+++ b/src/vault_search/resources.py
@@ -44,8 +44,19 @@ from .schema_meta import FrontmatterKeyInfo
 __all__ = ["build_schema_payload"]
 
 
+# 全 error entry に付与する共通の wire-format prefix template (#214).
+#
+# entry に直接 dict access した agent が top-level errors_wire_format_note を
+# 経由せずに FastMCP の wrap 形式を理解できるようにするための backreference。
+# ``<tool>`` は呼び出し時の MCP tool 名 (例: vault_search) に置換される placeholder。
+# agent は ``wire_prefix.replace("<tool>", name) + example`` で期待 wire
+# message を構築できる。値は全 entry 共通の定数なので、将来の FastMCP wrap 形式
+# 変更時は本定数 1 箇所だけ更新する。
+_ERROR_WIRE_PREFIX_TEMPLATE: str = "Error executing tool <tool>: "
+
+
 def _serialize_error_catalog() -> dict[str, dict[str, str]]:
-    """``ERROR_CATALOG`` を agent-facing wire 形式に変換する (#199 / #200 / #201).
+    """``ERROR_CATALOG`` を agent-facing wire 形式に変換する (#199 / #200 / #201 / #214).
 
     * ``exception_class`` は live class 参照なので ``__name__`` に展開する
       (raised_by)
@@ -53,12 +64,16 @@ def _serialize_error_catalog() -> dict[str, dict[str, str]]:
       が agent の pattern-match 対象に混ざらないようにする (#200)
     * 戻り dict の key は ``ErrorCode`` Literal 値と一致する (string literal に
       統一、live class attr は参照しない #199)
+    * 各 entry に共通の ``wire_prefix`` を付与し、entry 単独で wire 形式を
+      理解可能にする (#214 — top-level ``errors_wire_format_note`` への
+      backreference)
     """
     return {
         code: {
             "raised_by": info["exception_class"].__name__,
             "description": info["description"],
             "example": info["example"],
+            "wire_prefix": _ERROR_WIRE_PREFIX_TEMPLATE,
         }
         for code, info in ERROR_CATALOG.items()
         if not info.get("abstract", False)

--- a/tests/test_schema_resource.py
+++ b/tests/test_schema_resource.py
@@ -781,6 +781,51 @@ def test_payload_has_errors_wire_format_note(vault_index: VaultIndex) -> None:
     )
 
 
+def test_payload_errors_entries_have_wire_prefix(vault_index: VaultIndex) -> None:
+    """各 error entry に共通の ``wire_prefix`` が付与される (#214).
+
+    entry に直接 dict access した agent が top-level ``errors_wire_format_note``
+    を skim しなくても FastMCP の wrap 形式を理解できるようにする。全 entry
+    共通の定数文字列で、``<tool>`` placeholder を含むことで template 形式を
+    明示する (agent が ``wire_prefix.replace('<tool>', name) + example`` を
+    構築できる)。
+    """
+    from typing import get_args
+
+    from vault_search.exceptions import ERROR_CATALOG, ErrorCode
+    from vault_search.resources import build_schema_payload
+
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
+    errors = payload["errors"]
+
+    abstract_codes = {c for c, info in ERROR_CATALOG.items() if info.get("abstract", False)}
+    concrete_codes = set(get_args(ErrorCode)) - abstract_codes
+
+    prefixes: set[str] = set()
+    for code in concrete_codes:
+        entry = errors[code]
+        assert "wire_prefix" in entry, (
+            f"errors['{code}'] missing 'wire_prefix' (#214): {entry!r}"
+        )
+        prefix = entry["wire_prefix"]
+        assert isinstance(prefix, str) and prefix.strip(), (
+            f"errors['{code}']['wire_prefix'] must be non-empty str: {prefix!r}"
+        )
+        assert "Error executing tool" in prefix, (
+            f"wire_prefix must document FastMCP wrap shape: {prefix!r}"
+        )
+        assert "<tool>" in prefix, (
+            f"wire_prefix must expose '<tool>' placeholder so agent can "
+            f"construct wrapped message per tool name: {prefix!r}"
+        )
+        prefixes.add(prefix)
+
+    assert len(prefixes) == 1, (
+        f"wire_prefix must be a single shared constant across all entries, "
+        f"got {len(prefixes)} distinct values: {prefixes}"
+    )
+
+
 def test_resources_module_does_not_import_validation(vault_index: VaultIndex) -> None:
     """resources.py は例外階層を import しない (#201 dependency inversion).
 

--- a/tests/test_schema_resource.py
+++ b/tests/test_schema_resource.py
@@ -661,7 +661,7 @@ def test_payload_has_errors_section(vault_index: VaultIndex) -> None:
         assert code in errors, f"errors['{code}'] missing: got {sorted(errors)}"
         entry = errors[code]
         assert isinstance(entry, dict), f"errors['{code}'] must be dict: {entry!r}"
-        for field in ("description", "raised_by", "example"):
+        for field in ("description", "raised_by", "example", "wire_prefix"):
             assert field in entry, f"errors['{code}'] missing '{field}': {entry!r}"
             assert isinstance(entry[field], str) and entry[field].strip(), (
                 f"errors['{code}']['{field}'] must be non-empty str: {entry[field]!r}"

--- a/tests/test_schema_resource.py
+++ b/tests/test_schema_resource.py
@@ -824,6 +824,46 @@ def test_payload_errors_entries_have_wire_prefix(vault_index: VaultIndex) -> Non
     )
 
 
+def test_wire_prefix_matches_actual_fastmcp_wrap(
+    vault_index: VaultIndex, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``wire_prefix`` template が実 FastMCP の wrap 形式と一致する (#214 drift guard).
+
+    ``_ERROR_WIRE_PREFIX_TEMPLATE`` は hardcode 文字列なので、FastMCP upgrade で
+    ``ToolError(f"Error executing tool {name}: {e}")`` の wrap 形式が変わった
+    場合に silent に嘘をつく (agent は実 wire と異なる prefix を期待する) リスク
+    がある。実際にエラーを誘発して FastMCP の出力を捕捉し、``wire_prefix`` を
+    ``<tool>`` 展開した文字列が prefix として一致することを assert する。
+
+    本テストが失敗したら ``src/vault_search/resources.py`` の
+    ``_ERROR_WIRE_PREFIX_TEMPLATE`` を実 wrap 形式に追随させる。
+    """
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    from vault_search import server as server_mod
+    from vault_search.resources import build_schema_payload
+
+    monkeypatch.setattr(server_mod, "_index", vault_index)
+
+    payload = build_schema_payload(vault_index.list_frontmatter_keys())
+    # 全 entry 共通の定数なので任意の concrete entry から 1 件取り出す
+    wire_prefix_template = next(iter(payload["errors"].values()))["wire_prefix"]
+
+    tool_name = "vault_get_note"
+    with pytest.raises(ToolError) as exc_info:
+        asyncio.run(server_mod.mcp.call_tool(tool_name, {"path": "__does_not_exist__.md"}))
+
+    expected_prefix = wire_prefix_template.replace("<tool>", tool_name)
+    actual = str(exc_info.value)
+    assert actual.startswith(expected_prefix), (
+        "wire_prefix template drifted from FastMCP actual wrap shape.\n"
+        f"  expected prefix: {expected_prefix!r}\n"
+        f"  actual message:  {actual!r}\n"
+        "Update _ERROR_WIRE_PREFIX_TEMPLATE in src/vault_search/resources.py "
+        "to match the current FastMCP wrap format."
+    )
+
+
 def test_resources_module_does_not_import_validation(vault_index: VaultIndex) -> None:
     """resources.py は例外階層を import しない (#201 dependency inversion).
 

--- a/tests/test_schema_resource.py
+++ b/tests/test_schema_resource.py
@@ -804,9 +804,7 @@ def test_payload_errors_entries_have_wire_prefix(vault_index: VaultIndex) -> Non
     prefixes: set[str] = set()
     for code in concrete_codes:
         entry = errors[code]
-        assert "wire_prefix" in entry, (
-            f"errors['{code}'] missing 'wire_prefix' (#214): {entry!r}"
-        )
+        assert "wire_prefix" in entry, f"errors['{code}'] missing 'wire_prefix' (#214): {entry!r}"
         prefix = entry["wire_prefix"]
         assert isinstance(prefix, str) and prefix.strip(), (
             f"errors['{code}']['wire_prefix'] must be non-empty str: {prefix!r}"


### PR DESCRIPTION
## Summary
Add a `wire_prefix` field to each error entry in the schema payload, enabling agents to understand FastMCP's error wrapping format without needing to reference the top-level `errors_wire_format_note`. This improves robustness when agents access error entries directly via dict lookup.

## Changes
- **resources.py**: 
  - Introduce `_ERROR_WIRE_PREFIX_TEMPLATE` constant containing the FastMCP error wrap prefix with a `<tool>` placeholder
  - Update `_serialize_error_catalog()` to include `wire_prefix` in each error entry
  - Update docstring to document the new field and its purpose

- **payload_meta.py**:
  - Bump schema version from "2.1" to "2.2" (additive change)
  - Document the new `wire_prefix` field addition in version history

- **test_schema_resource.py**:
  - Add comprehensive test `test_payload_errors_entries_have_wire_prefix()` that validates:
    - All concrete error codes have a `wire_prefix` field
    - The prefix is a non-empty string documenting FastMCP wrap shape
    - The prefix contains the `<tool>` placeholder for per-tool customization
    - All entries share a single constant prefix value

## Implementation Details
- The `wire_prefix` is a shared constant across all error entries, allowing agents to construct wrapped error messages via `wire_prefix.replace("<tool>", tool_name) + example`
- This design enables centralized updates to the wire format in a single location if FastMCP's wrapping format changes
- The change is backward-compatible (additive) and properly versioned in the schema

https://claude.ai/code/session_0143ywX5HWwXj4eYMgRzTEmx