### PR TITLE
Fix: record fail-loud decision for vault_reindex dict spread (#210)

### DIFF
--- a/.claude/rules/fastmcp-gotchas.md
+++ b/.claude/rules/fastmcp-gotchas.md
@@ -78,6 +78,37 @@
 - 撤去候補: MCP 2.0 / FastMCP 上流で `ToolError` が structured payload を
   サポートした時点で本 Gotcha は解消
 
+## vault_reindex の dict spread key 衝突 (fail-loud 方針)
+
+- **経緯**: PR #209 (#174 修正) で `stats.update(watcher_stats)` から
+  `ReindexStats(**stats, **watcher_stats)` に変更。同名 kwarg が重複した
+  場合の挙動が `silent override` (watcher 勝ち) から
+  `TypeError: got multiple values for keyword argument` に変わった
+- **採用方針 (#210)**: `TypeError` 維持 (fail-loud)。silent override は
+  復元しない
+- **根拠**:
+  - key 衝突は indexer が watcher 所管の key を誤って返しているバグで、
+    user-visible error ではなく developer error として扱う方が適切
+  - silent override は「watcher 側が勝つ」という挙動を agent / user に
+    暗黙に押しつける。将来 indexer が新 key を返すようになったとき、
+    watcher 値が勝ち続ける現在の挙動は silent な regression 源になりうる
+  - 本プロジェクトの一般方針 (frontmatter-normalization.md の
+    `_normalize_scalar` の「silent coercion を許さない」等) も fail-loud 寄り
+- **MCP 経路での副作用**: `TypeError` は FastMCP の `ToolError` wrap により
+  平文 `Tool execution failed` として agent に届く (上の `Tool error —
+  構造化属性の wire 消失` 参照)。agent 側での復旧は不可能だが、これは
+  CI / dev で検出すべき programmer error であり、production wire で
+  graceful degrade する必要はない
+- **regression guard**:
+  `tests/test_server.py::test_vault_reindex_stats_and_watcher_keys_are_disjoint`
+  が `build_index()` の key と watcher `failure_stats()` + `watcher_active`
+  の key が disjoint であることを CI で検証。将来 `ReindexStats` の key を
+  追加するとき、どちらの dict が owns するかを設計者に強制的に選ばせる
+- **再評価のトリガ**: `watcher_active` 的な派生 key を両側から返したい
+  ユースケース (例: indexer が watcher の健全性を踏まえた complex stat
+  を返す) が出てきたとき。その時は `ReindexStats(**{**stats, **watcher_stats})`
+  で明示的に merge 方向を宣言する案を再考する
+
 ## Tool annotations
 
 - **付与経路**: `mcp_contract.py` の `_TOOL_SPECS[name].annotations` に

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -299,6 +299,8 @@ def vault_reindex(force: bool = False) -> dict[str, Any]:
         # assign するため、watchdog 未インストールや inotify 上限で start() が
         # False を返しても _watcher は残る。実際の監視状態は is_active() で判定 (#173)。
         watcher_stats["watcher_active"] = _watcher.is_active()
+    # dict spread の key 衝突は fail-loud 方針で TypeError 維持 (#210 / fastmcp-gotchas.md)。
+    # 両辺の key は test_vault_reindex_stats_and_watcher_keys_are_disjoint で disjoint を CI lock。
     return ReindexStats(**stats, **watcher_stats).model_dump(mode="json")
 
 

--- a/src/vault_search/server.py
+++ b/src/vault_search/server.py
@@ -292,16 +292,32 @@ def vault_reindex(force: bool = False) -> dict[str, Any]:
             区別できるようにする。
     """
     stats = _get_index().build_index(force=force)
-    watcher_stats: dict[str, Any] = {}
-    if _watcher is not None:
-        watcher_stats.update(_watcher.failure_stats())
-        # _watcher is not None だけでは不足 — main() は start() の返り値に関わらず
-        # assign するため、watchdog 未インストールや inotify 上限で start() が
-        # False を返しても _watcher は残る。実際の監視状態は is_active() で判定 (#173)。
-        watcher_stats["watcher_active"] = _watcher.is_active()
+    watcher_stats = _compute_watcher_stats(_watcher)
     # dict spread の key 衝突は fail-loud 方針で TypeError 維持 (#210 / fastmcp-gotchas.md)。
     # 両辺の key は test_vault_reindex_stats_and_watcher_keys_are_disjoint で disjoint を CI lock。
     return ReindexStats(**stats, **watcher_stats).model_dump(mode="json")
+
+
+def _compute_watcher_stats(watcher: VaultWatcher | None) -> dict[str, Any]:
+    """``vault_reindex`` response にマージする watcher 由来 stats を組み立てる.
+
+    ``watcher`` が ``None`` (``--no-watch`` または未初期化) の場合は空 dict。
+    この関数を ``vault_reindex`` と regression test
+    (``test_vault_reindex_stats_and_watcher_keys_are_disjoint``) の双方から
+    呼び出すことで、call site に新 key が追加されたときに test 側の key 集合が
+    自動追従する (#210 review D-1).
+
+    ``_watcher is not None`` だけでは不足 — ``main()`` は ``start()`` の返り値に
+    関わらず assign するため、watchdog 未インストールや inotify 上限で
+    ``start()`` が False を返しても ``_watcher`` は残る。実際の監視状態は
+    ``is_active()`` で判定 (#173)。
+    """
+    if watcher is None:
+        return {}
+    stats: dict[str, Any] = {}
+    stats.update(watcher.failure_stats())
+    stats["watcher_active"] = watcher.is_active()
+    return stats
 
 
 @mcp.tool(annotations=TOOL_SPECS["vault_stats"].annotations)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -336,6 +336,34 @@ def test_vault_reindex_does_not_mutate_build_index_return(
     )
 
 
+def test_vault_reindex_stats_and_watcher_keys_are_disjoint(vault_index: VaultIndex) -> None:
+    """``ReindexStats(**stats, **watcher_stats)`` の key 衝突回避を構造的に保証する (#210).
+
+    server.py の ``vault_reindex`` は ``build_index()`` の戻り dict と watcher
+    由来 dict を ``**`` 展開で ``ReindexStats`` に渡す。Python の関数呼び出しは
+    同名 kwarg が重複すると ``TypeError: got multiple values for keyword argument``
+    で即死する (fail-loud) — これは silent override ではなく fail-loud を
+    選んだ設計判断 (詳細: ``.claude/rules/fastmcp-gotchas.md`` の「vault_reindex
+    の dict spread key 衝突 (fail-loud 方針)」)。
+
+    当該 TypeError を runtime で発火させないため、ここでは ``build_index()``
+    の返す key set と watcher 側 (``failure_stats()`` + ``watcher_active``) の
+    key set が disjoint であることを CI で lock する。将来どちらかの key を
+    追加するときに相手側と衝突すれば、このテストが事前に落ちて設計者を
+    強制的に stop させる。
+    """
+    stats = vault_index.build_index()
+    watcher = VaultWatcher(vault_index)
+    watcher_keys = set(watcher.failure_stats().keys()) | {"watcher_active"}
+    stats_keys = set(stats.keys())
+    assert stats_keys.isdisjoint(watcher_keys), (
+        "build_index() と watcher_stats で key が重複している (#210). "
+        "ReindexStats(**stats, **watcher_stats) が TypeError で落ちるため、"
+        "どちらか一方を rename するか ReindexStats の schema を見直すこと。"
+        f"overlap={stats_keys & watcher_keys}"
+    )
+
+
 def test_main_stops_watcher_on_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """mcp.run() が例外を起こしても _watcher.stop() が呼ばれる (#39 try/finally)."""
     import sys as _sys

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -347,14 +347,26 @@ def test_vault_reindex_stats_and_watcher_keys_are_disjoint(vault_index: VaultInd
     の dict spread key 衝突 (fail-loud 方針)」)。
 
     当該 TypeError を runtime で発火させないため、ここでは ``build_index()``
-    の返す key set と watcher 側 (``failure_stats()`` + ``watcher_active``) の
-    key set が disjoint であることを CI で lock する。将来どちらかの key を
-    追加するときに相手側と衝突すれば、このテストが事前に落ちて設計者を
-    強制的に stop させる。
+    の返す key set と watcher 側 dict の key set が disjoint であることを CI
+    で lock する。将来どちらかの key を追加するときに相手側と衝突すれば、
+    このテストが事前に落ちて設計者を強制的に stop させる。
+
+    - watcher 側 key 集合は ``server._compute_watcher_stats`` 経由で取得する
+      ことで、``vault_reindex`` の実装が新 inline key を追加したときに test
+      側も自動追従する (#210 review D-1 対応)
+    - indexer 側 key 集合は ``build_index()`` の契約どおり完全一致で固定する
+      (#210 review A-1 対応)。将来 build_index が key を条件付きで返すように
+      なっても、この等式で早期検知する
     """
     stats = vault_index.build_index()
+    assert set(stats.keys()) == {"added", "updated", "deleted", "skipped", "errors"}, (
+        "build_index() の戻り key 集合が想定と異なる (#210 A-1). "
+        "stats の key を増減させた場合、ReindexStats の schema も更新が必要。"
+        f"actual={set(stats.keys())}"
+    )
+
     watcher = VaultWatcher(vault_index)
-    watcher_keys = set(watcher.failure_stats().keys()) | {"watcher_active"}
+    watcher_keys = set(server_mod._compute_watcher_stats(watcher).keys())
     stats_keys = set(stats.keys())
     assert stats_keys.isdisjoint(watcher_keys), (
         "build_index() と watcher_stats で key が重複している (#210). "


### PR DESCRIPTION
## Summary

Issue #210 は PR #209 で `stats.update(watcher_stats)` を `ReindexStats(**stats, **watcher_stats)` に変更したことで同名キー衝突時の挙動が `silent override` (watcher 勝ち) から `TypeError` に変わった点について、どちらを正とするかを決定する issue。

**決定**: TypeError 維持 (fail-loud)。key 衝突は indexer が watcher 所管の key を誤って返す developer error であり、silent override は「watcher 側が勝つ」挙動を暗黙に押しつける silent regression 源になる。`frontmatter-normalization.md` 等の「silent coercion を許さない」general 方針とも整合。

MCP 経路では `TypeError` が FastMCP の `ToolError` wrap で平文 `Tool execution failed` として agent に届くが、これは CI / dev で検出すべき programmer error であり production wire で graceful degrade する必要はない。

## Changes

- **Test**: `tests/test_server.py::test_vault_reindex_stats_and_watcher_keys_are_disjoint` — `build_index()` と watcher 由来 dict の key が disjoint であることを CI lock。`_compute_watcher_stats` helper を経由することで call site に新 key が追加されたときに test 側も自動追従する。
- **Docs**: `.claude/rules/fastmcp-gotchas.md` に「vault_reindex の dict spread key 衝突 (fail-loud 方針)」節を追加。決定根拠・MCP wire 副作用・再評価トリガを記録。
- **Code**: `src/vault_search/server.py` に `_compute_watcher_stats` helper を抽出 (inline の watcher_stats 組立てを関数化)。call site に fail-loud 方針への pointer コメント 2 行。

## Test plan

- [x] `tests/test_server.py::test_vault_reindex_stats_and_watcher_keys_are_disjoint` — disjoint invariant + build_index 完全 key 集合を CI lock
- [x] 全 588 tests pass / ruff clean

## TDD

issue 性質上、既存挙動 (TypeError) を正として decision 記録 + regression guard を付与する形。Red にならないため `Test:` + `Docs:` 分割:

- `222209b Test:` — disjoint key invariant を pin する regression test
- `4cbed4d Docs:` — fail-loud 決定を rules/fastmcp-gotchas.md に記録 + call site にコメント
- `51043be Fix:` — review Round 1 findings (A-1 完全 key 集合 / D-1 `_compute_watcher_stats` helper 抽出) 対応

## Review-loop

軽量化ガイドラインに従い 2 並列 (A Correctness / D Architecture, Round 1 のみ):

- **Round 1**: 3 findings 観測 (A-1 5/10 / D-1 6/10 / D-2 5/10 / D-3 <5 accept)
  - A-1 + D-1: `Fix:` commit で PR 内対応
  - D-2 (ADR 配置場所 watch): issue #224 起票
- 両 reviewer が CONVERGED 判定、Round 2 不要

## 関連

- Issue #210 (本 PR で close 見込み)
- PR #209 (#174 の Green 修正、挙動変更の元)
- Issue #224 (ADR 配置場所 watch item、follow-up)

https://claude.ai/code/session_01TLUHsMw5RK6K3nWAm1XsJG